### PR TITLE
Add MATLAB to Python migration docs

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -1,0 +1,54 @@
+# MATLAB to Python Migration
+
+This repository now contains experimental Python modules that replicate
+portions of the MATLAB functionality. The long term goal is to allow
+running ISETCam algorithms from Python directly or through MATLAB using
+`pyenv`.
+
+## Creating the Environment
+
+Use a dedicated conda environment as described in
+[`python/README.md`](../python/README.md):
+
+```bash
+conda create -n py39 python=3.9
+conda activate py39
+```
+
+Within MATLAB, point `pyenv` to the environment interpreter:
+
+```matlab
+pyenv('Version','/opt/miniconda3/envs/py39/bin/python');
+```
+
+The file `python/s_python.m` provides a step‑by‑step walkthrough of the
+setup process.
+
+## Running the Python Initialization Routines
+
+Once the environment is activated (or after `pyenv` inside MATLAB), the
+Python initialization mirrors the MATLAB `ieInit` command. In Python you
+can run:
+
+```python
+from isetcam import ie_init
+session = ie_init()
+```
+
+This returns a dictionary similar to the MATLAB `vcSESSION` structure.
+You can also call `ie_init_session()` directly to construct the session
+data structure without clearing the environment.
+
+## Unit Tests
+
+Unit tests are located in [`python/tests`](../python/tests). They can be
+executed with `pytest` once the `PYTHONPATH` includes the `python`
+directory:
+
+```bash
+export PYTHONPATH=$PWD/python
+pytest -q
+```
+
+Running these tests verifies that the initialization routines and helper
+functions behave as expected.


### PR DESCRIPTION
## Summary
- document the approach for migrating MATLAB code to Python
- show how to run `ie_init` from Python
- explain test invocation and environment setup

## Testing
- `export PYTHONPATH=$PWD/python && pytest -q`