### PR TITLE
Add gamma handling for display objects

### DIFF
--- a/python/isetcam/display/display_get.py
+++ b/python/isetcam/display/display_get.py
@@ -12,14 +12,16 @@ from .display_class import Display
 def display_get(display: Display, param: str) -> Any:
     """Return a parameter value from ``display``.
 
-    Supported parameters are ``spd``, ``wave``, ``n_wave``/``nwave`` and
-    ``name``.
+    Supported parameters are ``spd``, ``wave``, ``n_wave``/``nwave``, ``gamma``
+    and ``name``.
     """
     key = param.lower().replace(" ", "")
     if key == "spd":
         return display.spd
     if key == "wave":
         return display.wave
+    if key == "gamma":
+        return display.gamma
     if key in {"nwave", "n_wave"}:
         return len(display.wave)
     if key == "name":

--- a/python/isetcam/display/display_set.py
+++ b/python/isetcam/display/display_set.py
@@ -12,8 +12,8 @@ from .display_class import Display
 def display_set(display: Display, param: str, val: Any) -> None:
     """Set a parameter value on ``display``.
 
-    Supported parameters are ``spd``, ``wave`` and ``name``. ``n_wave`` is a
-    derived value and therefore cannot be set.
+    Supported parameters are ``spd``, ``wave``, ``gamma`` and ``name``.
+    ``n_wave`` is a derived value and therefore cannot be set.
     """
     key = param.lower().replace(" ", "")
     if key == "spd":
@@ -21,6 +21,9 @@ def display_set(display: Display, param: str, val: Any) -> None:
         return
     if key == "wave":
         display.wave = np.asarray(val)
+        return
+    if key == "gamma":
+        display.gamma = None if val is None else np.asarray(val)
         return
     if key == "name":
         display.name = None if val is None else str(val)

--- a/python/tests/test_display_get_set.py
+++ b/python/tests/test_display_get_set.py
@@ -6,11 +6,13 @@ from isetcam.display import Display, display_get, display_set
 def test_display_get_set():
     wave = np.array([500, 510, 520])
     spd = np.ones((3, 2))
-    disp = Display(spd=spd.copy(), wave=wave, name="orig")
+    gamma = np.array([[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]])
+    disp = Display(spd=spd.copy(), wave=wave, gamma=gamma.copy(), name="orig")
 
     assert np.allclose(display_get(disp, "spd"), spd)
     assert np.array_equal(display_get(disp, "wave"), wave)
     assert display_get(disp, "n wave") == 3
+    assert np.array_equal(display_get(disp, "gamma"), gamma)
     assert display_get(disp, "name") == "orig"
 
     new_spd = np.zeros_like(spd)
@@ -21,6 +23,10 @@ def test_display_get_set():
     display_set(disp, "wave", new_wave)
     assert np.array_equal(display_get(disp, "wave"), new_wave)
     assert display_get(disp, "n_wave") == len(new_wave)
+
+    new_gamma = gamma * 2
+    display_set(disp, "gamma", new_gamma)
+    assert np.array_equal(display_get(disp, "gamma"), new_gamma)
 
     display_set(disp, "name", "new")
     assert display_get(disp, "name") == "new"


### PR DESCRIPTION
## Summary
- expand `display_get` to handle the `gamma` parameter
- allow updating gamma in `display_set`
- test new behavior in `test_display_get_set`

## Testing
- `pytest -q`
