### PR TITLE
Add scene_from_file utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -3,6 +3,7 @@
 from .scene_class import Scene
 from .scene_add import scene_add
 from .scene_utils import get_photons, set_photons, get_n_wave
+from .scene_from_file import scene_from_file
 from .scene_get import scene_get
 from .scene_set import scene_set
 
@@ -12,6 +13,7 @@ __all__ = [
     "get_photons",
     "set_photons",
     "get_n_wave",
+    "scene_from_file",
     "scene_get",
     "scene_set",
 ]

--- a/python/isetcam/scene/scene_from_file.py
+++ b/python/isetcam/scene/scene_from_file.py
@@ -1,0 +1,55 @@
+"""Create a Scene from an image file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import imageio.v2 as imageio
+
+from ..luminance_from_energy import luminance_from_energy
+from .scene_class import Scene
+
+
+def scene_from_file(
+    path: str | Path,
+    mean_luminance: Optional[float] = None,
+    wave: Optional[np.ndarray] = None,
+) -> Scene:
+    """Read ``path`` and return a :class:`Scene`.
+
+    Parameters
+    ----------
+    path : str or Path
+        Location of the image file to read.
+    mean_luminance : float, optional
+        When provided, scale the image so that its mean luminance equals this
+        value.
+    wave : array-like, optional
+        Wavelength samples in nanometers. If omitted, a simple sequence
+        ``np.arange(n_channels)`` is used.
+
+    Returns
+    -------
+    Scene
+        Scene containing the image data.
+    """
+    img = imageio.imread(Path(path))
+    data = np.asarray(img, dtype=float)
+    if data.ndim == 2:
+        data = data[:, :, np.newaxis]
+
+    if wave is None:
+        wave = np.arange(data.shape[2])
+    wave = np.asarray(wave).reshape(-1)
+    if len(wave) != data.shape[2]:
+        raise ValueError("wave must match number of image channels")
+
+    if mean_luminance is not None:
+        lum = luminance_from_energy(data, wave)
+        current_mean = float(lum.mean())
+        if current_mean > 0:
+            data = data * (mean_luminance / current_mean)
+
+    return Scene(photons=data, wave=wave)

--- a/python/tests/test_scene_from_file.py
+++ b/python/tests/test_scene_from_file.py
@@ -1,0 +1,35 @@
+import numpy as np
+from pathlib import Path
+
+from isetcam.scene import scene_from_file, Scene
+from isetcam import luminance_from_energy
+
+
+def test_scene_from_file_rgb():
+    root = Path(__file__).resolve().parents[2]
+    fpath = root / 'data' / 'images' / 'rgb' / 'adelson.png'
+    wave = np.array([450, 550, 650, 750])
+    sc = scene_from_file(fpath, wave=wave)
+    assert isinstance(sc, Scene)
+    assert sc.photons.dtype == float
+    assert sc.photons.ndim == 3 and sc.photons.shape[2] == 4
+    assert np.array_equal(sc.wave, wave)
+
+
+def test_scene_from_file_mean_luminance():
+    root = Path(__file__).resolve().parents[2]
+    fpath = root / 'data' / 'images' / 'rgb' / 'adelson.png'
+    wave = np.array([450, 550, 650, 750])
+    target = 10.0
+    sc = scene_from_file(fpath, mean_luminance=target, wave=wave)
+    lum = luminance_from_energy(sc.photons, sc.wave)
+    assert np.isclose(lum.mean(), target, atol=1e-6)
+
+
+def test_scene_from_file_gray():
+    root = Path(__file__).resolve().parents[2]
+    fpath = root / 'data' / 'images' / 'targets' / 'usaf1951' / 'USAF1951-72dpi.jpg'
+    wave = np.array([550])
+    sc = scene_from_file(fpath, wave=wave)
+    assert sc.photons.ndim == 3 and sc.photons.shape[2] == 1
+    assert np.array_equal(sc.wave, wave)


### PR DESCRIPTION
## Summary
- implement `scene_from_file` to create `Scene` objects from image files
- export new helper from `isetcam.scene`
- test RGB/gray image loading and luminance scaling

## Testing
- `pytest -q`