### PR TITLE
Add initial Python utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ A set of tutorial videos introducing aspects of ISETCam and the companion tool f
 * May 10, 2024 We work more smoothly with EXR files, including sceneFromFile now reading in EXR files, and writing out sensor2EXR) This work was implemented for the extensions to HDR imaging and application of the Restormer PyTorch network for demosaicing sensor data.
 * April 15, 2024 Implemented a remote copy function ieSCP, to help with the distributed nature of our assets and datafiles
 
+* October 10, 2024 - Started migrating utilities to Python. Added ``ie_tone.py`` replicating ``ieTone``.

--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -1,0 +1,1 @@
+"""Python utilities migrated from ISETCam MATLAB toolbox."""

--- a/python/isetcam/ie_tone.py
+++ b/python/isetcam/ie_tone.py
@@ -1,0 +1,46 @@
+"""Generate a pure tone similar to the MATLAB ``ieTone`` function."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:
+    import sounddevice as sd
+    _HAS_SOUNDDEVICE = True
+except Exception:  # sounddevice may not be installed
+    _HAS_SOUNDDEVICE = False
+
+
+def ie_tone(
+    frequency: float = 256.0,
+    amplitude: float = 0.2,
+    duration: float = 0.25,
+    fs: float = 8192.0,
+    play: bool = False,
+) -> np.ndarray:
+    """Create (and optionally play) a tone.
+
+    Parameters
+    ----------
+    frequency : float
+        Tone frequency in Hertz.
+    amplitude : float
+        Amplitude of the tone.
+    duration : float
+        Duration of the tone in seconds.
+    fs : float
+        Sampling frequency in Hertz.
+    play : bool
+        If ``True`` and ``sounddevice`` is available, play the tone.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array containing the tone samples.
+    """
+    t = np.arange(0, fs * duration + 1) / fs
+    y = amplitude * np.sin(2 * np.pi * frequency * t)
+    if play and _HAS_SOUNDDEVICE:
+        sd.play(y, samplerate=int(fs))
+        sd.wait()
+    return y

--- a/python/isetcam/tests/test_ie_tone.py
+++ b/python/isetcam/tests/test_ie_tone.py
@@ -1,0 +1,17 @@
+import unittest
+import numpy as np
+from ..ie_tone import ie_tone
+
+
+class TestIeTone(unittest.TestCase):
+    def test_tone_shape(self):
+        fs = 1000
+        duration = 0.1
+        y = ie_tone(frequency=440, amplitude=0.5, duration=duration, fs=fs, play=False)
+        expected_len = int(fs * duration) + 1
+        self.assertEqual(len(y), expected_len)
+        self.assertAlmostEqual(np.max(y), 0.5, places=2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- start Python utility package and add `ie_tone` port of MATLAB `ieTone`
- document start of Python migration in README
- add basic unit test for `ie_tone`

## Testing
- `python3 -m unittest python.isetcam.tests.test_ie_tone`