### PR TITLE
Add minimal Sensor dataclass with tests

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -1,1 +1,42 @@
 """Sensor-related functions."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .sensor_class import Sensor
+
+
+def get_volts(sensor: Sensor) -> np.ndarray:
+    """Return the voltage data from ``sensor``."""
+    return sensor.volts
+
+
+def set_volts(sensor: Sensor, volts: np.ndarray) -> None:
+    """Set the voltage data for ``sensor``."""
+    sensor.volts = np.asarray(volts)
+
+
+def get_exposure_time(sensor: Sensor) -> float:
+    """Return the exposure time for ``sensor``."""
+    return sensor.exposure_time
+
+
+def set_exposure_time(sensor: Sensor, exposure_time: float) -> None:
+    """Set the exposure time for ``sensor``."""
+    sensor.exposure_time = float(exposure_time)
+
+
+def get_n_wave(sensor: Sensor) -> int:
+    """Return the number of wavelength samples in ``sensor``."""
+    return len(sensor.wave)
+
+
+__all__ = [
+    "Sensor",
+    "get_volts",
+    "set_volts",
+    "get_exposure_time",
+    "set_exposure_time",
+    "get_n_wave",
+]

--- a/python/isetcam/sensor/sensor_class.py
+++ b/python/isetcam/sensor/sensor_class.py
@@ -1,0 +1,16 @@
+"""Basic :class:`Sensor` dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class Sensor:
+    """Minimal representation of an ISETCam sensor."""
+
+    volts: np.ndarray
+    wave: np.ndarray
+    exposure_time: float

--- a/python/tests/test_sensor_class.py
+++ b/python/tests/test_sensor_class.py
@@ -1,0 +1,28 @@
+import numpy as np
+from isetcam.sensor import (
+    Sensor,
+    get_volts,
+    set_volts,
+    get_exposure_time,
+    set_exposure_time,
+    get_n_wave,
+)
+
+
+def test_sensor_accessors():
+    wave = np.array([500, 510, 520])
+    volts = np.ones((1, 1, 3))
+    exposure_time = 0.01
+    s = Sensor(volts=volts.copy(), wave=wave, exposure_time=exposure_time)
+
+    assert get_n_wave(s) == 3
+    assert np.allclose(get_volts(s), volts)
+    assert get_exposure_time(s) == exposure_time
+
+    new_volts = np.zeros_like(volts)
+    set_volts(s, new_volts)
+    assert np.allclose(get_volts(s), new_volts)
+
+    new_exposure = 0.02
+    set_exposure_time(s, new_exposure)
+    assert get_exposure_time(s) == new_exposure


### PR DESCRIPTION
## Summary
- add `Sensor` dataclass for basic sensor representation
- implement simple accessors for sensor volt data and exposure time
- test creation of `Sensor` and accessor functionality

## Testing
- `export PYTHONPATH=$PWD/python:$PYTHONPATH`
- `pytest -q`