### PR TITLE
Implement oi_get and oi_set for optical image

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -3,6 +3,8 @@
 from .oi_class import OpticalImage
 from .oi_utils import get_photons, set_photons, get_n_wave
 from .oi_add import oi_add
+from .oi_get import oi_get
+from .oi_set import oi_set
 
 __all__ = [
     "OpticalImage",
@@ -10,4 +12,6 @@ __all__ = [
     "set_photons",
     "get_n_wave",
     "oi_add",
+    "oi_get",
+    "oi_set",
 ]

--- a/python/isetcam/opticalimage/oi_class.py
+++ b/python/isetcam/opticalimage/oi_class.py
@@ -13,3 +13,4 @@ class OpticalImage:
 
     photons: np.ndarray
     wave: np.ndarray
+    name: str | None = None

--- a/python/isetcam/opticalimage/oi_get.py
+++ b/python/isetcam/opticalimage/oi_get.py
@@ -1,0 +1,30 @@
+"""Retrieve parameters from :class:`OpticalImage` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .oi_class import OpticalImage
+from ..luminance_from_photons import luminance_from_photons
+
+
+def oi_get(oi: OpticalImage, param: str) -> Any:
+    """Return a parameter value from ``oi``.
+
+    Supported parameters are ``photons``, ``wave``, ``n_wave``/``nwave``,
+    ``name``, and ``luminance``.
+    """
+    key = param.lower().replace(" ", "")
+    if key == "photons":
+        return oi.photons
+    if key == "wave":
+        return oi.wave
+    if key in {"nwave", "n_wave"}:
+        return len(oi.wave)
+    if key == "name":
+        return getattr(oi, "name", None)
+    if key == "luminance":
+        return luminance_from_photons(oi.photons, oi.wave)
+    raise KeyError(f"Unknown optical image parameter '{param}'")

--- a/python/isetcam/opticalimage/oi_set.py
+++ b/python/isetcam/opticalimage/oi_set.py
@@ -1,0 +1,28 @@
+"""Assign parameters on :class:`OpticalImage` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+def oi_set(oi: OpticalImage, param: str, val: Any) -> None:
+    """Set a parameter value on ``oi``.
+
+    Supported parameters are ``photons``, ``wave`` and ``name``. ``n_wave`` and
+    ``luminance`` are derived values and therefore cannot be set.
+    """
+    key = param.lower().replace(" ", "")
+    if key == "photons":
+        oi.photons = np.asarray(val)
+        return
+    if key == "wave":
+        oi.wave = np.asarray(val)
+        return
+    if key == "name":
+        oi.name = None if val is None else str(val)
+        return
+    raise KeyError(f"Unknown or read-only optical image parameter '{param}'")

--- a/python/tests/test_oi_get_set.py
+++ b/python/tests/test_oi_get_set.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from isetcam.opticalimage import OpticalImage, oi_get, oi_set
+from isetcam.luminance_from_photons import luminance_from_photons
+
+
+def test_oi_get_set():
+    wave = np.array([500, 510, 520])
+    photons = np.ones((2, 2, 3))
+    oi = OpticalImage(photons=photons.copy(), wave=wave, name="orig")
+
+    assert np.allclose(oi_get(oi, "photons"), photons)
+    assert np.array_equal(oi_get(oi, "wave"), wave)
+    assert oi_get(oi, "n wave") == 3
+    assert oi_get(oi, "name") == "orig"
+
+    expected_lum = luminance_from_photons(photons, wave)
+    assert np.allclose(oi_get(oi, "luminance"), expected_lum)
+
+    new_photons = np.zeros_like(photons)
+    oi_set(oi, "photons", new_photons)
+    assert np.allclose(oi_get(oi, "photons"), new_photons)
+
+    new_wave = np.array([400, 500])
+    oi_set(oi, "wave", new_wave)
+    assert np.array_equal(oi_get(oi, "wave"), new_wave)
+    assert oi_get(oi, "n_wave") == len(new_wave)
+
+    oi_set(oi, "name", "new")
+    assert oi_get(oi, "name") == "new"


### PR DESCRIPTION
## Summary
- allow naming OpticalImage dataclass
- add `oi_get` and `oi_set` modules for reading/writing optical image parameters
- expose new functions from the opticalimage package
- test get/set functionality for OpticalImage

## Testing
- `pytest -q`