### PR TITLE
Add luminance to radiance conversion

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -8,6 +8,7 @@ from .ie_init import ie_init
 from .ie_init_session import ie_init_session
 from .luminance_from_energy import luminance_from_energy
 from .luminance_from_photons import luminance_from_photons
+from .ie_luminance_to_radiance import ie_luminance_to_radiance
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 
@@ -22,6 +23,7 @@ __all__ = [
     'energy_to_quanta',
     'luminance_from_energy',
     'luminance_from_photons',
+    'ie_luminance_to_radiance',
     'rgb_to_xw_format',
     'xw_to_rgb_format',
     'ie_init',

--- a/python/isetcam/ie_luminance_to_radiance.py
+++ b/python/isetcam/ie_luminance_to_radiance.py
@@ -1,0 +1,74 @@
+"""Generate spectral radiance from a monochromatic luminance value."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .luminance_from_energy import luminance_from_energy
+
+
+def ie_luminance_to_radiance(
+    lum: float,
+    peak_wave: float,
+    sd: float = 10,
+    wave: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return spectral radiance matching ``lum`` for a Gaussian source.
+
+    Parameters
+    ----------
+    lum : float
+        Desired luminance of the source in candela per square meter.
+    peak_wave : float
+        Wavelength of the monochromatic peak in nanometers.  Valid range
+        is roughly 350--720 nm.
+    sd : float, optional
+        Standard deviation of the Gaussian spectral model in nanometers.
+    wave : array-like, optional
+        Wavelength samples in nanometers.  When not provided, the range
+        300--770 nm in 1 nm steps is used.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Radiance values in watts/sr/nm/m^2 and the wavelength samples.
+    """
+    if wave is None:
+        wave = np.arange(300, 771, 1)
+    wave = np.asarray(wave).reshape(-1)
+
+    if not (350 <= peak_wave <= 720):
+        raise ValueError("peak_wave must be between 350 and 720 nm")
+
+    # Impulse at the peak wavelength
+    energy = np.zeros_like(wave, dtype=float)
+    idx = np.argmin(np.abs(wave - peak_wave))
+    energy[idx] = 1.0
+
+    # Gaussian kernel approximating MATLAB ``fspecial('gaussian',[8*sd,1],sd)``
+    if len(wave) > 1:
+        step = wave[1] - wave[0]
+    else:
+        step = 1
+    size = max(int(round(8 * sd / step)), 1)
+    if size % 2 == 0:
+        size += 1
+    rad = (size - 1) // 2
+    x = np.arange(-rad, rad + 1) * step
+    g = np.exp(-0.5 * (x / sd) ** 2)
+    g /= g.sum()
+
+    energy = np.convolve(energy, g, mode="same")
+
+    # Scale to achieve the desired luminance
+    lum_unit = luminance_from_energy(energy, wave)
+    if lum_unit == 0:
+        raise ValueError("Luminance of unit spectrum is zero; check wave range")
+    energy *= lum / lum_unit
+
+    # Verify luminance
+    final_lum = luminance_from_energy(energy, wave)
+    if not np.isclose(final_lum, lum, atol=1e-6):
+        raise RuntimeError("Spectrum does not reproduce desired luminance")
+
+    return energy, wave

--- a/python/tests/test_luminance_to_radiance.py
+++ b/python/tests/test_luminance_to_radiance.py
@@ -1,0 +1,25 @@
+import numpy as np
+from isetcam import ie_luminance_to_radiance, luminance_from_energy
+
+
+def test_luminance_match_default_wave():
+    lum = 10.0
+    peak = 360
+    energy, wave = ie_luminance_to_radiance(lum, peak)
+    calc = luminance_from_energy(energy, wave)
+    assert np.isclose(calc, lum, atol=1e-6)
+    assert len(energy) == len(wave)
+    assert wave[0] == 300 and wave[-1] == 770
+
+
+def test_custom_sd_and_wave():
+    lum = 50.0
+    peak = 425
+    wave = np.arange(350, 701, 5)
+    energy, out_wave = ie_luminance_to_radiance(lum, peak, sd=20, wave=wave)
+    assert np.array_equal(out_wave, wave)
+    calc = luminance_from_energy(energy, wave)
+    assert np.isclose(calc, lum, atol=1e-6)
+    # Energy should peak near the chosen wavelength
+    idx = np.argmax(energy)
+    assert abs(wave[idx] - peak) <= 5


### PR DESCRIPTION
## Summary
- implement `ie_luminance_to_radiance` for generating a radiance spectrum from a luminance value
- expose new helper from `isetcam` package
- test conversion for default and custom wavelength grids

## Testing
- `PYTHONPATH=python pytest -q`