### PR TITLE
Implement optical image cropping and padding

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -6,6 +6,8 @@ from .oi_add import oi_add
 from .oi_get import oi_get
 from .oi_set import oi_set
 from .oi_from_file import oi_from_file
+from .oi_crop import oi_crop
+from .oi_pad import oi_pad
 
 __all__ = [
     "OpticalImage",
@@ -16,4 +18,6 @@ __all__ = [
     "oi_get",
     "oi_set",
     "oi_from_file",
+    "oi_crop",
+    "oi_pad",
 ]

--- a/python/isetcam/opticalimage/oi_crop.py
+++ b/python/isetcam/opticalimage/oi_crop.py
@@ -1,0 +1,50 @@
+"""Crop a region from an :class:`OpticalImage`."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .oi_class import OpticalImage
+from .oi_utils import get_photons
+
+
+def oi_crop(oi: OpticalImage, rect: Sequence[int]) -> OpticalImage:
+    """Return a new optical image cropped to ``rect``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image to crop.
+    rect : sequence of int
+        ``(x, y, width, height)`` rectangle describing the crop in pixels.
+        ``x`` and ``y`` are the upper-left corner using 0-based indexing.
+
+    Returns
+    -------
+    OpticalImage
+        Optical image containing the cropped photon data with the original
+        wavelength samples. The returned object includes ``crop_rect`` and
+        ``full_size`` attributes describing the crop metadata.
+    """
+
+    if len(rect) != 4:
+        raise ValueError("rect must have four elements (x, y, width, height)")
+
+    x, y, w, h = [int(v) for v in rect]
+    if w <= 0 or h <= 0:
+        raise ValueError("width and height must be positive")
+
+    photons = get_photons(oi)
+    height, width = photons.shape[:2]
+
+    if x < 0 or y < 0 or x + w > width or y + h > height:
+        raise ValueError("rect is outside the optical image bounds")
+
+    cropped = photons[y : y + h, x : x + w, :].copy()
+    out = OpticalImage(photons=cropped, wave=oi.wave, name=oi.name)
+    # Attach metadata about the crop
+    out.crop_rect = (x, y, w, h)
+    out.full_size = (height, width)
+    return out

--- a/python/isetcam/opticalimage/oi_pad.py
+++ b/python/isetcam/opticalimage/oi_pad.py
@@ -1,0 +1,48 @@
+"""Pad an :class:`OpticalImage`'s photon data."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+def oi_pad(oi: OpticalImage, pad_size: int | Sequence[int], value: float = 0) -> OpticalImage:
+    """Pad ``oi`` by ``pad_size`` pixels on all sides.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image to pad.
+    pad_size : int or sequence of int
+        Amount of padding. If an integer, the same value is used on all
+        sides. If a sequence of two integers, the first specifies padding
+        for the top and bottom, and the second for the left and right.
+        A sequence of four integers specifies ``(top, bottom, left, right)``.
+    value : float, optional
+        Value used to fill the padded region. Defaults to 0.
+
+    Returns
+    -------
+    OpticalImage
+        New optical image containing the padded photon data with the same
+        wavelength samples.
+    """
+
+    if isinstance(pad_size, Sequence) and not isinstance(pad_size, (int, float)):
+        pad = list(pad_size)
+        if len(pad) == 2:
+            top = bottom = int(pad[0])
+            left = right = int(pad[1])
+        elif len(pad) == 4:
+            top, bottom, left, right = [int(v) for v in pad]
+        else:
+            raise ValueError("pad_size must be a scalar or have length 2 or 4")
+    else:
+        top = bottom = left = right = int(pad_size)
+
+    pad_width = ((top, bottom), (left, right), (0, 0))
+    padded = np.pad(oi.photons, pad_width, mode="constant", constant_values=value)
+    return OpticalImage(photons=padded, wave=oi.wave, name=oi.name)

--- a/python/tests/test_oi_crop_pad.py
+++ b/python/tests/test_oi_crop_pad.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+
+from isetcam.opticalimage import OpticalImage, oi_crop, oi_pad
+
+
+def _simple_oi(width: int = 4, height: int = 4, n_wave: int = 2) -> OpticalImage:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    return OpticalImage(photons=photons, wave=wave)
+
+
+def test_oi_crop_basic():
+    oi = _simple_oi(4, 4, 2)
+    out = oi_crop(oi, (1, 1, 2, 2))
+    expected = oi.photons[1:3, 1:3, :]
+    assert np.array_equal(out.photons, expected)
+    assert np.array_equal(out.wave, oi.wave)
+    assert out.crop_rect == (1, 1, 2, 2)
+    assert out.full_size == (4, 4)
+
+
+def test_oi_crop_out_of_bounds():
+    oi = _simple_oi(4, 4, 1)
+    with pytest.raises(ValueError):
+        oi_crop(oi, (3, 3, 2, 2))
+
+
+def test_oi_pad_scalar():
+    oi = _simple_oi(2, 2, 1)
+    out = oi_pad(oi, 1, value=-1)
+    expected = np.pad(oi.photons, ((1, 1), (1, 1), (0, 0)), constant_values=-1)
+    assert np.array_equal(out.photons, expected)
+    assert np.array_equal(out.wave, oi.wave)
+
+
+def test_oi_pad_tuple():
+    oi = _simple_oi(2, 2, 1)
+    out = oi_pad(oi, (1, 2, 3, 4), value=5)
+    expected = np.pad(
+        oi.photons,
+        ((1, 2), (3, 4), (0, 0)),
+        constant_values=5,
+    )
+    assert np.array_equal(out.photons, expected)
+    assert np.array_equal(out.wave, oi.wave)
+


### PR DESCRIPTION
## Summary
- add `oi_crop` and `oi_pad` utilities for optical images
- export them in `isetcam.opticalimage`
- test cropping and padding logic

## Testing
- `pytest -q`