### PR TITLE
Add display dataclass and accessors

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -21,7 +21,7 @@ from .xw_to_rgb_format import xw_to_rgb_format
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor
+from . import scene, opticalimage, sensor, display
 
 __all__ = [
     'vc_constants',
@@ -45,4 +45,5 @@ __all__ = [
     'scene',
     'opticalimage',
     'sensor',
+    'display',
 ]

--- a/python/isetcam/display/__init__.py
+++ b/python/isetcam/display/__init__.py
@@ -1,0 +1,11 @@
+"""Display-related functions."""
+
+from .display_class import Display
+from .display_get import display_get
+from .display_set import display_set
+
+__all__ = [
+    "Display",
+    "display_get",
+    "display_set",
+]

--- a/python/isetcam/display/display_class.py
+++ b/python/isetcam/display/display_class.py
@@ -1,0 +1,16 @@
+"""Basic :class:`Display` dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class Display:
+    """Minimal representation of an ISETCam display."""
+
+    spd: np.ndarray
+    wave: np.ndarray
+    name: str | None = None

--- a/python/isetcam/display/display_get.py
+++ b/python/isetcam/display/display_get.py
@@ -1,0 +1,27 @@
+"""Retrieve parameters from :class:`Display` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .display_class import Display
+
+
+def display_get(display: Display, param: str) -> Any:
+    """Return a parameter value from ``display``.
+
+    Supported parameters are ``spd``, ``wave``, ``n_wave``/``nwave`` and
+    ``name``.
+    """
+    key = param.lower().replace(" ", "")
+    if key == "spd":
+        return display.spd
+    if key == "wave":
+        return display.wave
+    if key in {"nwave", "n_wave"}:
+        return len(display.wave)
+    if key == "name":
+        return getattr(display, "name", None)
+    raise KeyError(f"Unknown display parameter '{param}'")

--- a/python/isetcam/display/display_set.py
+++ b/python/isetcam/display/display_set.py
@@ -1,0 +1,28 @@
+"""Assign parameters on :class:`Display` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .display_class import Display
+
+
+def display_set(display: Display, param: str, val: Any) -> None:
+    """Set a parameter value on ``display``.
+
+    Supported parameters are ``spd``, ``wave`` and ``name``. ``n_wave`` is a
+    derived value and therefore cannot be set.
+    """
+    key = param.lower().replace(" ", "")
+    if key == "spd":
+        display.spd = np.asarray(val)
+        return
+    if key == "wave":
+        display.wave = np.asarray(val)
+        return
+    if key == "name":
+        display.name = None if val is None else str(val)
+        return
+    raise KeyError(f"Unknown or read-only display parameter '{param}'")

--- a/python/tests/test_display_get_set.py
+++ b/python/tests/test_display_get_set.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from isetcam.display import Display, display_get, display_set
+
+
+def test_display_get_set():
+    wave = np.array([500, 510, 520])
+    spd = np.ones((3, 2))
+    disp = Display(spd=spd.copy(), wave=wave, name="orig")
+
+    assert np.allclose(display_get(disp, "spd"), spd)
+    assert np.array_equal(display_get(disp, "wave"), wave)
+    assert display_get(disp, "n wave") == 3
+    assert display_get(disp, "name") == "orig"
+
+    new_spd = np.zeros_like(spd)
+    display_set(disp, "spd", new_spd)
+    assert np.allclose(display_get(disp, "spd"), new_spd)
+
+    new_wave = np.array([400, 500])
+    display_set(disp, "wave", new_wave)
+    assert np.array_equal(display_get(disp, "wave"), new_wave)
+    assert display_get(disp, "n_wave") == len(new_wave)
+
+    display_set(disp, "name", "new")
+    assert display_get(disp, "name") == "new"


### PR DESCRIPTION
## Summary
- add `Display` dataclass in `display` package
- implement `display_get` and `display_set`
- export new display components
- test new get/set helpers

## Testing
- `pytest -q`