### PR TITLE
Add image distortion utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -42,10 +42,11 @@ from .srgb_xyz import (
     xyz_to_srgb,
 )
 from .init_default_spectrum import init_default_spectrum
+from .imgproc import image_distort
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, display, illuminant, camera
+from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc
 
 __all__ = [
     'vc_constants',
@@ -86,6 +87,7 @@ __all__ = [
     'srgb_to_xyz',
     'xyz_to_srgb',
     'init_default_spectrum',
+    'image_distort',
     'ie_init',
     'ie_init_session',
     'camera',
@@ -94,4 +96,5 @@ __all__ = [
     'sensor',
     'display',
     'illuminant',
+    'imgproc',
 ]

--- a/python/isetcam/imgproc/__init__.py
+++ b/python/isetcam/imgproc/__init__.py
@@ -1,0 +1,5 @@
+"""Image processing utilities."""
+
+from .image_distort import image_distort
+
+__all__ = ["image_distort"]

--- a/python/isetcam/imgproc/image_distort.py
+++ b/python/isetcam/imgproc/image_distort.py
@@ -1,0 +1,71 @@
+"""Apply simple distortions to an image."""
+
+from __future__ import annotations
+
+import numpy as np
+from io import BytesIO
+from typing import Any
+
+from PIL import Image
+
+from ..ie_param_format import ie_param_format
+
+
+def image_distort(img: np.ndarray, d_method: str, *args: Any) -> np.ndarray:
+    """Distort image data using the specified method.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Image data array. Can be ``uint8`` or floating point.
+    d_method : str
+        Distortion method. Supported values are ``'gaussian noise'``,
+        ``'jpeg compress'`` and ``'scale contrast'``.
+    *args : Any
+        Optional parameters for the distortion method.
+
+    Returns
+    -------
+    np.ndarray
+        Distorted image in the same dtype as ``img``.
+    """
+
+    if img.size == 0:
+        return img
+
+    method = ie_param_format(d_method)
+
+    if method == "gaussiannoise":
+        if len(args) > 0:
+            n_scale = float(args[0])
+        else:
+            n_scale = 0.05 * float(img.max())
+        noise = n_scale * np.random.randn(*img.shape)
+
+        if np.issubdtype(img.dtype, np.integer) and img.max() < 256:
+            img_f = img.astype(float) + noise
+            img_f = np.clip(img_f, 0, 255)
+            return img_f.astype(np.uint8)
+        else:
+            return img.astype(float) + noise
+
+    if method == "jpegcompress":
+        if len(args) > 0:
+            quality = int(args[0])
+        else:
+            quality = 75
+        pil_img = Image.fromarray(img)
+        with BytesIO() as buf:
+            pil_img.save(buf, format="JPEG", quality=quality)
+            buf.seek(0)
+            out = np.array(Image.open(buf))
+        return out.astype(img.dtype)
+
+    if method == "scalecontrast":
+        if len(args) > 0:
+            scale = float(args[0])
+        else:
+            scale = 0.1
+        return img * (1 + scale)
+
+    raise ValueError(f"Unknown method: {d_method}")

--- a/python/tests/test_image_distort.py
+++ b/python/tests/test_image_distort.py
@@ -1,0 +1,24 @@
+import numpy as np
+from isetcam import image_distort
+
+
+def test_gaussian_noise():
+    np.random.seed(0)
+    img = np.ones((10, 10), dtype=np.uint8) * 100
+    out = image_distort(img, 'gaussian noise', 5)
+    assert out.shape == img.shape
+    assert out.dtype == np.uint8
+    assert not np.array_equal(out, img)
+
+
+def test_jpeg_compress(tmp_path):
+    img = np.random.randint(0, 255, (20, 20, 3), dtype=np.uint8)
+    out = image_distort(img, 'jpeg compress', 50)
+    assert out.shape == img.shape
+    assert out.dtype == img.dtype
+
+
+def test_scale_contrast():
+    img = np.ones((5, 5), dtype=float)
+    out = image_distort(img, 'scale contrast', 0.2)
+    assert np.allclose(out, img * 1.2)


### PR DESCRIPTION
## Summary
- add new `imgproc` package with `image_distort` function
- expose `image_distort` in the top-level API
- test gaussian noise, jpeg compression and contrast scaling

## Testing
- `PYTHONPATH=python pytest -q`