### PR TITLE
Add ie_param_format utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -9,6 +9,7 @@ from .ie_init_session import ie_init_session
 from .luminance_from_energy import luminance_from_energy
 from .luminance_from_photons import luminance_from_photons
 from .ie_luminance_to_radiance import ie_luminance_to_radiance
+from .ie_param_format import ie_param_format
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 
@@ -24,6 +25,7 @@ __all__ = [
     'luminance_from_energy',
     'luminance_from_photons',
     'ie_luminance_to_radiance',
+    'ie_param_format',
     'rgb_to_xw_format',
     'xw_to_rgb_format',
     'ie_init',

--- a/python/isetcam/ie_param_format.py
+++ b/python/isetcam/ie_param_format.py
@@ -1,0 +1,56 @@
+"""Format parameter names in ISET style."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+import numbers
+
+
+def ie_param_format(value: Any) -> Any:
+    """Convert parameter names to lowercase without spaces.
+
+    Strings are normalized by converting to lowercase and removing any
+    spaces. Lists and tuples are handled recursively such that every
+    element at an even index (1-based odd position) is formatted using
+    this rule. Numeric values and other data types are returned
+    unchanged.
+
+    Parameters
+    ----------
+    value : Any
+        Value or container to be formatted.
+
+    Returns
+    -------
+    Any
+        Formatted value.
+    """
+    # Numbers just get returned unchanged
+    if isinstance(value, numbers.Number):
+        return value
+
+    # Strings are converted to lowercase and spaces removed
+    if isinstance(value, str):
+        return value.replace(" ", "").lower()
+
+    # Handle list or tuple of key/value pairs
+    if isinstance(value, list):
+        formatted = []
+        for idx, item in enumerate(value):
+            if idx % 2 == 0:
+                formatted.append(ie_param_format(item))
+            else:
+                formatted.append(item)
+        return formatted
+
+    if isinstance(value, tuple):
+        formatted = []
+        for idx, item in enumerate(value):
+            if idx % 2 == 0:
+                formatted.append(ie_param_format(item))
+            else:
+                formatted.append(item)
+        return tuple(formatted)
+
+    # If it's some other sequence (but not a string), leave it as is
+    return value

--- a/python/tests/test_ie_param_format.py
+++ b/python/tests/test_ie_param_format.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from isetcam import ie_param_format
+
+
+def test_format_string():
+    assert ie_param_format("Exposure Time") == "exposuretime"
+    assert ie_param_format("Hello World") == "helloworld"
+
+
+def test_format_numeric():
+    assert ie_param_format(42) == 42
+    arr = np.array([1, 2])
+    assert ie_param_format(arr) is arr
+
+
+def test_format_list():
+    inp = ["Exposure Time", 1, "CamelCase", True]
+    out = ie_param_format(inp)
+    assert out == ["exposuretime", 1, "camelcase", True]
+
+
+def test_format_tuple():
+    inp = ("Exposure Time", 1, "CamelCase", 2)
+    out = ie_param_format(inp)
+    assert out == ("exposuretime", 1, "camelcase", 2)


### PR DESCRIPTION
## Summary
- implement MATLAB `ieParamFormat` in Python
- expose `ie_param_format` from the isetcam package
- test parameter formatting helper

## Testing
- `PYTHONPATH=$PWD/python pytest -q`