### PR TITLE
Add OpticalImage dataclass and helpers

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -1,1 +1,11 @@
 """Optical image functions."""
+
+from .oi_class import OpticalImage
+from .oi_utils import get_photons, set_photons, get_n_wave
+
+__all__ = [
+    "OpticalImage",
+    "get_photons",
+    "set_photons",
+    "get_n_wave",
+]

--- a/python/isetcam/opticalimage/oi_class.py
+++ b/python/isetcam/opticalimage/oi_class.py
@@ -1,0 +1,15 @@
+"""Basic :class:`OpticalImage` dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class OpticalImage:
+    """Minimal representation of an ISETCam optical image."""
+
+    photons: np.ndarray
+    wave: np.ndarray

--- a/python/isetcam/opticalimage/oi_utils.py
+++ b/python/isetcam/opticalimage/oi_utils.py
@@ -1,0 +1,22 @@
+"""Accessor utilities for :class:`OpticalImage`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+def get_photons(oi: OpticalImage) -> np.ndarray:
+    """Return the irradiance data from ``oi``."""
+    return oi.photons
+
+
+def set_photons(oi: OpticalImage, photons: np.ndarray) -> None:
+    """Set the irradiance data for ``oi``."""
+    oi.photons = np.asarray(photons)
+
+
+def get_n_wave(oi: OpticalImage) -> int:
+    """Return the number of wavelength samples in ``oi``."""
+    return len(oi.wave)

--- a/python/tests/test_oi_utils.py
+++ b/python/tests/test_oi_utils.py
@@ -1,0 +1,15 @@
+import numpy as np
+from isetcam.opticalimage import OpticalImage, get_photons, set_photons, get_n_wave
+
+
+def test_oi_accessors():
+    wave = np.array([500, 510, 520])
+    photons = np.ones((1, 1, 3))
+    oi = OpticalImage(photons=photons.copy(), wave=wave)
+
+    assert get_n_wave(oi) == 3
+    assert np.allclose(get_photons(oi), photons)
+
+    new_photons = np.zeros_like(photons)
+    set_photons(oi, new_photons)
+    assert np.allclose(get_photons(oi), new_photons)


### PR DESCRIPTION
## Summary
- add `OpticalImage` dataclass
- add optical image accessor utilities
- export new objects from `opticalimage` package
- test the new helpers

## Testing
- `PYTHONPATH=python pytest -q`