### PR TITLE
Add illuminant utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -21,7 +21,7 @@ from .xw_to_rgb_format import xw_to_rgb_format
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, display
+from . import scene, opticalimage, sensor, display, illuminant
 
 __all__ = [
     'vc_constants',
@@ -46,4 +46,5 @@ __all__ = [
     'opticalimage',
     'sensor',
     'display',
+    'illuminant',
 ]

--- a/python/isetcam/illuminant/__init__.py
+++ b/python/isetcam/illuminant/__init__.py
@@ -1,0 +1,11 @@
+"""Illuminant-related functions."""
+
+from .illuminant_class import Illuminant
+from .illuminant_blackbody import illuminant_blackbody
+from .illuminant_create import illuminant_create
+
+__all__ = [
+    "Illuminant",
+    "illuminant_blackbody",
+    "illuminant_create",
+]

--- a/python/isetcam/illuminant/illuminant_blackbody.py
+++ b/python/isetcam/illuminant/illuminant_blackbody.py
@@ -1,0 +1,19 @@
+"""Generate a blackbody spectral distribution."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..vc_constants import vc_constants
+
+
+def illuminant_blackbody(temp: float, wave: np.ndarray) -> np.ndarray:
+    """Return blackbody spectral radiance at ``temp`` for wavelengths ``wave``."""
+    wave = np.asarray(wave, dtype=float)
+    h = vc_constants("h")
+    c = vc_constants("c")
+    k = vc_constants("j")
+    lam = wave * 1e-9
+    exponent = (h * c) / (lam * k * temp)
+    spd = (2 * h * c**2) / (lam**5) / (np.exp(exponent) - 1)
+    return spd

--- a/python/isetcam/illuminant/illuminant_class.py
+++ b/python/isetcam/illuminant/illuminant_class.py
@@ -1,0 +1,16 @@
+"""Basic :class:`Illuminant` dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class Illuminant:
+    """Spectral power distribution of an illuminant."""
+
+    spd: np.ndarray
+    wave: np.ndarray
+    name: str | None = None

--- a/python/isetcam/illuminant/illuminant_create.py
+++ b/python/isetcam/illuminant/illuminant_create.py
@@ -1,0 +1,36 @@
+"""Factory function for :class:`Illuminant` objects."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from scipy.io import loadmat
+
+from .illuminant_class import Illuminant
+
+
+_DEF_DIR = 'data'
+
+
+def _load_spd(path: Path) -> tuple[np.ndarray, np.ndarray]:
+    data = loadmat(path)
+    wave = data['wavelength'].ravel()
+    spd = data['data'].ravel()
+    return wave, spd
+
+
+def illuminant_create(name: str, wave: np.ndarray | None = None) -> Illuminant:
+    """Create an illuminant by name, optionally interpolated to ``wave``."""
+    root = Path(__file__).resolve().parents[3]
+    fname = name.strip().upper() + '.mat'
+    path = root / _DEF_DIR / 'lights' / fname
+    if not path.exists():
+        raise FileNotFoundError(f"Unknown illuminant '{name}'")
+    src_wave, spd = _load_spd(path)
+    if wave is not None:
+        wave = np.asarray(wave, dtype=float)
+        spd = np.interp(wave, src_wave, spd, left=0.0, right=0.0)
+    else:
+        wave = src_wave
+    return Illuminant(spd=spd.astype(float), wave=wave, name=name)

--- a/python/tests/test_illuminant.py
+++ b/python/tests/test_illuminant.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from isetcam.illuminant import Illuminant, illuminant_blackbody, illuminant_create
+
+
+def test_illuminant_create_d65_peak():
+    illum = illuminant_create('D65')
+    peak_wave = illum.wave[illum.spd.argmax()]
+    assert peak_wave == 460
+
+
+def test_illuminant_create_interp():
+    wave = np.array([400, 500, 600])
+    illum = illuminant_create('D65', wave)
+    assert np.array_equal(illum.wave, wave)
+    assert illum.spd.shape == wave.shape
+
+
+def test_blackbody_shape():
+    wave = np.arange(400, 701, 10)
+    spd = illuminant_blackbody(6500, wave)
+    assert spd.shape == wave.shape
+    assert np.all(spd >= 0)


### PR DESCRIPTION
## Summary
- add Illuminant dataclass with SPD and wavelength
- support blackbody distribution and dataset-based illuminants
- export illuminant package
- test D65 illuminant properties

## Testing
- `PYTHONPATH=$PWD/python pytest -q`