### PR TITLE
Implement scene_crop utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -7,6 +7,7 @@ from .scene_from_file import scene_from_file
 from .scene_get import scene_get
 from .scene_set import scene_set
 from .scene_adjust_luminance import scene_adjust_luminance
+from .scene_crop import scene_crop
 
 __all__ = [
     "Scene",
@@ -18,4 +19,5 @@ __all__ = [
     "scene_get",
     "scene_set",
     "scene_adjust_luminance",
+    "scene_crop",
 ]

--- a/python/isetcam/scene/scene_crop.py
+++ b/python/isetcam/scene/scene_crop.py
@@ -1,0 +1,50 @@
+"""Crop a region from a :class:`Scene`."""
+
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import numpy as np
+
+from .scene_class import Scene
+from .scene_utils import get_photons
+
+
+def scene_crop(scene: Scene, rect: Sequence[int]) -> Scene:
+    """Return a new scene cropped to ``rect``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene to crop.
+    rect : sequence of int
+        ``(x, y, width, height)`` rectangle describing the crop in pixels.
+        ``x`` and ``y`` are the upper-left corner using 0-based indexing.
+
+    Returns
+    -------
+    Scene
+        Scene containing the cropped photon data with the original
+        wavelength samples. The returned object includes ``crop_rect`` and
+        ``full_size`` attributes describing the crop metadata.
+    """
+
+    if len(rect) != 4:
+        raise ValueError("rect must have four elements (x, y, width, height)")
+
+    x, y, w, h = [int(v) for v in rect]
+    if w <= 0 or h <= 0:
+        raise ValueError("width and height must be positive")
+
+    photons = get_photons(scene)
+    height, width = photons.shape[:2]
+
+    if x < 0 or y < 0 or x + w > width or y + h > height:
+        raise ValueError("rect is outside the scene bounds")
+
+    cropped = photons[y : y + h, x : x + w, :].copy()
+    out = Scene(photons=cropped, wave=scene.wave, name=scene.name)
+    # Attach metadata about the crop
+    out.crop_rect = (x, y, w, h)
+    out.full_size = (height, width)
+    return out

--- a/python/tests/test_scene_crop.py
+++ b/python/tests/test_scene_crop.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from isetcam.scene import Scene, scene_crop
+
+
+def _simple_scene(width: int = 4, height: int = 4, n_wave: int = 2) -> Scene:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    return Scene(photons=photons, wave=wave)
+
+
+def test_scene_crop_basic():
+    sc = _simple_scene(4, 4, 2)
+    out = scene_crop(sc, (1, 1, 2, 2))
+    expected = sc.photons[1:3, 1:3, :]
+    assert np.array_equal(out.photons, expected)
+    assert np.array_equal(out.wave, sc.wave)
+    assert out.crop_rect == (1, 1, 2, 2)
+    assert out.full_size == (4, 4)
+
+
+def test_scene_crop_out_of_bounds():
+    sc = _simple_scene(4, 4, 1)
+    with pytest.raises(ValueError):
+        scene_crop(sc, (3, 3, 2, 2))


### PR DESCRIPTION
## Summary
- implement `scene_crop` for cropping scene photon data and storing crop metadata
- expose `scene_crop` through scene package
- test cropping behaviour

## Testing
- `export PYTHONPATH=$PWD/python`
- `pytest -q`