### PR TITLE
Add Python ie_session_get/set

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -10,6 +10,8 @@ from .luminance_from_energy import luminance_from_energy
 from .luminance_from_photons import luminance_from_photons
 from .ie_luminance_to_radiance import ie_luminance_to_radiance
 from .ie_param_format import ie_param_format
+from .ie_session_get import ie_session_get
+from .ie_session_set import ie_session_set
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 
@@ -26,6 +28,8 @@ __all__ = [
     'luminance_from_photons',
     'ie_luminance_to_radiance',
     'ie_param_format',
+    'ie_session_get',
+    'ie_session_set',
     'rgb_to_xw_format',
     'xw_to_rgb_format',
     'ie_init',

--- a/python/isetcam/ie_session_get.py
+++ b/python/isetcam/ie_session_get.py
@@ -1,0 +1,66 @@
+"""Access values from the global ISETCam session."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .ie_init_session import vcSESSION, ISET_PREFS
+from .ie_param_format import ie_param_format
+
+
+_OBJTYPE_MAP = {
+    "scene": "SCENE",
+    "oi": "OPTICALIMAGE",
+    "opticalimage": "OPTICALIMAGE",
+    "sensor": "ISA",
+    "isa": "ISA",
+    "vcimage": "VCIMAGE",
+    "ip": "VCIMAGE",
+    "display": "DISPLAY",
+}
+
+
+def _norm_objtype(name: str) -> str:
+    key = ie_param_format(name)
+    if key not in _OBJTYPE_MAP:
+        raise KeyError(f"Unknown object type '{name}'")
+    return _OBJTYPE_MAP[key]
+
+
+def ie_session_get(param: str, *args: Any) -> Any:
+    """Return a value from the global ``vcSESSION`` or ``ISET_PREFS``.
+
+    Parameters
+    ----------
+    param : str
+        Name of the session parameter.
+    *args : Any
+        Additional arguments used by some parameters.
+    """
+    p = ie_param_format(param)
+
+    if p == "version":
+        return vcSESSION.get("VERSION")
+    if p in {"name", "sessionname"}:
+        return vcSESSION.get("NAME")
+    if p in {"dir", "sessiondir"}:
+        return vcSESSION.get("DIR")
+    if p == "waitbar":
+        gui = vcSESSION.get("GUI", {})
+        return gui.get("waitbar", ISET_PREFS.get("waitbar", 0))
+    if p in {"fontsize", "fontsize", "font size"}:
+        return ISET_PREFS.get("fontSize", 12)
+    if p in {"initclear", "init clear"}:
+        return ISET_PREFS.get("initClear", 0)
+
+    if p == "selected":
+        if not args:
+            raise ValueError("Object type required for 'selected'")
+        obj = _norm_objtype(str(args[0]))
+        return vcSESSION.get("SELECTED", {}).get(obj)
+
+    if p in _OBJTYPE_MAP:
+        obj = _norm_objtype(p)
+        return vcSESSION.get("SELECTED", {}).get(obj)
+
+    raise KeyError(f"Unknown session parameter '{param}'")

--- a/python/isetcam/ie_session_set.py
+++ b/python/isetcam/ie_session_set.py
@@ -1,0 +1,66 @@
+"""Modify values in the global ISETCam session."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .ie_init_session import vcSESSION, ISET_PREFS
+from .ie_param_format import ie_param_format
+
+
+_OBJTYPE_MAP = {
+    "scene": "SCENE",
+    "oi": "OPTICALIMAGE",
+    "opticalimage": "OPTICALIMAGE",
+    "sensor": "ISA",
+    "isa": "ISA",
+    "vcimage": "VCIMAGE",
+    "ip": "VCIMAGE",
+    "display": "DISPLAY",
+}
+
+
+def _norm_objtype(name: str) -> str:
+    key = ie_param_format(name)
+    if key not in _OBJTYPE_MAP:
+        raise KeyError(f"Unknown object type '{name}'")
+    return _OBJTYPE_MAP[key]
+
+
+def ie_session_set(param: str, val: Any, *args: Any) -> None:
+    """Set a value in the global ``vcSESSION`` or ``ISET_PREFS``."""
+    p = ie_param_format(param)
+
+    if p == "version":
+        vcSESSION["VERSION"] = val
+        return
+    if p in {"name", "sessionname"}:
+        vcSESSION["NAME"] = val
+        return
+    if p in {"dir", "sessiondir"}:
+        vcSESSION["DIR"] = val
+        return
+    if p == "waitbar":
+        ISET_PREFS["waitbar"] = int(bool(val))
+        vcSESSION.setdefault("GUI", {})["waitbar"] = int(bool(val))
+        return
+    if p in {"fontsize", "font size"}:
+        ISET_PREFS["fontSize"] = val
+        return
+    if p in {"initclear", "init clear"}:
+        ISET_PREFS["initClear"] = int(bool(val))
+        return
+
+    if p == "selected":
+        if not args:
+            raise ValueError("Object type required for 'selected'")
+        obj = _norm_objtype(str(args[0]))
+        vcSESSION.setdefault("SELECTED", {})[obj] = val
+        return
+
+    if p in _OBJTYPE_MAP:
+        obj = _norm_objtype(p)
+        vcSESSION.setdefault("SELECTED", {})[obj] = val
+        return
+
+    raise KeyError(f"Unknown session parameter '{param}'")

--- a/python/tests/test_ie_session_get_set.py
+++ b/python/tests/test_ie_session_get_set.py
@@ -1,0 +1,31 @@
+from isetcam import ie_init, ie_session_get, ie_session_set
+
+
+def test_set_and_get_basic_values():
+    ie_init()
+    ie_session_set('version', '1.2.3')
+    assert ie_session_get('version') == '1.2.3'
+
+    ie_session_set('name', 'my session')
+    assert ie_session_get('name') == 'my session'
+
+    ie_session_set('dir', '/tmp')
+    assert ie_session_get('dir') == '/tmp'
+
+    ie_session_set('waitbar', 1)
+    assert ie_session_get('waitbar') == 1
+
+    ie_session_set('font size', 14)
+    assert ie_session_get('font size') == 14
+
+    ie_session_set('init clear', True)
+    assert ie_session_get('init clear') in {True, 1}
+
+
+def test_selected_object_handling():
+    ie_init()
+    ie_session_set('scene', 2)
+    assert ie_session_get('scene') == 2
+
+    ie_session_set('selected', 3, 'sensor')
+    assert ie_session_get('selected', 'sensor') == 3


### PR DESCRIPTION
## Summary
- implement `ie_session_get` and `ie_session_set` to access/modify `vcSESSION` and `ISET_PREFS`
- export the new helpers from `isetcam`
- test setting and retrieving session parameters

## Testing
- `export PYTHONPATH=$PWD/python && pytest -q`