### PR TITLE
Add XYZ/LAB conversion utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -22,6 +22,8 @@ from .ie_save_session import ie_save_session
 from .ie_load_session import ie_load_session
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
+from .xyz_to_lab import xyz_to_lab
+from .lab_to_xyz import lab_to_xyz
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
@@ -48,6 +50,8 @@ __all__ = [
     'ie_load_session',
     'rgb_to_xw_format',
     'xw_to_rgb_format',
+    'xyz_to_lab',
+    'lab_to_xyz',
     'ie_init',
     'ie_init_session',
     'scene',

--- a/python/isetcam/lab_to_xyz.py
+++ b/python/isetcam/lab_to_xyz.py
@@ -1,0 +1,65 @@
+"""Convert CIE L*a*b* values to CIE XYZ."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+
+_DEF_THRESHOLD = 0.206893
+
+def lab_to_xyz(lab: np.ndarray, whitepoint: np.ndarray) -> np.ndarray:
+    """Convert CIE L*a*b* values to XYZ tristimulus values.
+
+    Parameters
+    ----------
+    lab : np.ndarray
+        L*a*b* values in either XW format ``(n, 3)`` or RGB format
+        ``(rows, cols, 3)``.
+    whitepoint : array-like
+        Reference whitepoint as ``(Xn, Yn, Zn)``.
+
+    Returns
+    -------
+    np.ndarray
+        XYZ values in the same spatial format as ``lab``.
+    """
+    lab = np.asarray(lab, dtype=float)
+    wp = np.asarray(whitepoint, dtype=float).reshape(3)
+    Xn, Yn, Zn = wp
+
+    if lab.ndim == 3:
+        xw, r, c = rgb_to_xw_format(lab)
+        reshape = True
+    elif lab.ndim == 2:
+        if lab.shape[1] != 3:
+            raise ValueError("lab must have shape (n,3)")
+        xw = lab
+        reshape = False
+    else:
+        raise ValueError("lab must be (n,3) or (rows,cols,3)")
+
+    fy = (xw[:, 0] + 16) / 116
+    y = fy ** 3
+    yy = xw[:, 0] <= 7.9996
+    y[yy] = xw[yy, 0] / 903.3
+    fy[yy] = 7.787 * y[yy] + 16 / 116
+
+    fx = xw[:, 1] / 500 + fy
+    fz = fy - xw[:, 2] / 200
+
+    xx = fx < _DEF_THRESHOLD
+    zz = fz < _DEF_THRESHOLD
+
+    x = fx ** 3
+    z = fz ** 3
+    x[xx] = (fx[xx] - 16 / 116) / 7.787
+    z[zz] = (fz[zz] - 16 / 116) / 7.787
+
+    xyz = np.stack([x * Xn, y * Yn, z * Zn], axis=1)
+
+    if reshape:
+        xyz = xw_to_rgb_format(xyz, r, c)
+    return xyz

--- a/python/isetcam/xyz_to_lab.py
+++ b/python/isetcam/xyz_to_lab.py
@@ -1,0 +1,76 @@
+"""Convert CIE XYZ values to CIE L*a*b*."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+
+_DEF_THRESHOLD = 0.008856
+
+
+def xyz_to_lab(xyz: np.ndarray, whitepoint: np.ndarray) -> np.ndarray:
+    """Convert XYZ tristimulus values to CIE L*a*b*.
+
+    Parameters
+    ----------
+    xyz : np.ndarray
+        XYZ values in either XW format ``(n, 3)`` or RGB format
+        ``(rows, cols, 3)``.
+    whitepoint : array-like
+        Reference whitepoint as ``(Xn, Yn, Zn)``.
+
+    Returns
+    -------
+    np.ndarray
+        L*a*b* values in the same spatial format as ``xyz``.
+    """
+    xyz = np.asarray(xyz, dtype=float)
+    wp = np.asarray(whitepoint, dtype=float).reshape(3)
+    Xn, Yn, Zn = wp
+
+    if xyz.ndim == 3:
+        xw, r, c = rgb_to_xw_format(xyz)
+        reshape = True
+    elif xyz.ndim == 2:
+        if xyz.shape[1] != 3:
+            raise ValueError("xyz must have shape (n,3)")
+        xw = xyz
+        reshape = False
+    else:
+        raise ValueError("xyz must be (n,3) or (rows,cols,3)")
+
+    x = xw[:, 0] / Xn
+    y = xw[:, 1] / Yn
+    z = xw[:, 2] / Zn
+
+    lab = np.zeros_like(xw)
+
+    yy = y <= _DEF_THRESHOLD
+    xx = x <= _DEF_THRESHOLD
+    zz = z <= _DEF_THRESHOLD
+
+    fy_small = y[yy]
+
+    y_cbrt = np.cbrt(y)
+    lab[:, 0] = 116 * y_cbrt - 16
+    lab[yy, 0] = 903.3 * fy_small
+
+    fx = 7.787 * x[xx] + 16 / 116
+    fy = 7.787 * fy_small + 16 / 116
+    fz = 7.787 * z[zz] + 16 / 116
+
+    x_cbrt = np.cbrt(x)
+    z_cbrt = np.cbrt(z)
+    x_cbrt[xx] = fx
+    y_cbrt[yy] = fy
+    z_cbrt[zz] = fz
+
+    lab[:, 1] = 500 * (x_cbrt - y_cbrt)
+    lab[:, 2] = 200 * (y_cbrt - z_cbrt)
+
+    if reshape:
+        lab = xw_to_rgb_format(lab, r, c)
+    return lab

--- a/python/tests/test_lab_xyz.py
+++ b/python/tests/test_lab_xyz.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from isetcam import xyz_to_lab, lab_to_xyz
+
+
+WHITEPOINT = np.array([0.95047, 1.0, 1.08883])
+
+
+def test_xyz_lab_round_trip_xw():
+    xyz = np.random.rand(10, 3)
+    lab = xyz_to_lab(xyz, WHITEPOINT)
+    xyz2 = lab_to_xyz(lab, WHITEPOINT)
+    assert np.allclose(xyz2, xyz, atol=1e-6)
+
+
+def test_xyz_lab_round_trip_rgb():
+    xyz = np.random.rand(4, 5, 3)
+    lab = xyz_to_lab(xyz, WHITEPOINT)
+    xyz2 = lab_to_xyz(lab, WHITEPOINT)
+    assert np.allclose(xyz2, xyz, atol=1e-6)


### PR DESCRIPTION
## Summary
- implement `xyz_to_lab` and `lab_to_xyz` with support for RGB/XW formats
- export conversions via package `__init__`
- add tests for round‑trip XYZ/LAB conversions

## Testing
- `pytest -q`