### PR TITLE
Add xyz/xyy color conversion utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -26,6 +26,8 @@ from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 from .xyz_to_lab import xyz_to_lab
 from .lab_to_xyz import lab_to_xyz
+from .xyz_to_xyy import xyz_to_xyy
+from .xyy_to_xyz import xyy_to_xyz
 from .y_to_lstar import y_to_lstar
 from .xyz_to_uv import xyz_to_uv
 from .xyz_to_luv import xyz_to_luv
@@ -65,6 +67,8 @@ __all__ = [
     'xw_to_rgb_format',
     'xyz_to_lab',
     'lab_to_xyz',
+    'xyz_to_xyy',
+    'xyy_to_xyz',
     'y_to_lstar',
     'xyz_to_uv',
     'xyz_to_luv',

--- a/python/isetcam/xyy_to_xyz.py
+++ b/python/isetcam/xyy_to_xyz.py
@@ -1,0 +1,48 @@
+"""Convert CIE xyY values to XYZ tristimulus values."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+
+def xyy_to_xyz(xyy: np.ndarray) -> np.ndarray:
+    """Convert xyY coordinates to XYZ tristimulus values.
+
+    Parameters
+    ----------
+    xyy : np.ndarray
+        xyY values in either XW format ``(n, 3)`` or RGB format
+        ``(rows, cols, 3)``.
+
+    Returns
+    -------
+    np.ndarray
+        XYZ values in the same spatial format as ``xyy``.
+    """
+    xyy = np.asarray(xyy, dtype=float)
+
+    if xyy.ndim == 3:
+        xw, r, c = rgb_to_xw_format(xyy)
+        reshape = True
+    elif xyy.ndim == 2 and xyy.shape[1] == 3:
+        xw = xyy
+        reshape = False
+    else:
+        raise ValueError("xyy must be (n,3) or (rows,cols,3)")
+
+    xyz = np.zeros_like(xw)
+    xyz[:, 1] = xw[:, 2]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        sXYZ = np.zeros_like(xw[:, 0])
+        mask = xw[:, 1] != 0
+        sXYZ[mask] = xw[mask, 2] / xw[mask, 1]
+        xyz[mask, 0] = (xw[mask, 0] / xw[mask, 1]) * xw[mask, 2]
+        xyz[mask, 2] = sXYZ[mask] - xw[mask, 2] - xyz[mask, 0]
+
+    if reshape:
+        xyz = xw_to_rgb_format(xyz, r, c)
+
+    return xyz

--- a/python/isetcam/xyz_to_xyy.py
+++ b/python/isetcam/xyz_to_xyy.py
@@ -1,0 +1,46 @@
+"""Convert XYZ tristimulus values to CIE xyY."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+
+def xyz_to_xyy(xyz: np.ndarray) -> np.ndarray:
+    """Convert XYZ tristimulus values to xyY coordinates.
+
+    Parameters
+    ----------
+    xyz : np.ndarray
+        XYZ values in either XW format ``(n, 3)`` or RGB format
+        ``(rows, cols, 3)``.
+
+    Returns
+    -------
+    np.ndarray
+        xyY values in the same spatial format as ``xyz``.
+    """
+    xyz = np.asarray(xyz, dtype=float)
+
+    if xyz.ndim == 3:
+        xw, r, c = rgb_to_xw_format(xyz)
+        reshape = True
+    elif xyz.ndim == 2 and xyz.shape[1] == 3:
+        xw = xyz
+        reshape = False
+    else:
+        raise ValueError("xyz must be (n,3) or (rows,cols,3)")
+
+    s = xw.sum(axis=1)
+    xyy = np.zeros_like(xw)
+    nz = s != 0
+    xyy[nz, 0] = xw[nz, 0] / s[nz]
+    xyy[nz, 1] = xw[nz, 1] / s[nz]
+    xyy[:, 2] = xw[:, 1]
+
+    if reshape:
+        xyy = xw_to_rgb_format(xyy, r, c)
+
+    return xyy

--- a/python/tests/test_xyz_xyy.py
+++ b/python/tests/test_xyz_xyy.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+from isetcam import xyz_to_xyy, xyy_to_xyz
+
+
+def _expected_xyz_to_xyy(xyz: np.ndarray) -> np.ndarray:
+    xyz = np.asarray(xyz, float)
+    s = xyz.sum(axis=-1)
+    x = np.zeros_like(s)
+    y = np.zeros_like(s)
+    mask = s != 0
+    x[mask] = xyz[..., 0][mask] / s[mask]
+    y[mask] = xyz[..., 1][mask] / s[mask]
+    Y = xyz[..., 1]
+    return np.stack([x, y, Y], axis=-1)
+
+
+def _expected_xyy_to_xyz(xyy: np.ndarray) -> np.ndarray:
+    xyy = np.asarray(xyy, float)
+    X = np.zeros_like(xyy[..., 0])
+    Y = xyy[..., 2]
+    Z = np.zeros_like(X)
+    mask = xyy[..., 1] != 0
+    X[mask] = (xyy[..., 0][mask] / xyy[..., 1][mask]) * Y[mask]
+    sXYZ = np.zeros_like(X)
+    sXYZ[mask] = Y[mask] / xyy[..., 1][mask]
+    Z[mask] = sXYZ[mask] - Y[mask] - X[mask]
+    return np.stack([X, Y, Z], axis=-1)
+
+
+def test_xyz_xyy_round_trip_xw():
+    xyz = np.random.rand(10, 3)
+    xyY = xyz_to_xyy(xyz)
+    xyz2 = xyy_to_xyz(xyY)
+    assert np.allclose(xyz2, xyz, atol=1e-6)
+
+
+def test_xyz_xyy_round_trip_rgb():
+    xyz = np.random.rand(4, 5, 3)
+    xyY = xyz_to_xyy(xyz)
+    xyz2 = xyy_to_xyz(xyY)
+    assert np.allclose(xyz2, xyz, atol=1e-6)
+
+
+def test_xyz_xyy_formulas():
+    xyz = np.random.rand(6, 3)
+    xyY = xyz_to_xyy(xyz)
+    expected_xyY = _expected_xyz_to_xyy(xyz)
+    assert np.allclose(xyY, expected_xyY)
+
+    xyz2 = xyy_to_xyz(xyY)
+    expected_xyz = _expected_xyy_to_xyz(xyY)
+    assert np.allclose(xyz2, expected_xyz)


### PR DESCRIPTION
## Summary
- implement `xyz_to_xyy` and `xyy_to_xyz` conversions
- export the utilities in package `__init__`
- add tests for round-trip xyz/xyy conversion

## Testing
- `PYTHONPATH=$PWD/python pytest -q`