### PR TITLE
Add default spectrum helper

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -41,6 +41,7 @@ from .srgb_xyz import (
     srgb_to_xyz,
     xyz_to_srgb,
 )
+from .init_default_spectrum import init_default_spectrum
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
@@ -84,6 +85,7 @@ __all__ = [
     'linear_to_srgb',
     'srgb_to_xyz',
     'xyz_to_srgb',
+    'init_default_spectrum',
     'ie_init',
     'ie_init_session',
     'scene',

--- a/python/isetcam/init_default_spectrum.py
+++ b/python/isetcam/init_default_spectrum.py
@@ -1,0 +1,56 @@
+"""Utility for initializing wavelength sampling on dataclass objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def init_default_spectrum(
+    obj: Any,
+    spectral_type: str = "multispectral",
+    wave: np.ndarray | None = None,
+) -> Any:
+    """Set default wavelength samples for ``obj`` and return it.
+
+    Parameters
+    ----------
+    obj : dataclass instance
+        Object with a ``wave`` attribute that will be updated.
+    spectral_type : {'multispectral', 'monochrome', 'custom'}, optional
+        Defines the type of spectrum to assign. ``'multispectral'``
+        uses a 400--700 nm range in 10 nm steps. ``'monochrome'``
+        assigns a single wavelength (550 nm by default). ``'custom'``
+        uses the provided ``wave`` values.
+    wave : array-like, optional
+        Custom wavelength samples used when ``spectral_type`` is
+        ``'custom'`` or to override the defaults.
+
+    Returns
+    -------
+    obj
+        The updated dataclass instance.
+    """
+    if not hasattr(obj, "wave"):
+        raise AttributeError("Object must have a 'wave' attribute")
+
+    stype = spectral_type.lower()
+    if stype == "multispectral":
+        w = np.arange(400, 701, 10, dtype=float) if wave is None else np.asarray(wave, dtype=float)
+    elif stype == "monochrome":
+        if wave is None:
+            w = np.array([550.0], dtype=float)
+        else:
+            w = np.asarray(wave, dtype=float).reshape(-1)
+            if w.size != 1:
+                raise ValueError("Monochrome spectrum must contain a single wavelength")
+    elif stype == "custom":
+        if wave is None:
+            raise ValueError("wave must be provided for custom spectral type")
+        w = np.asarray(wave, dtype=float)
+    else:
+        raise ValueError(f"Unknown spectral_type '{spectral_type}'")
+
+    obj.wave = w
+    return obj

--- a/python/isetcam/opticalimage/oi_class.py
+++ b/python/isetcam/opticalimage/oi_class.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..init_default_spectrum import init_default_spectrum
+
 import numpy as np
 
 
@@ -12,5 +14,9 @@ class OpticalImage:
     """Minimal representation of an ISETCam optical image."""
 
     photons: np.ndarray
-    wave: np.ndarray
+    wave: np.ndarray | None = None
     name: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.wave is None:
+            init_default_spectrum(self)

--- a/python/isetcam/scene/scene_class.py
+++ b/python/isetcam/scene/scene_class.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..init_default_spectrum import init_default_spectrum
+
 import numpy as np
 
 
@@ -12,5 +14,9 @@ class Scene:
     """Minimal representation of an ISETCam scene."""
 
     photons: np.ndarray
-    wave: np.ndarray
+    wave: np.ndarray | None = None
     name: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.wave is None:
+            init_default_spectrum(self)

--- a/python/isetcam/sensor/sensor_class.py
+++ b/python/isetcam/sensor/sensor_class.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..init_default_spectrum import init_default_spectrum
+
 import numpy as np
 
 
@@ -12,6 +14,10 @@ class Sensor:
     """Minimal representation of an ISETCam sensor."""
 
     volts: np.ndarray
-    wave: np.ndarray
     exposure_time: float
+    wave: np.ndarray | None = None
     name: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.wave is None:
+            init_default_spectrum(self)

--- a/python/tests/test_init_default_spectrum.py
+++ b/python/tests/test_init_default_spectrum.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from isetcam import init_default_spectrum
+from isetcam.scene import Scene
+from isetcam.sensor import Sensor
+from isetcam.opticalimage import OpticalImage
+
+
+def test_default_multispectral():
+    obj = Scene(photons=np.zeros((1, 1, 31)), wave=None)
+    init_default_spectrum(obj)
+    assert np.array_equal(obj.wave, np.arange(400, 701, 10))
+
+
+def test_default_monochrome():
+    obj = Sensor(volts=np.zeros((1, 1, 1)), wave=None, exposure_time=0.0)
+    init_default_spectrum(obj, spectral_type="monochrome")
+    assert np.array_equal(obj.wave, np.array([550.0]))
+
+
+def test_custom_wave():
+    custom = np.array([450, 550, 650])
+    obj = OpticalImage(photons=np.zeros((1, 1, 3)), wave=None)
+    init_default_spectrum(obj, spectral_type="custom", wave=custom)
+    assert np.array_equal(obj.wave, custom)


### PR DESCRIPTION
## Summary
- add `init_default_spectrum` helper to create wavelength samples
- use helper in Scene, Sensor and OpticalImage dataclasses
- export new helper from package
- test spectrum helper

## Testing
- `PYTHONPATH=python pytest -q`
