### PR TITLE
Add ie_init session utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -3,6 +3,7 @@
 from .vc_constants import vc_constants
 from .vc_get_image_format import vc_get_image_format
 from .quanta2energy import quanta_to_energy
+from .ie_init import ie_init, ie_init_session
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
@@ -12,6 +13,8 @@ __all__ = [
     'vc_constants',
     'vc_get_image_format',
     'quanta_to_energy',
+    'ie_init',
+    'ie_init_session',
     'scene',
     'opticalimage',
     'sensor',

--- a/python/isetcam/ie_init.py
+++ b/python/isetcam/ie_init.py
@@ -1,0 +1,89 @@
+"""Session initialization utilities for ISETCam Python."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any, Dict
+import warnings
+
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+# Global preferences and session storage
+ISET_PREFS: Dict[str, Any] = {}
+VC_SESSION: Dict[str, Any] = {}
+
+
+def ie_init(clear: bool = False) -> Dict[str, Any]:
+    """Initialize a fresh ISETCam session.
+
+    Parameters
+    ----------
+    clear : bool, optional
+        When ``True`` attempt to clear any existing session variables.
+
+    Returns
+    -------
+    Dict[str, Any]
+        The initialized session dictionary.
+    """
+    # Warn about known incompatibilities (mirrors MATLAB behavior)
+    if "2019b" in os.sys.version:
+        warnings.warn("Windows do not run correctly under version 2019b")
+
+    # Close any open GUI windows
+    if plt is not None:
+        try:
+            plt.close("all")
+        except Exception:
+            pass
+
+    # Reset preferences to defaults
+    ISET_PREFS.clear()
+    ISET_PREFS.update({
+        "waitbar": 0,
+        "init_clear": int(clear),
+        "font_size": 12,
+    })
+
+    # Clear previous session data
+    VC_SESSION.clear()
+
+    # Initialize the session structure
+    return ie_init_session()
+
+
+def ie_init_session() -> Dict[str, Any]:
+    """Initialize the global session structure.
+
+    Returns
+    -------
+    Dict[str, Any]
+        The newly created session dictionary stored in ``VC_SESSION``.
+    """
+    global VC_SESSION
+
+    VC_SESSION = {
+        "NAME": f"iset-{datetime.now():%Y%m%dT%H%M%S}",
+        "DIR": os.getcwd(),
+        "SELECTED": {
+            "SCENE": None,
+            "OPTICALIMAGE": None,
+            "ISA": None,
+            "VCIMAGE": None,
+            "DISPLAY": None,
+            "GRAPHWIN": None,
+        },
+        "SCENE": [None],
+        "OPTICALIMAGE": [None],
+        "ISA": [None],
+        "VCIMAGE": [None],
+        "GRAPHWIN": [],
+        "DISPLAY": [None],
+        "initHelp": 0,
+        "GUI": {"waitbar": ISET_PREFS.get("waitbar", 0)},
+    }
+    return VC_SESSION

--- a/python/tests/test_ie_init.py
+++ b/python/tests/test_ie_init.py
@@ -1,0 +1,15 @@
+from isetcam import ie_init, ie_init_session, vc_constants
+
+
+def test_ie_init_returns_session():
+    session = ie_init()
+    assert isinstance(session, dict)
+    assert 'NAME' in session
+    assert 'DIR' in session
+    assert session['GUI']['waitbar'] == 0
+
+
+def test_ie_init_session_can_be_called_directly():
+    session = ie_init_session()
+    assert 'SCENE' in session
+    assert session['SCENE'][0] is None


### PR DESCRIPTION
## Summary
- translate `ieInit.m` to Python as `ie_init.py`
- expose new initialization utilities in package `__init__`
- add tests for `ie_init`

## Testing
- `PYTHONPATH=python pytest -q`