### PR TITLE
Add utilities for RGB/XW array conversions

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -8,6 +8,8 @@ from .ie_init import ie_init
 from .ie_init_session import ie_init_session
 from .luminance_from_energy import luminance_from_energy
 from .luminance_from_photons import luminance_from_photons
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
@@ -20,6 +22,8 @@ __all__ = [
     'energy_to_quanta',
     'luminance_from_energy',
     'luminance_from_photons',
+    'rgb_to_xw_format',
+    'xw_to_rgb_format',
     'ie_init',
     'ie_init_session',
     'scene',

--- a/python/isetcam/rgb_to_xw_format.py
+++ b/python/isetcam/rgb_to_xw_format.py
@@ -1,0 +1,35 @@
+"""Convert image data from RGB format to XW format."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Tuple
+
+
+def rgb_to_xw_format(im_rgb: np.ndarray) -> Tuple[np.ndarray, int, int]:
+    """Reshape ``im_rgb`` from ``(rows, cols, bands)`` to ``(rows*cols, bands)``.
+
+    Parameters
+    ----------
+    im_rgb : np.ndarray
+        Image data in RGB format. Monochrome images may be provided as
+        ``(rows, cols)``.
+
+    Returns
+    -------
+    Tuple[np.ndarray, int, int]
+        ``im_xw`` array in XW format along with the original row and column
+        dimensions.
+    """
+    im_rgb = np.asarray(im_rgb)
+    if im_rgb.ndim == 2:
+        rows, cols = im_rgb.shape
+        bands = 1
+        im_rgb = im_rgb.reshape(rows, cols, bands)
+    elif im_rgb.ndim == 3:
+        rows, cols, bands = im_rgb.shape
+    else:
+        raise ValueError("im_rgb must be a 2D or 3D array")
+
+    im_xw = im_rgb.reshape(rows * cols, bands)
+    return im_xw, rows, cols

--- a/python/isetcam/xw_to_rgb_format.py
+++ b/python/isetcam/xw_to_rgb_format.py
@@ -1,0 +1,39 @@
+"""Convert image data from XW format to RGB format."""
+
+from __future__ import annotations
+
+from typing import Tuple
+import numpy as np
+
+
+def xw_to_rgb_format(im_xw: np.ndarray, rows: int, cols: int) -> np.ndarray:
+    """Reshape ``im_xw`` from ``(rows*cols, bands)`` to ``(rows, cols, bands)``.
+
+    Parameters
+    ----------
+    im_xw : np.ndarray
+        Image data in XW format. Monochrome data may be provided as ``(rows*cols,)``.
+    rows : int
+        Number of image rows.
+    cols : int
+        Number of image columns.
+
+    Returns
+    -------
+    np.ndarray
+        Image data in RGB format with shape ``(rows, cols, bands)``.
+    """
+    im_xw = np.asarray(im_xw)
+    if im_xw.ndim == 1:
+        bands = 1
+        if im_xw.size != rows * cols:
+            raise ValueError("Input size does not match rows*cols")
+        im_xw = im_xw.reshape(rows * cols, bands)
+    elif im_xw.ndim == 2:
+        if im_xw.shape[0] != rows * cols:
+            raise ValueError("Input size does not match rows*cols")
+        bands = im_xw.shape[1]
+    else:
+        raise ValueError("im_xw must be a 1D or 2D array")
+
+    return im_xw.reshape(rows, cols, bands)

--- a/python/tests/test_rgb_xw_format.py
+++ b/python/tests/test_rgb_xw_format.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from isetcam import rgb_to_xw_format, xw_to_rgb_format
+
+
+def test_round_trip_rgb_xw():
+    rgb = np.arange(24).reshape(2, 3, 4)
+    xw, r, c = rgb_to_xw_format(rgb)
+    assert xw.shape == (6, 4)
+    assert r == 2 and c == 3
+    rgb2 = xw_to_rgb_format(xw, r, c)
+    assert np.array_equal(rgb2, rgb)
+
+
+def test_single_band_image():
+    rgb = np.arange(4).reshape(2, 2)
+    xw, r, c = rgb_to_xw_format(rgb)
+    assert xw.shape == (4, 1)
+    rgb2 = xw_to_rgb_format(xw, r, c)
+    assert rgb2.shape == (2, 2, 1)
+    assert np.array_equal(rgb2.squeeze(), rgb)


### PR DESCRIPTION
## Summary
- add `rgb_to_xw_format` and `xw_to_rgb_format` helpers
- export new helpers from the `isetcam` package
- test round‑trip conversions between RGB and XW formats

## Testing
- `PYTHONPATH=python pytest -q`