### PR TITLE
Add Python session persistence utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -17,6 +17,8 @@ from .cct import cct
 from .ie_param_format import ie_param_format
 from .ie_session_get import ie_session_get
 from .ie_session_set import ie_session_set
+from .ie_save_session import ie_save_session
+from .ie_load_session import ie_load_session
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 
@@ -40,6 +42,8 @@ __all__ = [
     'ie_param_format',
     'ie_session_get',
     'ie_session_set',
+    'ie_save_session',
+    'ie_load_session',
     'rgb_to_xw_format',
     'xw_to_rgb_format',
     'ie_init',

--- a/python/isetcam/ie_load_session.py
+++ b/python/isetcam/ie_load_session.py
@@ -1,0 +1,20 @@
+"""Load an ISETCam session from disk."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .ie_init_session import vcSESSION
+
+
+def ie_load_session(path: str | Path) -> Dict[str, Any]:
+    """Load session data from ``path`` and update ``vcSESSION``."""
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    vcSESSION.clear()
+    vcSESSION.update(data)
+    return vcSESSION
+

--- a/python/isetcam/ie_save_session.py
+++ b/python/isetcam/ie_save_session.py
@@ -1,0 +1,15 @@
+"""Save an ISETCam session to disk."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def ie_save_session(session: Dict[str, Any], path: str | Path) -> None:
+    """Serialize ``session`` to ``path`` in JSON format."""
+    p = Path(path)
+    with p.open("w", encoding="utf-8") as f:
+        json.dump(session, f, indent=2)
+

--- a/python/tests/test_ie_session_persistence.py
+++ b/python/tests/test_ie_session_persistence.py
@@ -1,0 +1,30 @@
+import copy
+
+from isetcam import (
+    ie_init,
+    ie_session_set,
+    ie_session_get,
+    ie_save_session,
+    ie_load_session,
+)
+from isetcam.ie_init_session import vcSESSION
+
+
+def test_session_save_and_load(tmp_path):
+    ie_init()
+    ie_session_set('version', '1.0')
+    ie_session_set('name', 'my session')
+    ie_session_set('scene', 3)
+
+    expected = copy.deepcopy(vcSESSION)
+    path = tmp_path / 'session.json'
+    ie_save_session(vcSESSION, path)
+
+    ie_init()
+    assert ie_session_get('version') is None
+
+    loaded = ie_load_session(path)
+    assert loaded == expected
+    assert ie_session_get('scene') == 3
+    assert ie_session_get('name') == 'my session'
+


### PR DESCRIPTION
## Summary
- add `ie_save_session` and `ie_load_session` for JSON persistence of `vcSESSION`
- expose new helpers from the `isetcam` package
- test saving and loading sessions

## Testing
- `pytest -q`