### PR TITLE
Add scene_get/set accessors

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -3,6 +3,8 @@
 from .scene_class import Scene
 from .scene_add import scene_add
 from .scene_utils import get_photons, set_photons, get_n_wave
+from .scene_get import scene_get
+from .scene_set import scene_set
 
 __all__ = [
     "Scene",
@@ -10,4 +12,6 @@ __all__ = [
     "get_photons",
     "set_photons",
     "get_n_wave",
+    "scene_get",
+    "scene_set",
 ]

--- a/python/isetcam/scene/scene_class.py
+++ b/python/isetcam/scene/scene_class.py
@@ -13,3 +13,4 @@ class Scene:
 
     photons: np.ndarray
     wave: np.ndarray
+    name: str | None = None

--- a/python/isetcam/scene/scene_get.py
+++ b/python/isetcam/scene/scene_get.py
@@ -1,0 +1,30 @@
+"""Retrieve parameters from :class:`Scene` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .scene_class import Scene
+from ..luminance_from_photons import luminance_from_photons
+
+
+def scene_get(scene: Scene, param: str) -> Any:
+    """Return a parameter value from ``scene``.
+
+    Supported parameters are ``photons``, ``wave``, ``n_wave``/``nwave``,
+    ``name``, and ``luminance``.
+    """
+    key = param.lower().replace(" ", "")
+    if key == "photons":
+        return scene.photons
+    if key == "wave":
+        return scene.wave
+    if key in {"nwave", "n_wave"}:
+        return len(scene.wave)
+    if key == "name":
+        return getattr(scene, "name", None)
+    if key == "luminance":
+        return luminance_from_photons(scene.photons, scene.wave)
+    raise KeyError(f"Unknown scene parameter '{param}'")

--- a/python/isetcam/scene/scene_set.py
+++ b/python/isetcam/scene/scene_set.py
@@ -1,0 +1,28 @@
+"""Assign parameters on :class:`Scene` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def scene_set(scene: Scene, param: str, val: Any) -> None:
+    """Set a parameter value on ``scene``.
+
+    Supported parameters are ``photons``, ``wave`` and ``name``. ``n_wave`` and
+    ``luminance`` are derived values and therefore cannot be set.
+    """
+    key = param.lower().replace(" ", "")
+    if key == "photons":
+        scene.photons = np.asarray(val)
+        return
+    if key == "wave":
+        scene.wave = np.asarray(val)
+        return
+    if key == "name":
+        scene.name = None if val is None else str(val)
+        return
+    raise KeyError(f"Unknown or read-only scene parameter '{param}'")

--- a/python/tests/test_scene_get_set.py
+++ b/python/tests/test_scene_get_set.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_get, scene_set
+from isetcam.luminance_from_photons import luminance_from_photons
+
+
+def test_scene_get_set():
+    wave = np.array([500, 510, 520])
+    photons = np.ones((2, 2, 3))
+    sc = Scene(photons=photons.copy(), wave=wave, name="orig")
+
+    assert np.allclose(scene_get(sc, "photons"), photons)
+    assert np.array_equal(scene_get(sc, "wave"), wave)
+    assert scene_get(sc, "n wave") == 3
+    assert scene_get(sc, "name") == "orig"
+
+    expected_lum = luminance_from_photons(photons, wave)
+    assert np.allclose(scene_get(sc, "luminance"), expected_lum)
+
+    new_photons = np.zeros_like(photons)
+    scene_set(sc, "photons", new_photons)
+    assert np.allclose(scene_get(sc, "photons"), new_photons)
+
+    new_wave = np.array([400, 500])
+    scene_set(sc, "wave", new_wave)
+    assert np.array_equal(scene_get(sc, "wave"), new_wave)
+    assert scene_get(sc, "n_wave") == len(new_wave)
+
+    scene_set(sc, "name", "new")
+    assert scene_get(sc, "name") == "new"


### PR DESCRIPTION
## Summary
- add `scene_get` and `scene_set` utilities for Scene objects
- expose new functions from `isetcam.scene`
- extend `Scene` dataclass with optional `name` field
- test round-trip getting and setting of scene values including luminance

## Testing
- `PYTHONPATH=python pytest -q`