### PR TITLE
Add first Python utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -1,0 +1,11 @@
+"""Python utilities migrated from ISETCam."""
+
+from .vc_constants import vc_constants
+from .vc_get_image_format import vc_get_image_format
+from .quanta2energy import quanta_to_energy
+
+__all__ = [
+    'vc_constants',
+    'vc_get_image_format',
+    'quanta_to_energy',
+]

--- a/python/isetcam/quanta2energy.py
+++ b/python/isetcam/quanta2energy.py
@@ -1,0 +1,51 @@
+"""Conversion utilities between photons and energy."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .vc_constants import vc_constants
+from .vc_get_image_format import vc_get_image_format
+
+
+def quanta_to_energy(wavelength: np.ndarray, photons: np.ndarray) -> np.ndarray:
+    """Convert photon counts to energy.
+
+    Parameters
+    ----------
+    wavelength : array-like
+        Sampled wavelengths in nanometers.
+    photons : np.ndarray
+        Photon counts in either RGB or XW format.
+
+    Returns
+    -------
+    np.ndarray
+        Energy values in the same format as ``photons``.
+    """
+    photons = np.asarray(photons)
+    if photons.size == 0:
+        return np.array([])
+
+    wavelength = np.asarray(wavelength).reshape(-1)
+
+    h = vc_constants('h')
+    c = vc_constants('c')
+
+    img_format = vc_get_image_format(photons, wavelength)
+    if img_format == 'RGB':
+        n, m, w = photons.shape
+        if w != len(wavelength):
+            raise ValueError('photons third dimension must be nWave')
+        flat = photons.reshape(n * m, w)
+        energy = (h * c / 1e-9) * flat / wavelength
+        return energy.reshape(n, m, w)
+
+    if img_format == 'XW':
+        if photons.ndim == 1:
+            photons = photons[np.newaxis, :]
+        if photons.shape[1] != len(wavelength):
+            raise ValueError('Photons (Quanta) must be in XW format.')
+        return (h * c / 1e-9) * photons / wavelength
+
+    raise ValueError('Unknown image format')

--- a/python/isetcam/vc_constants.py
+++ b/python/isetcam/vc_constants.py
@@ -1,0 +1,34 @@
+"""Utility functions providing physical constants used across ISETCam."""
+
+def vc_constants(name: str) -> float:
+    """Return value of a named physical constant.
+
+    Parameters
+    ----------
+    name : str
+        Name of the constant. Supported values are ``'planck'``, ``'h'``,
+        ``'plancksconstant'``, ``'q'`` (electron charge), ``'c'`` (speed of
+        light), ``'j'`` (Boltzmann constant), and ``'mmPerDeg``.
+
+    Returns
+    -------
+    float
+        Numeric value of the requested constant.
+
+    Raises
+    ------
+    KeyError
+        If an unknown constant name is supplied.
+    """
+    key = name.lower()
+    if key in {'planck', 'h', 'plancksconstant'}:
+        return 6.626176e-34
+    if key in {'q', 'electroncharge'}:
+        return 1.602177e-19
+    if key in {'c', 'speedoflight'}:
+        return 2.99792458e8
+    if key in {'j', 'joulesperkelvin', 'boltzman'}:
+        return 1.380662e-23
+    if key == 'mmperdeg':
+        return 0.3
+    raise KeyError(f"Unknown physical constant '{name}'")

--- a/python/isetcam/vc_get_image_format.py
+++ b/python/isetcam/vc_get_image_format.py
@@ -1,0 +1,34 @@
+"""Determine whether an image is in RGB or XW format."""
+
+from typing import Optional
+import numpy as np
+
+
+def vc_get_image_format(data: np.ndarray, wave: np.ndarray) -> Optional[str]:
+    """Determine the ISET image format, either ``'RGB'`` or ``'XW'``.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Image data either in RGB (height x width x n_wave) or XW (n_pixels x n_wave)
+        format.
+    wave : np.ndarray
+        Vector of wavelength samples.
+
+    Returns
+    -------
+    Optional[str]
+        ``'RGB'`` if data appears to be in RGB format, ``'XW'`` if in XW format,
+        otherwise ``None``.
+    """
+    wave = np.asarray(wave)
+
+    if data.ndim == 3 and len(wave) == data.shape[2]:
+        return 'RGB'
+    if data.ndim == 2 and len(wave) == 1:
+        return 'RGB'
+    if data.ndim == 2 and len(wave) == data.shape[1]:
+        return 'XW'
+    if data.ndim == 1 and data.size == len(wave):
+        return 'XW'
+    return None

--- a/python/tests/test_quanta2energy.py
+++ b/python/tests/test_quanta2energy.py
@@ -1,0 +1,25 @@
+import numpy as np
+from isetcam import vc_constants, vc_get_image_format, quanta_to_energy
+
+def test_vc_constants():
+    assert np.isclose(vc_constants('h'), 6.626176e-34)
+    assert np.isclose(vc_constants('q'), 1.602177e-19)
+    assert np.isclose(vc_constants('c'), 2.99792458e8)
+    assert np.isclose(vc_constants('j'), 1.380662e-23)
+    assert np.isclose(vc_constants('mmPerDeg'), 0.3)
+
+
+def test_vc_get_image_format():
+    data_rgb = np.zeros((2, 2, 3))
+    wave = np.array([500, 510, 520])
+    assert vc_get_image_format(data_rgb, wave) == 'RGB'
+    data_xw = np.zeros((4, 3))
+    assert vc_get_image_format(data_xw, wave) == 'XW'
+
+
+def test_quanta_to_energy():
+    wave = np.array([500, 510, 520])
+    photons = np.ones((1, 3))
+    energy = quanta_to_energy(wave, photons)
+    expected = (vc_constants('h') * vc_constants('c') / 1e-9) * photons / wave
+    assert np.allclose(energy, expected)


### PR DESCRIPTION
## Summary
- add initial Python migration modules under `python/isetcam`
- implement `vc_constants`, `vc_get_image_format` and `quanta_to_energy`
- include basic tests for these utilities

## Testing
- `python3 -m py_compile python/isetcam/*.py python/tests/test_quanta2energy.py`
