### PR TITLE
Add sRGB↔XYZ conversion utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -24,6 +24,12 @@ from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 from .xyz_to_lab import xyz_to_lab
 from .lab_to_xyz import lab_to_xyz
+from .srgb_xyz import (
+    srgb_to_linear,
+    linear_to_srgb,
+    srgb_to_xyz,
+    xyz_to_srgb,
+)
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
@@ -52,6 +58,10 @@ __all__ = [
     'xw_to_rgb_format',
     'xyz_to_lab',
     'lab_to_xyz',
+    'srgb_to_linear',
+    'linear_to_srgb',
+    'srgb_to_xyz',
+    'xyz_to_srgb',
     'ie_init',
     'ie_init_session',
     'scene',

--- a/python/isetcam/srgb_xyz.py
+++ b/python/isetcam/srgb_xyz.py
@@ -1,0 +1,128 @@
+"""Convert between sRGB and CIE XYZ color spaces."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+# XYZ to linear RGB matrix (row-vector form) from the sRGB standard
+_XYZ2LRGB = np.array([
+    [3.2410, -0.9692, 0.0556],
+    [-1.5374, 1.8760, -0.2040],
+    [-0.4986, 0.0416, 1.0570],
+])
+
+# Inverse matrix for converting linear RGB to XYZ.
+_LRGB2XYZ = np.linalg.inv(_XYZ2LRGB)
+
+
+_DEF_LRGB_EPS = 0.0031308
+_DEF_SRGB_EPS = 0.04045
+
+
+def srgb_to_linear(srgb: np.ndarray) -> np.ndarray:
+    """Convert nonlinear sRGB values to linear RGB.
+
+    Parameters
+    ----------
+    srgb : np.ndarray
+        sRGB values in ``[0, 1]``.
+
+    Returns
+    -------
+    np.ndarray
+        Linear RGB values in the same shape as ``srgb``.
+    """
+    srgb = np.asarray(srgb, dtype=float)
+    lrgb = srgb.copy()
+    mask = lrgb > _DEF_SRGB_EPS
+    lrgb[mask] = ((lrgb[mask] + 0.055) / 1.055) ** 2.4
+    lrgb[~mask] = lrgb[~mask] / 12.92
+    return lrgb
+
+
+def linear_to_srgb(lrgb: np.ndarray) -> np.ndarray:
+    """Convert linear RGB values to nonlinear sRGB."""
+    lrgb = np.asarray(lrgb, dtype=float)
+    if lrgb.max() > 1 or lrgb.min() < 0:
+        raise ValueError("Linear rgb values must be between 0 and 1")
+    srgb = lrgb.copy()
+    mask = srgb > _DEF_LRGB_EPS
+    srgb[mask] = 1.055 * srgb[mask] ** (1 / 2.4) - 0.055
+    srgb[~mask] = srgb[~mask] * 12.92
+    return srgb
+
+
+def srgb_to_xyz(srgb: np.ndarray) -> np.ndarray:
+    """Convert sRGB image data to CIE XYZ.
+
+    Parameters
+    ----------
+    srgb : np.ndarray
+        RGB values in either ``(N, 3)`` XW format or ``(R, C, 3)`` RGB format.
+
+    Returns
+    -------
+    np.ndarray
+        XYZ values in the same spatial format as ``srgb``.
+    """
+    if srgb.ndim == 3:
+        xw, r, c = rgb_to_xw_format(srgb)
+        reshape = True
+    elif srgb.ndim == 2 and srgb.shape[1] == 3:
+        xw = srgb
+        reshape = False
+    else:
+        raise ValueError("srgb must be (rows, cols, 3) or (n, 3)")
+
+    lrgb = srgb_to_linear(xw)
+    xyz = lrgb @ _LRGB2XYZ
+
+    if reshape:
+        xyz = xw_to_rgb_format(xyz, r, c)
+    return xyz
+
+
+def xyz_to_srgb(xyz: np.ndarray) -> tuple[np.ndarray, np.ndarray, float]:
+    """Convert CIE XYZ values to sRGB.
+
+    Parameters
+    ----------
+    xyz : np.ndarray
+        XYZ values in either ``(N, 3)`` or ``(R, C, 3)`` format.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, float]
+        Tuple containing ``srgb`` values, the intermediate linear RGB
+        ``lrgb`` array, and the normalization factor ``maxY`` applied to the
+        input XYZ data.
+    """
+    if xyz.ndim == 3:
+        xw, r, c = rgb_to_xw_format(xyz)
+        reshape = True
+    elif xyz.ndim == 2 and xyz.shape[1] == 3:
+        xw = xyz
+        reshape = False
+    else:
+        raise ValueError("xyz must be (rows, cols, 3) or (n, 3)")
+
+    Y = xw[:, 1]
+    maxY = float(Y.max())
+    if maxY > 1:
+        xw = xw / maxY
+    else:
+        maxY = 1.0
+
+    if xw.min() < 0:
+        xw = np.clip(xw, 0.0, 1.0)
+
+    lrgb = xw @ _XYZ2LRGB
+    srgb = linear_to_srgb(np.clip(lrgb, 0.0, 1.0))
+
+    if reshape:
+        srgb = xw_to_rgb_format(srgb, r, c)
+        lrgb = xw_to_rgb_format(lrgb, r, c)
+    return srgb, lrgb, maxY

--- a/python/tests/test_srgb_xyz.py
+++ b/python/tests/test_srgb_xyz.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+from isetcam import (
+    srgb_to_linear,
+    linear_to_srgb,
+    srgb_to_xyz,
+    xyz_to_srgb,
+)
+
+
+# Expected white point of sRGB in XYZ (D65 with unit luminance)
+_WHITE = np.array([0.9505, 1.0, 1.0890])
+
+
+def _expected_srgb_to_xyz(srgb: np.ndarray) -> np.ndarray:
+    M = np.array([
+        [0.41238088, 0.21261986, 0.0193435],
+        [0.35757284, 0.71513879, 0.11921217],
+        [0.18045230, 0.07214994, 0.95050657],
+    ])
+    srgb = np.asarray(srgb)
+    lrgb = srgb.copy()
+    mask = lrgb > 0.04045
+    lrgb[mask] = ((lrgb[mask] + 0.055) / 1.055) ** 2.4
+    lrgb[~mask] = lrgb[~mask] / 12.92
+    xw = lrgb.reshape(-1, 3)
+    xyz = xw @ M
+    return xyz.reshape(srgb.shape)
+
+
+def _expected_xyz_to_srgb(xyz: np.ndarray):
+    M = np.array([
+        [3.2410, -0.9692, 0.0556],
+        [-1.5374, 1.8760, -0.2040],
+        [-0.4986, 0.0416, 1.0570],
+    ])
+    xyz = np.asarray(xyz, float)
+    xw = xyz.reshape(-1, 3)
+    maxY = xw[:, 1].max()
+    if maxY > 1:
+        xw = xw / maxY
+    else:
+        maxY = 1.0
+    xw = np.clip(xw, 0.0, 1.0)
+    lrgb = xw @ M
+    clip = np.clip(lrgb, 0.0, 1.0)
+    srgb = clip.copy()
+    mask = srgb > 0.0031308
+    srgb[mask] = 1.055 * srgb[mask] ** (1 / 2.4) - 0.055
+    srgb[~mask] = srgb[~mask] * 12.92
+    return srgb.reshape(xyz.shape), lrgb.reshape(xyz.shape), maxY
+
+
+def test_white_point():
+    xyz = srgb_to_xyz(np.ones((1, 1, 3)))
+    assert np.allclose(xyz.reshape(3), _WHITE, atol=1e-4)
+
+
+def test_srgb_linear_round_trip():
+    srgb = np.random.rand(10, 3)
+    lrgb = srgb_to_linear(srgb)
+    srgb2 = linear_to_srgb(lrgb)
+    assert np.allclose(srgb2, srgb, atol=1e-6)
+
+
+def test_srgb_xyz_round_trip_rgb():
+    srgb = np.random.rand(4, 5, 3)
+    xyz = srgb_to_xyz(srgb)
+    srgb2, lrgb, maxY = xyz_to_srgb(xyz)
+    assert np.allclose(srgb2, srgb, atol=1e-6)
+    assert maxY == 1.0
+    assert lrgb.shape == srgb.shape
+
+
+def test_xyz_scaling():
+    xyz = 2 * _WHITE.reshape(1, 1, 3)
+    srgb, lrgb, maxY = xyz_to_srgb(xyz)
+    assert np.allclose(srgb, 1.0, atol=1e-4)
+    assert np.isclose(maxY, 2.0)
+    assert lrgb.shape == xyz.shape
+
+
+def test_against_matlab_formula():
+    srgb = np.random.rand(6, 3)
+    xyz = srgb_to_xyz(srgb)
+    expected = _expected_srgb_to_xyz(srgb)
+    assert np.allclose(xyz, expected)
+
+    srgb2, lrgb, maxY = xyz_to_srgb(xyz)
+    ex_srgb, ex_lrgb, ex_maxY = _expected_xyz_to_srgb(xyz)
+    assert np.allclose(srgb2, ex_srgb)
+    assert np.allclose(lrgb, ex_lrgb)
+    assert np.isclose(maxY, ex_maxY)


### PR DESCRIPTION
## Summary
- add Python implementation of srgb2xyz/xyz2srgb with sRGB gamma handling
- expose conversion functions from package
- test conversions against MATLAB equations

## Testing
- `PYTHONPATH=$PWD/python pytest -q`