### PR TITLE
Add sensor_get/set API

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import numpy as np
 
 from .sensor_class import Sensor
+from .sensor_get import sensor_get
+from .sensor_set import sensor_set
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -39,4 +41,6 @@ __all__ = [
     "get_exposure_time",
     "set_exposure_time",
     "get_n_wave",
+    "sensor_get",
+    "sensor_set",
 ]

--- a/python/isetcam/sensor/sensor_class.py
+++ b/python/isetcam/sensor/sensor_class.py
@@ -14,3 +14,4 @@ class Sensor:
     volts: np.ndarray
     wave: np.ndarray
     exposure_time: float
+    name: str | None = None

--- a/python/isetcam/sensor/sensor_get.py
+++ b/python/isetcam/sensor/sensor_get.py
@@ -1,0 +1,30 @@
+"""Retrieve parameters from :class:`Sensor` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .sensor_class import Sensor
+from ..ie_param_format import ie_param_format
+
+
+def sensor_get(sensor: Sensor, param: str) -> Any:
+    """Return a parameter value from ``sensor``.
+
+    Supported parameters are ``volts``, ``wave``, ``n_wave``/``nwave``,
+    ``exposure_time``/``exposure time`` and ``name``.
+    """
+    key = ie_param_format(param)
+    if key == "volts":
+        return sensor.volts
+    if key == "wave":
+        return sensor.wave
+    if key in {"nwave", "n_wave"}:
+        return len(sensor.wave)
+    if key in {"exposure_time", "exposuretime"}:
+        return sensor.exposure_time
+    if key == "name":
+        return getattr(sensor, "name", None)
+    raise KeyError(f"Unknown sensor parameter '{param}'")

--- a/python/isetcam/sensor/sensor_set.py
+++ b/python/isetcam/sensor/sensor_set.py
@@ -1,0 +1,32 @@
+"""Assign parameters on :class:`Sensor` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .sensor_class import Sensor
+from ..ie_param_format import ie_param_format
+
+
+def sensor_set(sensor: Sensor, param: str, val: Any) -> None:
+    """Set a parameter value on ``sensor``.
+
+    Supported parameters are ``volts``, ``wave``, ``exposure_time``/``exposure time``
+    and ``name``. ``n_wave`` is derived from ``wave`` and therefore cannot be set.
+    """
+    key = ie_param_format(param)
+    if key == "volts":
+        sensor.volts = np.asarray(val)
+        return
+    if key == "wave":
+        sensor.wave = np.asarray(val)
+        return
+    if key in {"exposure_time", "exposuretime"}:
+        sensor.exposure_time = float(val)
+        return
+    if key == "name":
+        sensor.name = None if val is None else str(val)
+        return
+    raise KeyError(f"Unknown or read-only sensor parameter '{param}'")

--- a/python/tests/test_sensor_get_set.py
+++ b/python/tests/test_sensor_get_set.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from isetcam.sensor import Sensor, sensor_get, sensor_set
+
+
+def test_sensor_get_set():
+    wave = np.array([500, 510, 520])
+    volts = np.ones((2, 2, 3))
+    s = Sensor(volts=volts.copy(), wave=wave, exposure_time=0.01, name="orig")
+
+    assert np.allclose(sensor_get(s, "volts"), volts)
+    assert np.array_equal(sensor_get(s, "wave"), wave)
+    assert sensor_get(s, "n wave") == 3
+    assert sensor_get(s, "exposure time") == 0.01
+    assert sensor_get(s, "name") == "orig"
+
+    new_volts = np.zeros_like(volts)
+    sensor_set(s, "volts", new_volts)
+    assert np.allclose(sensor_get(s, "volts"), new_volts)
+
+    new_wave = np.array([400, 500])
+    sensor_set(s, "wave", new_wave)
+    assert np.array_equal(sensor_get(s, "wave"), new_wave)
+    assert sensor_get(s, "n_wave") == len(new_wave)
+
+    sensor_set(s, "exposure_time", 0.02)
+    assert sensor_get(s, "exposure time") == 0.02
+
+    sensor_set(s, "name", "new")
+    assert sensor_get(s, "name") == "new"


### PR DESCRIPTION
## Summary
- add sensor_get and sensor_set helpers
- export helpers from sensor package
- support optional sensor name field
- test sensor_get/set functionality

## Testing
- `PYTHONPATH=python pytest -q`