### PR TITLE
Add initial Python utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ web/webImageBrowser/PackagingLog.html
 
 *.asv
 data/images/multispectral/FruitMCC.mat
+
+# Python artifacts
+__pycache__/
+*.pyc
+

--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -1,0 +1,14 @@
+"""Python utilities for ISETCam.
+
+This package provides basic routines translated from MATLAB.
+"""
+
+from .utils import vc_constants, rgb2xw, xw2rgb, quanta_to_energy, energy_to_quanta
+
+__all__ = [
+    'vc_constants',
+    'rgb2xw',
+    'xw2rgb',
+    'quanta_to_energy',
+    'energy_to_quanta',
+]

--- a/python/isetcam/utils.py
+++ b/python/isetcam/utils.py
@@ -1,0 +1,133 @@
+import numpy as np
+
+# Mapping of physical constants used in ISETCam
+VC_CONSTANTS = {
+    'planck': 6.626176e-34,
+    'h': 6.626176e-34,
+    'plancksconstant': 6.626176e-34,
+    'q': 1.602177e-19,
+    'electroncharge': 1.602177e-19,
+    'c': 2.99792458e8,
+    'speedoflight': 2.99792458e8,
+    'j': 1.380662e-23,
+    'joulesperkelvin': 1.380662e-23,
+    'boltzman': 1.380662e-23,
+    'mmperdeg': 0.3,
+}
+
+
+def vc_constants(key: str) -> float:
+    """Return the value of a physical constant.
+
+    Parameters
+    ----------
+    key : str
+        Name of the constant. The lookup is case-insensitive and
+        follows the names used in the MATLAB ``vcConstants`` function.
+
+    Returns
+    -------
+    float
+        Numerical value of the constant.
+    """
+    k = key.lower()
+    if k not in VC_CONSTANTS:
+        raise ValueError(f"Unknown physical constant: {key}")
+    return VC_CONSTANTS[k]
+
+
+def rgb2xw(image: np.ndarray):
+    """Convert an array from RGB (row, col, wave) format to XW format.
+
+    Parameters
+    ----------
+    image : ndarray
+        Array in (rows, cols, wavelengths) format. If the input is a
+        2-D array it is treated as having a single wavelength.
+
+    Returns
+    -------
+    xw : ndarray
+        Array of shape (rows*cols, wavelengths).
+    r : int
+        Number of rows in the input image.
+    c : int
+        Number of columns in the input image.
+    w : int
+        Number of wavelength bands.
+    """
+    arr = np.asarray(image)
+    if arr.ndim == 2:
+        arr = arr[:, :, None]
+    r, c, w = arr.shape
+    xw = arr.reshape((r * c, w))
+    return xw, r, c, w
+
+
+def xw2rgb(xw: np.ndarray, r: int, c: int) -> np.ndarray:
+    """Convert an array from XW format back to RGB format."""
+    xw = np.asarray(xw)
+    w = xw.shape[1]
+    if xw.shape[0] != r * c:
+        raise ValueError('row*col must equal number of rows in xw')
+    return xw.reshape((r, c, w))
+
+
+def quanta_to_energy(wavelength, photons):
+    """Convert quanta (photons) to energy.
+
+    Parameters
+    ----------
+    wavelength : array_like
+        Sample wavelengths in nanometers.
+    photons : ndarray
+        Spectral data either in RGB (rows, cols, wave) or XW format.
+
+    Returns
+    -------
+    ndarray
+        Energy in the same format as the input.
+    """
+    wave = np.asarray(wavelength).reshape(-1)
+    p = np.asarray(photons)
+    h = vc_constants('h')
+    c = vc_constants('c')
+
+    if p.ndim == 3:
+        xw, r, c_, _ = rgb2xw(p)
+        energy = (h * c / 1e-9) * (xw / wave)
+        energy = xw2rgb(energy, r, c_)
+    else:
+        if p.ndim == 1:
+            p = p[np.newaxis, :]
+        if p.shape[1] != wave.size:
+            raise ValueError('photons must have columns equal to number of wavelengths')
+        energy = (h * c / 1e-9) * (p / wave)
+        if energy.shape[0] == 1:
+            energy = energy[0]
+    return energy
+
+
+def energy_to_quanta(wavelength, energy):
+    """Convert energy to number of photons."""
+    wave = np.asarray(wavelength).reshape(-1)
+    e = np.asarray(energy)
+    h = vc_constants('h')
+    c = vc_constants('c')
+
+    if e.ndim == 3:
+        n, m, w = e.shape
+        if w != wave.size:
+            raise ValueError('energy third dimension must equal number of wavelengths')
+        reshaped = e.reshape((n * m, w)).T
+        photons = (reshaped / (h * c)) * (1e-9 * wave[:, None])
+        photons = photons.T.reshape((n, m, w))
+    else:
+        if e.ndim == 1:
+            e = e[:, np.newaxis]
+        if e.shape[0] != wave.size:
+            raise ValueError('energy rows must equal number of wavelengths')
+        photons = (e / (h * c)) * (1e-9 * wave[:, None])
+        if photons.shape[1] == 1:
+            photons = photons[:, 0]
+    return photons

--- a/python/tests/test_color.py
+++ b/python/tests/test_color.py
@@ -1,0 +1,21 @@
+import unittest
+import numpy as np
+from isetcam import quanta_to_energy, energy_to_quanta
+
+class TestColorConversions(unittest.TestCase):
+    def test_round_trip_vector(self):
+        wave = np.arange(400, 710, 10)
+        photons = np.linspace(1, 5, wave.size)
+        energy = quanta_to_energy(wave, photons)
+        recovered = energy_to_quanta(wave, energy)
+        self.assertTrue(np.allclose(photons, recovered))
+
+    def test_round_trip_image(self):
+        wave = np.arange(400, 710, 10)
+        data = np.random.rand(4, 5, wave.size)
+        energy = quanta_to_energy(wave, data)
+        recovered = energy_to_quanta(wave, energy)
+        self.assertTrue(np.allclose(data, recovered))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- provide Python utilities and constants in `isetcam` package
- add tests that round-trip energy to quanta
- ignore Python cache files

## Testing
- `PYTHONPATH=python python3 -m unittest discover -s python/tests`