### PR TITLE
Add cct_to_sun daylight SPD function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ web/webImageBrowser/PackagingLog.html
 
 *.asv
 data/images/multispectral/FruitMCC.mat
+__pycache__/
+*/__pycache__/

--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -15,6 +15,7 @@ from .ie_xyz_from_photons import ie_xyz_from_photons
 from .ie_color_transform import ie_color_transform
 from .chromaticity import chromaticity
 from .cct import cct
+from .cct_to_sun import cct_to_sun
 from .ie_param_format import ie_param_format
 from .ie_session_get import ie_session_get
 from .ie_session_set import ie_session_set
@@ -49,6 +50,7 @@ __all__ = [
     'ie_color_transform',
     'chromaticity',
     'cct',
+    'cct_to_sun',
     'ie_param_format',
     'ie_session_get',
     'ie_session_set',

--- a/python/isetcam/cct_to_sun.py
+++ b/python/isetcam/cct_to_sun.py
@@ -1,0 +1,81 @@
+"""Generate a daylight spectral power distribution from CCT."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+from scipy.io import loadmat
+
+from .energy_to_quanta import energy_to_quanta
+
+
+_DEF_FILE = "cieDaylightBasis.mat"
+
+
+def _load_daylight_basis(wave: np.ndarray) -> np.ndarray:
+    """Return daylight basis functions interpolated to ``wave``."""
+    root = Path(__file__).resolve().parents[2]
+    mat = loadmat(root / "data" / "lights" / _DEF_FILE)
+    src_wave = mat["wavelength"].ravel()
+    data = mat["data"]
+    if np.array_equal(wave, src_wave):
+        return data.astype(float)
+
+    out = np.zeros((wave.size, data.shape[1]), dtype=float)
+    for i in range(data.shape[1]):
+        out[:, i] = np.interp(wave, src_wave, data[:, i], left=0.0, right=0.0)
+    return out
+
+
+Units = Literal["energy", "photons", "quanta"]
+
+
+def cct_to_sun(wave: np.ndarray, cct: np.ndarray | float, units: Units = "energy") -> np.ndarray:
+    """Return daylight SPD for the given correlated color temperature(s).
+
+    Parameters
+    ----------
+    wave : array-like
+        Sampled wavelengths in nanometers.
+    cct : array-like or float
+        Correlated color temperature(s) in Kelvin.
+    units : {"energy", "photons", "quanta"}, optional
+        Desired output units. Defaults to "energy".
+
+    Returns
+    -------
+    np.ndarray
+        Spectral power distribution with shape ``(len(wave), len(cct))`` or
+        ``(len(wave),)`` when ``cct`` is scalar.
+    """
+    wave = np.asarray(wave, dtype=float).reshape(-1)
+    cct = np.asarray(cct, dtype=float).reshape(-1)
+
+    mask = np.zeros_like(cct, dtype=int)
+    mask[(cct >= 4000) & (cct < 7000)] = 1
+    mask[(cct >= 7000) & (cct < 30000)] = 2
+    if np.any(mask == 0):
+        raise ValueError("CCT must be in the range [4000, 30000)")
+
+    xdt1 = -4.6070e9 / cct**3 + 2.9678e6 / cct**2 + 0.09911e3 / cct + 0.244063
+    xdt2 = -2.0064e9 / cct**3 + 1.9018e6 / cct**2 + 0.24748e3 / cct + 0.237040
+    xd = np.where(mask == 1, xdt1, xdt2)
+    yd = -3.000 * xd**2 + 2.870 * xd - 0.275
+
+    M1 = (-1.3515 - 1.7703 * xd + 5.9114 * yd) / (
+        0.0241 + 0.2562 * xd - 0.7341 * yd
+    )
+    M2 = (0.0300 - 31.4424 * xd + 30.0717 * yd) / (
+        0.0241 + 0.2562 * xd - 0.7341 * yd
+    )
+    basis = _load_daylight_basis(wave)
+    spd = basis[:, 1:3] @ np.vstack([M1, M2]) + basis[:, 0][:, np.newaxis]
+
+    if units.lower() in {"photons", "quanta"}:
+        spd = energy_to_quanta(wave, spd)
+
+    if spd.shape[1] == 1:
+        return spd[:, 0]
+    return spd

--- a/python/tests/test_cct_to_sun.py
+++ b/python/tests/test_cct_to_sun.py
@@ -1,0 +1,32 @@
+import numpy as np
+from pathlib import Path
+from scipy.io import loadmat
+
+from isetcam import cct_to_sun, energy_to_quanta
+
+
+def test_cct_to_sun_matches_d65():
+    wave = np.arange(380, 781, 5)
+    spd = cct_to_sun(wave, 6500)
+
+    root = Path(__file__).resolve().parents[2]
+    d65 = loadmat(root / "data" / "lights" / "D65.mat")
+    d_wave = d65["wavelength"].ravel()
+    d_spd = d65["data"].ravel()
+    ref = np.interp(wave, d_wave, d_spd)
+
+    assert spd.shape == wave.shape
+    assert np.allclose(spd, ref, atol=1e-6)
+
+
+def test_cct_to_sun_photons_multi():
+    wave = np.arange(400, 701, 10)
+    ccts = np.array([4000, 6500])
+    spd_energy = cct_to_sun(wave, ccts, units="energy")
+    spd_photons = cct_to_sun(wave, ccts, units="photons")
+
+    assert spd_energy.shape == (len(wave), len(ccts))
+    assert spd_photons.shape == spd_energy.shape
+
+    expected = energy_to_quanta(wave, spd_energy)
+    assert np.allclose(spd_photons, expected)


### PR DESCRIPTION
## Summary
- implement `cct_to_sun` for computing daylight spectra from correlated color temperature
- export `cct_to_sun` from the isetcam package
- provide unit tests checking D65 match and photon conversion
- ignore Python `__pycache__` directories

## Testing
- `pytest -q python/tests/test_cct_to_sun.py`
- `pytest -q`