### PR TITLE
Add luminance utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -6,6 +6,8 @@ from .quanta2energy import quanta_to_energy
 from .energy_to_quanta import energy_to_quanta
 from .ie_init import ie_init
 from .ie_init_session import ie_init_session
+from .luminance_from_energy import luminance_from_energy
+from .luminance_from_photons import luminance_from_photons
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
@@ -16,6 +18,8 @@ __all__ = [
     'vc_get_image_format',
     'quanta_to_energy',
     'energy_to_quanta',
+    'luminance_from_energy',
+    'luminance_from_photons',
     'ie_init',
     'ie_init_session',
     'scene',

--- a/python/isetcam/luminance_from_energy.py
+++ b/python/isetcam/luminance_from_energy.py
@@ -1,0 +1,79 @@
+"""Calculate luminance from spectral energy data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from scipy.io import loadmat
+
+from .vc_get_image_format import vc_get_image_format
+
+_DEF_BINWIDTH = 10
+
+
+def _photopic_luminosity(wave: np.ndarray) -> np.ndarray:
+    """Return the photopic luminosity function interpolated to ``wave``."""
+    root = Path(__file__).resolve().parents[2]
+    fpath = root / 'data' / 'human' / 'luminosity.mat'
+    data = loadmat(fpath)
+    src_wave = data['wavelength'].ravel()
+    V = data['data'].ravel()
+    return np.interp(wave, src_wave, V, left=0.0, right=0.0)
+
+
+def luminance_from_energy(
+    energy: np.ndarray, wavelength: np.ndarray, binwidth: Optional[float] = None
+) -> np.ndarray:
+    """Compute luminance (cd/m^2) from spectral energy.
+
+    Parameters
+    ----------
+    energy : np.ndarray
+        Spectral energy in either RGB or XW format with wavelength along
+        the last dimension or columns.
+    wavelength : array-like
+        Sampled wavelengths in nanometers.
+    binwidth : float, optional
+        Spectral bin width in nanometers. When not provided, it is derived
+        from ``wavelength`` if possible, otherwise defaults to 10 nm.
+
+    Returns
+    -------
+    np.ndarray
+        Luminance values in the same spatial format as ``energy``.
+    """
+    energy = np.asarray(energy)
+    if energy.size == 0:
+        return np.array([])
+
+    wavelength = np.asarray(wavelength).reshape(-1)
+    if binwidth is None:
+        if len(wavelength) > 1:
+            binwidth = wavelength[1] - wavelength[0]
+        else:
+            binwidth = _DEF_BINWIDTH
+
+    img_format = vc_get_image_format(energy, wavelength)
+    if img_format == 'RGB':
+        n, m, w = energy.shape
+        if w != len(wavelength):
+            raise ValueError('energy third dimension must be nWave')
+        xw = energy.reshape(n * m, w)
+    else:
+        if energy.ndim == 1:
+            xw = energy[np.newaxis, :]
+        else:
+            xw = energy
+        if xw.shape[1] != len(wavelength):
+            raise ValueError('Energy must be in XW format with wavelength columns')
+        n = m = None
+
+    V = _photopic_luminosity(wavelength)
+    lum = 683 * xw.dot(V) * binwidth
+
+    if img_format == 'RGB':
+        lum = lum.reshape(n, m)
+
+    return lum

--- a/python/isetcam/luminance_from_photons.py
+++ b/python/isetcam/luminance_from_photons.py
@@ -1,0 +1,16 @@
+"""Calculate luminance from photon counts."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .quanta2energy import quanta_to_energy
+from .luminance_from_energy import luminance_from_energy
+
+
+def luminance_from_photons(
+    photons: np.ndarray, wavelength: np.ndarray, binwidth: float | None = None
+) -> np.ndarray:
+    """Compute luminance (cd/m^2) from spectral photon data."""
+    energy = quanta_to_energy(wavelength, photons)
+    return luminance_from_energy(energy, wavelength, binwidth)

--- a/python/tests/test_luminance.py
+++ b/python/tests/test_luminance.py
@@ -1,0 +1,45 @@
+import numpy as np
+from pathlib import Path
+from scipy.io import loadmat
+
+from isetcam import (
+    luminance_from_energy,
+    luminance_from_photons,
+    energy_to_quanta,
+)
+
+
+def _expected_luminance(wave, energy):
+    root = Path(__file__).resolve().parents[2]
+    mat = loadmat(root / 'data' / 'human' / 'luminosity.mat')
+    V = np.interp(wave, mat['wavelength'].ravel(), mat['data'].ravel(), left=0.0, right=0.0)
+    binwidth = wave[1] - wave[0] if len(wave) > 1 else 10
+    xw = energy.reshape(-1, len(wave))
+    lum = 683 * xw.dot(V) * binwidth
+    return lum.reshape(energy.shape[:-1])
+
+
+def test_luminance_from_energy_xw():
+    wave = np.arange(400, 701, 10)
+    energy = np.ones((1, len(wave)))
+    lum = luminance_from_energy(energy, wave)
+    expected = _expected_luminance(wave, energy)
+    assert np.allclose(lum, expected)
+
+
+def test_luminance_from_energy_rgb():
+    wave = np.arange(400, 701, 10)
+    energy = np.ones((1, 1, len(wave)))
+    lum = luminance_from_energy(energy, wave)
+    expected = _expected_luminance(wave, energy.reshape(1, len(wave)))
+    assert np.allclose(lum, expected.reshape(1, 1))
+
+
+def test_luminance_from_photons():
+    wave = np.arange(400, 701, 10)
+    energy = np.ones((1, len(wave)))
+    # energy_to_quanta expects wavelength along rows
+    photons = energy_to_quanta(wave, energy.T).T
+    lum = luminance_from_photons(photons, wave)
+    expected = _expected_luminance(wave, energy)
+    assert np.allclose(lum, expected)


### PR DESCRIPTION
## Summary
- add luminance calculation routines in Python
- export new functions from package init
- test luminance conversion on known spectrum

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_energy2quanta.py python/tests/test_quanta2energy.py python/tests/test_ie_init.py python/tests/test_luminance.py`