### PR TITLE
Add scotopic luminance utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -8,6 +8,7 @@ from .ie_init import ie_init
 from .ie_init_session import ie_init_session
 from .luminance_from_energy import luminance_from_energy
 from .luminance_from_photons import luminance_from_photons
+from .scotopic_luminance_from_energy import scotopic_luminance_from_energy
 from .ie_luminance_to_radiance import ie_luminance_to_radiance
 from .ie_xyz_from_energy import ie_xyz_from_energy
 from .ie_xyz_from_photons import ie_xyz_from_photons
@@ -33,6 +34,7 @@ __all__ = [
     'energy_to_quanta',
     'luminance_from_energy',
     'luminance_from_photons',
+    'scotopic_luminance_from_energy',
     'ie_luminance_to_radiance',
     'ie_xyz_from_energy',
     'ie_xyz_from_photons',

--- a/python/isetcam/scotopic_luminance_from_energy.py
+++ b/python/isetcam/scotopic_luminance_from_energy.py
@@ -1,0 +1,79 @@
+"""Calculate scotopic luminance from spectral energy data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from scipy.io import loadmat
+
+from .vc_get_image_format import vc_get_image_format
+
+_DEF_BINWIDTH = 10
+
+
+def _scotopic_luminosity(wave: np.ndarray) -> np.ndarray:
+    """Return the scotopic luminosity function interpolated to ``wave``."""
+    root = Path(__file__).resolve().parents[2]
+    fpath = root / 'data' / 'human' / 'rods.mat'
+    data = loadmat(fpath)
+    src_wave = data['wavelength'].ravel()
+    Vprime = data['data'].ravel()
+    return np.interp(wave, src_wave, Vprime, left=0.0, right=0.0)
+
+
+def scotopic_luminance_from_energy(
+    energy: np.ndarray, wavelength: np.ndarray, binwidth: Optional[float] = None
+) -> np.ndarray:
+    """Compute scotopic luminance (cd/m^2) from spectral energy.
+
+    Parameters
+    ----------
+    energy : np.ndarray
+        Spectral energy in either RGB or XW format with wavelength along
+        the last dimension or columns.
+    wavelength : array-like
+        Sampled wavelengths in nanometers.
+    binwidth : float, optional
+        Spectral bin width in nanometers. When not provided, it is derived
+        from ``wavelength`` if possible, otherwise defaults to 10 nm.
+
+    Returns
+    -------
+    np.ndarray
+        Scotopic luminance values in the same spatial format as ``energy``.
+    """
+    energy = np.asarray(energy)
+    if energy.size == 0:
+        return np.array([])
+
+    wavelength = np.asarray(wavelength).reshape(-1)
+    if binwidth is None:
+        if len(wavelength) > 1:
+            binwidth = wavelength[1] - wavelength[0]
+        else:
+            binwidth = _DEF_BINWIDTH
+
+    img_format = vc_get_image_format(energy, wavelength)
+    if img_format == 'RGB':
+        n, m, w = energy.shape
+        if w != len(wavelength):
+            raise ValueError('energy third dimension must be nWave')
+        xw = energy.reshape(n * m, w)
+    else:
+        if energy.ndim == 1:
+            xw = energy[np.newaxis, :]
+        else:
+            xw = energy
+        if xw.shape[1] != len(wavelength):
+            raise ValueError('Energy must be in XW format with wavelength columns')
+        n = m = None
+
+    Vprime = _scotopic_luminosity(wavelength)
+    lum = 1745 * xw.dot(Vprime) * binwidth
+
+    if img_format == 'RGB':
+        lum = lum.reshape(n, m)
+
+    return lum

--- a/python/tests/test_scotopic_luminance.py
+++ b/python/tests/test_scotopic_luminance.py
@@ -1,0 +1,31 @@
+import numpy as np
+from pathlib import Path
+from scipy.io import loadmat
+
+from isetcam import scotopic_luminance_from_energy
+
+
+def _expected_scotopic_luminance(wave, energy):
+    root = Path(__file__).resolve().parents[2]
+    mat = loadmat(root / 'data' / 'human' / 'rods.mat')
+    Vp = np.interp(wave, mat['wavelength'].ravel(), mat['data'].ravel(), left=0.0, right=0.0)
+    binwidth = wave[1] - wave[0] if len(wave) > 1 else 10
+    xw = energy.reshape(-1, len(wave))
+    lum = 1745 * xw.dot(Vp) * binwidth
+    return lum.reshape(energy.shape[:-1])
+
+
+def test_scotopic_luminance_from_energy_xw():
+    wave = np.arange(400, 701, 10)
+    energy = np.ones((1, len(wave)))
+    lum = scotopic_luminance_from_energy(energy, wave)
+    expected = _expected_scotopic_luminance(wave, energy)
+    assert np.allclose(lum, expected)
+
+
+def test_scotopic_luminance_from_energy_rgb():
+    wave = np.arange(400, 701, 10)
+    energy = np.ones((1, 1, len(wave)))
+    lum = scotopic_luminance_from_energy(energy, wave)
+    expected = _expected_scotopic_luminance(wave, energy.reshape(1, len(wave)))
+    assert np.allclose(lum, expected.reshape(1, 1))


### PR DESCRIPTION
## Summary
- port `ieScotopicLuminanceFromEnergy.m` to Python
- expose `scotopic_luminance_from_energy` via the package
- test scotopic luminance for RGB and XW inputs

## Testing
- `pytest -q`