### PR TITLE
Add scene accessor utilities

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -1,5 +1,13 @@
 """Scene-related functions."""
 
-from .scene_add import Scene, scene_add
+from .scene_class import Scene
+from .scene_add import scene_add
+from .scene_utils import get_photons, set_photons, get_n_wave
 
-__all__ = ["Scene", "scene_add"]
+__all__ = [
+    "Scene",
+    "scene_add",
+    "get_photons",
+    "set_photons",
+    "get_n_wave",
+]

--- a/python/isetcam/scene/scene_class.py
+++ b/python/isetcam/scene/scene_class.py
@@ -1,0 +1,15 @@
+"""Basic :class:`Scene` dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class Scene:
+    """Minimal representation of an ISETCam scene."""
+
+    photons: np.ndarray
+    wave: np.ndarray

--- a/python/isetcam/scene/scene_utils.py
+++ b/python/isetcam/scene/scene_utils.py
@@ -1,0 +1,22 @@
+"""Accessor utilities for :class:`Scene`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def get_photons(scene: Scene) -> np.ndarray:
+    """Return the photon data from ``scene``."""
+    return scene.photons
+
+
+def set_photons(scene: Scene, photons: np.ndarray) -> None:
+    """Set the photon data for ``scene``."""
+    scene.photons = np.asarray(photons)
+
+
+def get_n_wave(scene: Scene) -> int:
+    """Return the number of wavelength samples in ``scene``."""
+    return len(scene.wave)

--- a/python/tests/test_scene_add.py
+++ b/python/tests/test_scene_add.py
@@ -1,5 +1,10 @@
 import numpy as np
-from isetcam.scene import Scene, scene_add
+from isetcam.scene import (
+    Scene,
+    scene_add,
+    get_photons,
+    set_photons,
+)
 
 
 def _simple_scene(scale: float) -> Scene:
@@ -12,15 +17,15 @@ def test_scene_add_pair_add():
     s1 = _simple_scene(1.0)
     s2 = _simple_scene(2.0)
     out = scene_add(s1, s2, "add")
-    assert np.allclose(out.photons, s1.photons + s2.photons)
+    assert np.allclose(get_photons(out), get_photons(s1) + get_photons(s2))
 
 
 def test_scene_add_pair_average():
     s1 = _simple_scene(1.0)
     s2 = _simple_scene(3.0)
     out = scene_add(s1, s2, "average")
-    expected = (s1.photons + s2.photons) / 2
-    assert np.allclose(out.photons, expected)
+    expected = (get_photons(s1) + get_photons(s2)) / 2
+    assert np.allclose(get_photons(out), expected)
 
 
 def test_scene_add_pair_remove_spatial_mean():
@@ -33,12 +38,12 @@ def test_scene_add_pair_remove_spatial_mean():
     s2 = Scene(photons=pattern, wave=wave)
     out = scene_add(s1, s2, "remove spatial mean")
     expected = pattern - pattern.mean(axis=(0, 1), keepdims=True)
-    assert np.allclose(out.photons, expected)
+    assert np.allclose(get_photons(out), expected)
 
 
 def test_scene_add_weighted_list():
     s1 = _simple_scene(1.0)
     s2 = _simple_scene(2.0)
     out = scene_add([s1, s2], [0.5, 0.25], "add")
-    expected = 0.5 * s1.photons + 0.25 * s2.photons
-    assert np.allclose(out.photons, expected)
+    expected = 0.5 * get_photons(s1) + 0.25 * get_photons(s2)
+    assert np.allclose(get_photons(out), expected)

--- a/python/tests/test_scene_utils.py
+++ b/python/tests/test_scene_utils.py
@@ -1,0 +1,15 @@
+import numpy as np
+from isetcam.scene import Scene, get_photons, set_photons, get_n_wave
+
+
+def test_scene_accessors():
+    wave = np.array([500, 510, 520])
+    photons = np.ones((1, 1, 3))
+    sc = Scene(photons=photons.copy(), wave=wave)
+
+    assert get_n_wave(sc) == 3
+    assert np.allclose(get_photons(sc), photons)
+
+    new_photons = np.zeros_like(photons)
+    set_photons(sc, new_photons)
+    assert np.allclose(get_photons(sc), new_photons)


### PR DESCRIPTION
## Summary
- introduce `Scene` dataclass in new `scene_class` module
- add `get_photons`, `set_photons`, and `get_n_wave` accessor helpers
- update `scene_add` to rely on the new accessors
- expose accessors via `scene` package
- update existing tests and add tests for accessor helpers

## Testing
- `PYTHONPATH=python pytest -q`