### PR TITLE
Add MAT-file loaders for sensor and optical image

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -5,6 +5,7 @@ from .oi_utils import get_photons, set_photons, get_n_wave
 from .oi_add import oi_add
 from .oi_get import oi_get
 from .oi_set import oi_set
+from .oi_from_file import oi_from_file
 
 __all__ = [
     "OpticalImage",
@@ -14,4 +15,5 @@ __all__ = [
     "oi_add",
     "oi_get",
     "oi_set",
+    "oi_from_file",
 ]

--- a/python/isetcam/opticalimage/oi_from_file.py
+++ b/python/isetcam/opticalimage/oi_from_file.py
@@ -1,0 +1,52 @@
+"""Load an :class:`OpticalImage` from a MATLAB ``.mat`` file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from scipy.io import loadmat
+
+from .oi_class import OpticalImage
+
+
+def _get_attr(obj: object, name: str):
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def oi_from_file(path: str | Path, *, candidate_vars: Iterable[str] | None = None) -> OpticalImage:
+    """Load ``path`` and return an :class:`OpticalImage`.
+
+    Parameters
+    ----------
+    path:
+        MAT-file containing an optical image structure.
+    candidate_vars:
+        Optional sequence of variable names to search for. Defaults to
+        ``('oi', 'opticalimage')``.
+    """
+    if candidate_vars is None:
+        candidate_vars = ("oi", "opticalimage")
+
+    mat = loadmat(str(Path(path)), squeeze_me=True, struct_as_record=False)
+
+    oi_struct = None
+    for key in candidate_vars:
+        if key in mat:
+            oi_struct = mat[key]
+            break
+    if oi_struct is None:
+        raise KeyError("No optical image structure found in file")
+
+    photons = np.asarray(_get_attr(oi_struct, "photons"))
+    wave = _get_attr(oi_struct, "wave")
+    if wave is not None:
+        wave = np.asarray(wave).reshape(-1)
+    name = _get_attr(oi_struct, "name")
+    if isinstance(name, np.ndarray):
+        name = str(name.squeeze())
+
+    return OpticalImage(photons=photons, wave=wave, name=name)

--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -7,6 +7,7 @@ import numpy as np
 from .sensor_class import Sensor
 from .sensor_get import sensor_get
 from .sensor_set import sensor_set
+from .sensor_from_file import sensor_from_file
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -43,4 +44,5 @@ __all__ = [
     "get_n_wave",
     "sensor_get",
     "sensor_set",
+    "sensor_from_file",
 ]

--- a/python/isetcam/sensor/sensor_from_file.py
+++ b/python/isetcam/sensor/sensor_from_file.py
@@ -1,0 +1,53 @@
+"""Load a :class:`Sensor` from a MATLAB ``.mat`` file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from scipy.io import loadmat
+
+from .sensor_class import Sensor
+
+
+def _get_attr(obj: object, name: str):
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def sensor_from_file(path: str | Path, *, candidate_vars: Iterable[str] | None = None) -> Sensor:
+    """Load ``path`` and return a :class:`Sensor`.
+
+    Parameters
+    ----------
+    path:
+        MAT-file containing a sensor structure.
+    candidate_vars:
+        Optional sequence of variable names to search for. Defaults to
+        ``('sensor', 'isa', 'isa_')``.
+    """
+    if candidate_vars is None:
+        candidate_vars = ("sensor", "isa", "isa_")
+
+    mat = loadmat(str(Path(path)), squeeze_me=True, struct_as_record=False)
+
+    sensor_struct = None
+    for key in candidate_vars:
+        if key in mat:
+            sensor_struct = mat[key]
+            break
+    if sensor_struct is None:
+        raise KeyError("No sensor structure found in file")
+
+    volts = np.asarray(_get_attr(sensor_struct, "volts"))
+    exposure_time = float(_get_attr(sensor_struct, "exposure_time"))
+    wave = _get_attr(sensor_struct, "wave")
+    if wave is not None:
+        wave = np.asarray(wave).reshape(-1)
+    name = _get_attr(sensor_struct, "name")
+    if isinstance(name, np.ndarray):
+        name = str(name.squeeze())
+
+    return Sensor(volts=volts, exposure_time=exposure_time, wave=wave, name=name)

--- a/python/tests/test_oi_from_file.py
+++ b/python/tests/test_oi_from_file.py
@@ -1,0 +1,27 @@
+import numpy as np
+import scipy.io
+from dataclasses import asdict
+
+from isetcam.opticalimage import OpticalImage, oi_from_file
+
+
+def test_oi_from_file_roundtrip(tmp_path):
+    oi = OpticalImage(photons=np.ones((2, 2, 3)), wave=np.array([450, 550, 650]), name="foo")
+    path = tmp_path / "oi.mat"
+    scipy.io.savemat(path, {"oi": asdict(oi)})
+
+    loaded = oi_from_file(path)
+    assert isinstance(loaded, OpticalImage)
+    assert np.allclose(loaded.photons, oi.photons)
+    assert np.array_equal(loaded.wave, oi.wave)
+    assert loaded.name == oi.name
+
+
+def test_oi_from_file_altvar(tmp_path):
+    oi = OpticalImage(photons=np.zeros((1, 1, 1)), wave=np.array([500]), name="bar")
+    path = tmp_path / "oi.mat"
+    scipy.io.savemat(path, {"opticalimage": asdict(oi)})
+    loaded = oi_from_file(path)
+    assert np.allclose(loaded.photons, oi.photons)
+    assert loaded.name == oi.name
+

--- a/python/tests/test_sensor_from_file.py
+++ b/python/tests/test_sensor_from_file.py
@@ -1,0 +1,28 @@
+import numpy as np
+import scipy.io
+from dataclasses import asdict
+
+from isetcam.sensor import Sensor, sensor_from_file
+
+
+def test_sensor_from_file_roundtrip(tmp_path):
+    s = Sensor(volts=np.array([[1.0, 2.0]]), exposure_time=0.05, wave=np.array([500, 600]), name="demo")
+    path = tmp_path / "s.mat"
+    scipy.io.savemat(path, {"sensor": asdict(s)})
+
+    loaded = sensor_from_file(path)
+    assert isinstance(loaded, Sensor)
+    assert np.allclose(loaded.volts, s.volts)
+    assert loaded.exposure_time == s.exposure_time
+    assert np.array_equal(loaded.wave, s.wave)
+    assert loaded.name == s.name
+
+
+def test_sensor_from_file_isa(tmp_path):
+    s = Sensor(volts=np.ones((2, 2)), exposure_time=0.1, wave=np.array([450, 550]), name="foo")
+    path = tmp_path / "s.mat"
+    scipy.io.savemat(path, {"isa": asdict(s)})
+    loaded = sensor_from_file(path)
+    assert np.allclose(loaded.volts, s.volts)
+    assert loaded.name == s.name
+


### PR DESCRIPTION
## Summary
- load `Sensor` from MAT files
- load `OpticalImage` from MAT files
- export the new functions
- test MAT-file loading for sensor and optical image

## Testing
- `PYTHONPATH=python pytest -q`