### PR TITLE
Port ieCirclePoints to Python

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -16,6 +16,7 @@ from .ie_color_transform import ie_color_transform
 from .chromaticity import chromaticity
 from .cct import cct
 from .cct_to_sun import cct_to_sun
+from .circle_points import circle_points
 from .ie_param_format import ie_param_format
 from .ie_session_get import ie_session_get
 from .ie_session_set import ie_session_set
@@ -51,6 +52,7 @@ __all__ = [
     'chromaticity',
     'cct',
     'cct_to_sun',
+    'circle_points',
     'ie_param_format',
     'ie_session_get',
     'ie_session_set',

--- a/python/isetcam/circle_points.py
+++ b/python/isetcam/circle_points.py
@@ -1,0 +1,31 @@
+"""Generate evenly spaced points on a circle."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Tuple
+
+
+def circle_points(rad_spacing: float = 2 * np.pi / 60) -> Tuple[np.ndarray, np.ndarray]:
+    """Return ``(x, y)`` coordinates of points on a unit circle.
+
+    Parameters
+    ----------
+    rad_spacing : float, optional
+        Angular spacing between consecutive points in radians. Defaults to
+        ``2 * np.pi / 60`` which yields 61 samples around the circle.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        Arrays containing the x and y coordinates of the sampled points.
+    """
+    theta = np.arange(0.0, 2 * np.pi + rad_spacing / 2, rad_spacing)
+    if theta[-1] > 2 * np.pi:  # Match MATLAB's 0:spacing:2*pi behavior
+        theta = theta[:-1]
+    if theta[-1] != 2 * np.pi:
+        theta = np.append(theta, 2 * np.pi)
+
+    x = np.cos(theta)
+    y = np.sin(theta)
+    return x, y

--- a/python/tests/test_circle_points.py
+++ b/python/tests/test_circle_points.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from isetcam import circle_points
+
+
+def _expected_points(rad_spacing: float) -> tuple[np.ndarray, np.ndarray]:
+    theta = np.arange(0.0, 2 * np.pi + rad_spacing / 2, rad_spacing)
+    if theta[-1] > 2 * np.pi:
+        theta = theta[:-1]
+    if theta[-1] != 2 * np.pi:
+        theta = np.append(theta, 2 * np.pi)
+    return np.cos(theta), np.sin(theta)
+
+
+def test_circle_points_default():
+    x, y = circle_points()
+    ex, ey = _expected_points(2 * np.pi / 60)
+    assert np.allclose(x, ex)
+    assert np.allclose(y, ey)
+
+
+def test_circle_points_spacing():
+    rad_spacing = 2 * np.pi / 25
+    x, y = circle_points(rad_spacing)
+    ex, ey = _expected_points(rad_spacing)
+    assert np.allclose(x, ex)
+    assert np.allclose(y, ey)


### PR DESCRIPTION
## Summary
- add `circle_points` utility translated from MATLAB
- expose `circle_points` in `isetcam.__init__`
- test circle point sampling

## Testing
- `pytest -q python/tests/test_circle_points.py`
- `pytest -q`