### PR TITLE
Add basic Python utilities for exposure and PSNR

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ A set of tutorial videos introducing aspects of ISETCam and the companion tool f
 
 * May 10, 2024 We work more smoothly with EXR files, including sceneFromFile now reading in EXR files, and writing out sensor2EXR) This work was implemented for the extensions to HDR imaging and application of the Restormer PyTorch network for demosaicing sensor data.
 * April 15, 2024 Implemented a remote copy function ieSCP, to help with the distributed nature of our assets and datafiles
+* October 2024 - Initial Python utilities added for computing exposure value and PSNR (see ``python/isetcam``)
 

--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -1,0 +1,5 @@
+"""Utility functions for a Python version of ISETCam metrics."""
+
+from .metrics import exposure_value, iepsnr
+
+__all__ = ["exposure_value", "iepsnr"]

--- a/python/isetcam/metrics.py
+++ b/python/isetcam/metrics.py
@@ -1,0 +1,68 @@
+import math
+from typing import Sequence
+
+
+def exposure_value(f_number: float, exposure_time: float) -> float:
+    """Calculate the exposure value (EV).
+
+    Parameters
+    ----------
+    f_number : float
+        The f-number of the optics.
+    exposure_time : float
+        Exposure duration in seconds.
+
+    Returns
+    -------
+    float
+        The exposure value computed as ``log2((f_number ** 2) / exposure_time)``.
+    """
+    if exposure_time <= 0:
+        raise ValueError("exposure_time must be positive")
+    if f_number <= 0:
+        raise ValueError("f_number must be positive")
+    return math.log2((f_number ** 2) / exposure_time)
+
+
+def _sum_squared_error(im1: Sequence, im2: Sequence) -> tuple[float, int]:
+    """Return sum of squared error and element count for two arrays."""
+    if len(im1) != len(im2):
+        raise ValueError("Input images must have the same dimensions")
+    err = 0.0
+    count = 0
+    for a, b in zip(im1, im2):
+        if isinstance(a, Sequence) and not isinstance(a, (bytes, bytearray)):
+            sub_err, sub_count = _sum_squared_error(a, b)
+            err += sub_err
+            count += sub_count
+        else:
+            diff = float(a) - float(b)
+            err += diff * diff
+            count += 1
+    return err, count
+
+
+def _mean_square_error(im1: Sequence, im2: Sequence) -> float:
+    err, count = _sum_squared_error(im1, im2)
+    return err / count if count else 0.0
+
+
+def iepsnr(im1: Sequence, im2: Sequence) -> float:
+    """Compute Peak Signal-to-Noise Ratio (PSNR) between two images.
+
+    Parameters
+    ----------
+    im1, im2 : sequence of numbers or nested sequences
+        Input images with the same shape. Pixel values are assumed to be in
+        the range [0, 255].
+
+    Returns
+    -------
+    float
+        The PSNR value in decibels. Returns ``math.inf`` when the images are
+        identical.
+    """
+    mse = _mean_square_error(im1, im2)
+    if mse == 0:
+        return math.inf
+    return 20 * math.log10(255.0 / math.sqrt(mse))

--- a/python/tests/test_metrics.py
+++ b/python/tests/test_metrics.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import unittest
+
+# Add the parent directory to the Python path so that `isetcam` can be imported
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from isetcam.metrics import exposure_value, iepsnr
+
+
+class TestMetrics(unittest.TestCase):
+    def test_exposure_value(self):
+        ev = exposure_value(2.0, 0.5)
+        expected = (2.0 ** 2) / 0.5
+        expected = __import__('math').log2(expected)
+        self.assertAlmostEqual(ev, expected)
+
+    def test_exposure_value_errors(self):
+        with self.assertRaises(ValueError):
+            exposure_value(-1, 0.5)
+        with self.assertRaises(ValueError):
+            exposure_value(2, 0)
+
+    def test_iepsnr_identical(self):
+        img = [[0 for _ in range(10)] for _ in range(10)]
+        self.assertEqual(iepsnr(img, img), float('inf'))
+
+    def test_iepsnr_value(self):
+        img1 = [[0 for _ in range(10)] for _ in range(10)]
+        img2 = [[10 for _ in range(10)] for _ in range(10)]
+        diff = 10
+        mse = diff * diff
+        expected = 20 * __import__('math').log10(255.0 / __import__('math').sqrt(mse))
+        self.assertAlmostEqual(iepsnr(img1, img2), expected)
+
+    def test_iepsnr_shape_error(self):
+        img1 = [[0 for _ in range(5)] for _ in range(5)]
+        img2 = [[0 for _ in range(4)] for _ in range(4)]
+        with self.assertRaises(ValueError):
+            iepsnr(img1, img2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- start a lightweight `isetcam` Python package
- implement `exposure_value` and `iepsnr` functions
- add corresponding unit tests
- document Python utilities in README

## Testing
- `python -m unittest discover python/tests`