### PR TITLE
Add display_create function in Python

### DIFF
--- a/python/isetcam/display/__init__.py
+++ b/python/isetcam/display/__init__.py
@@ -1,11 +1,13 @@
 """Display-related functions."""
 
 from .display_class import Display
+from .display_create import display_create
 from .display_get import display_get
 from .display_set import display_set
 
 __all__ = [
     "Display",
+    "display_create",
     "display_get",
     "display_set",
 ]

--- a/python/isetcam/display/display_class.py
+++ b/python/isetcam/display/display_class.py
@@ -13,4 +13,5 @@ class Display:
 
     spd: np.ndarray
     wave: np.ndarray
+    gamma: np.ndarray | None = None
     name: str | None = None

--- a/python/isetcam/display/display_create.py
+++ b/python/isetcam/display/display_create.py
@@ -1,0 +1,44 @@
+"""Factory function for :class:`Display` objects."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from scipy.io import loadmat
+
+from .display_class import Display
+
+_DEFAULT_NAME = "LCD-Apple"
+_DEF_DIR = "data"
+
+
+def _load_display(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``wave``, ``spd`` and ``gamma`` arrays from ``path``."""
+    data = loadmat(path)
+    if "d" not in data:
+        raise KeyError("No display struct 'd' found in file")
+    d = data["d"][0, 0]
+    wave = d["wave"].ravel().astype(float)
+    spd = d["spd"].astype(float)
+    gamma = d["gamma"].astype(float)
+    return wave, spd, gamma
+
+
+def display_create(name: str | None = None) -> Display:
+    """Create a :class:`Display` by name.
+
+    Parameters
+    ----------
+    name:
+        Name of the display calibration file (without extension). When
+        ``None``, the default display is returned.
+    """
+    if name is None:
+        name = _DEFAULT_NAME
+    root = Path(__file__).resolve().parents[3]
+    path = root / _DEF_DIR / "displays" / f"{name}.mat"
+    if not path.exists():
+        raise FileNotFoundError(f"Unknown display '{name}'")
+    wave, spd, gamma = _load_display(path)
+    return Display(spd=spd, wave=wave, gamma=gamma, name=name)

--- a/python/tests/test_display_create.py
+++ b/python/tests/test_display_create.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from isetcam.display import display_create
+
+
+def test_display_create_default():
+    disp = display_create()
+    assert disp.name == "LCD-Apple"
+    assert disp.spd.shape[0] == disp.wave.shape[0]
+    assert disp.gamma is not None
+    assert disp.gamma.shape[1] == disp.spd.shape[1]
+
+
+def test_display_create_specific():
+    disp = display_create("lcdExample")
+    assert disp.name == "lcdExample"
+    assert disp.spd.shape[0] == disp.wave.shape[0]
+    assert disp.gamma is not None


### PR DESCRIPTION
## Summary
- implement `display_create` to load display calibration files
- support gamma in `Display` dataclass
- export new function and test it

## Testing
- `pytest -q`