### PR TITLE
Add PSNR metric to Python package

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -43,10 +43,11 @@ from .srgb_xyz import (
 )
 from .init_default_spectrum import init_default_spectrum
 from .imgproc import image_distort
+from .metrics.ie_psnr import ie_psnr
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc
+from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc, metrics
 
 __all__ = [
     'vc_constants',
@@ -88,6 +89,7 @@ __all__ = [
     'xyz_to_srgb',
     'init_default_spectrum',
     'image_distort',
+    'ie_psnr',
     'ie_init',
     'ie_init_session',
     'camera',
@@ -97,4 +99,5 @@ __all__ = [
     'display',
     'illuminant',
     'imgproc',
+    'metrics',
 ]

--- a/python/isetcam/metrics/__init__.py
+++ b/python/isetcam/metrics/__init__.py
@@ -1,0 +1,5 @@
+"""Image quality metrics."""
+
+from .ie_psnr import ie_psnr
+
+__all__ = ["ie_psnr"]

--- a/python/isetcam/metrics/ie_psnr.py
+++ b/python/isetcam/metrics/ie_psnr.py
@@ -1,0 +1,33 @@
+"""Peak signal-to-noise ratio between two images."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def ie_psnr(im1: np.ndarray, im2: np.ndarray) -> float:
+    """Compute PSNR value consistent with MATLAB ``iePSNR``.
+
+    Parameters
+    ----------
+    im1, im2 : np.ndarray
+        Images to compare. They must have the same shape.
+
+    Returns
+    -------
+    float
+        PSNR value in decibels. ``np.inf`` is returned when the images are
+        identical.
+    """
+    im1 = np.asarray(im1, dtype=float)
+    im2 = np.asarray(im2, dtype=float)
+    if im1.shape != im2.shape:
+        raise ValueError("Input images must have the same shape")
+
+    se = (255 * (im1 - im2)) ** 2
+    rmse = np.sqrt(np.mean(se))
+
+    if rmse == 0:
+        return np.inf
+
+    return 20 * np.log10(255 / np.sqrt(rmse))

--- a/python/tests/test_ie_psnr.py
+++ b/python/tests/test_ie_psnr.py
@@ -1,0 +1,16 @@
+import numpy as np
+from isetcam import ie_psnr
+
+
+def test_ie_psnr_basic():
+    img1 = np.zeros((4, 4), dtype=float)
+    img2 = np.zeros((4, 4), dtype=float)
+    assert np.isinf(ie_psnr(img1, img2))
+
+
+def test_ie_psnr_known_value():
+    img1 = np.zeros((1, 1), dtype=float)
+    img2 = np.array([[1 / 255]], dtype=float)
+    val = ie_psnr(img1, img2)
+    expected = 20 * np.log10(255)
+    assert np.isclose(val, expected)


### PR DESCRIPTION
## Summary
- implement `ie_psnr` in new `metrics` package
- export PSNR metric from `isetcam` top-level
- test the implementation

## Testing
- `pytest -q`