### PR TITLE
Use ie_param_format across accessor modules

### DIFF
--- a/python/isetcam/camera/camera_get.py
+++ b/python/isetcam/camera/camera_get.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from .camera_class import Camera
+from ..ie_param_format import ie_param_format
 
 
 def camera_get(camera: Camera, param: str) -> Any:
@@ -13,7 +14,7 @@ def camera_get(camera: Camera, param: str) -> Any:
     Supported parameters are ``sensor``, ``optical_image``/``oi``, ``name``
     and ``n_wave``/``nwave`` (derived from the sensor's wavelength sampling).
     """
-    key = param.lower().replace(" ", "").replace("_", "")
+    key = ie_param_format(param).replace("_", "")
     if key == "sensor":
         return camera.sensor
     if key in {"opticalimage", "oi"}:

--- a/python/isetcam/camera/camera_set.py
+++ b/python/isetcam/camera/camera_set.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from .camera_class import Camera
+from ..ie_param_format import ie_param_format
 
 
 def camera_set(camera: Camera, param: str, val: Any) -> None:
@@ -13,7 +14,7 @@ def camera_set(camera: Camera, param: str, val: Any) -> None:
     Supported parameters are ``sensor``, ``optical_image``/``oi`` and
     ``name``. ``n_wave`` is derived from the sensor and cannot be set.
     """
-    key = param.lower().replace(" ", "").replace("_", "")
+    key = ie_param_format(param).replace("_", "")
     if key == "sensor":
         camera.sensor = val
         return

--- a/python/isetcam/display/display_get.py
+++ b/python/isetcam/display/display_get.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 
 from .display_class import Display
+from ..ie_param_format import ie_param_format
 
 
 def display_get(display: Display, param: str) -> Any:
@@ -15,7 +16,7 @@ def display_get(display: Display, param: str) -> Any:
     Supported parameters are ``spd``, ``wave``, ``n_wave``/``nwave``, ``gamma``
     and ``name``.
     """
-    key = param.lower().replace(" ", "")
+    key = ie_param_format(param)
     if key == "spd":
         return display.spd
     if key == "wave":

--- a/python/isetcam/display/display_set.py
+++ b/python/isetcam/display/display_set.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 
 from .display_class import Display
+from ..ie_param_format import ie_param_format
 
 
 def display_set(display: Display, param: str, val: Any) -> None:
@@ -15,7 +16,7 @@ def display_set(display: Display, param: str, val: Any) -> None:
     Supported parameters are ``spd``, ``wave``, ``gamma`` and ``name``.
     ``n_wave`` is a derived value and therefore cannot be set.
     """
-    key = param.lower().replace(" ", "")
+    key = ie_param_format(param)
     if key == "spd":
         display.spd = np.asarray(val)
         return

--- a/python/isetcam/opticalimage/oi_get.py
+++ b/python/isetcam/opticalimage/oi_get.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from .oi_class import OpticalImage
 from ..luminance_from_photons import luminance_from_photons
+from ..ie_param_format import ie_param_format
 
 
 def oi_get(oi: OpticalImage, param: str) -> Any:
@@ -16,7 +17,7 @@ def oi_get(oi: OpticalImage, param: str) -> Any:
     Supported parameters are ``photons``, ``wave``, ``n_wave``/``nwave``,
     ``name``, and ``luminance``.
     """
-    key = param.lower().replace(" ", "")
+    key = ie_param_format(param)
     if key == "photons":
         return oi.photons
     if key == "wave":

--- a/python/isetcam/opticalimage/oi_set.py
+++ b/python/isetcam/opticalimage/oi_set.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 
 from .oi_class import OpticalImage
+from ..ie_param_format import ie_param_format
 
 
 def oi_set(oi: OpticalImage, param: str, val: Any) -> None:
@@ -15,7 +16,7 @@ def oi_set(oi: OpticalImage, param: str, val: Any) -> None:
     Supported parameters are ``photons``, ``wave`` and ``name``. ``n_wave`` and
     ``luminance`` are derived values and therefore cannot be set.
     """
-    key = param.lower().replace(" ", "")
+    key = ie_param_format(param)
     if key == "photons":
         oi.photons = np.asarray(val)
         return

--- a/python/isetcam/scene/scene_get.py
+++ b/python/isetcam/scene/scene_get.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from .scene_class import Scene
 from ..luminance_from_photons import luminance_from_photons
+from ..ie_param_format import ie_param_format
 
 
 def scene_get(scene: Scene, param: str) -> Any:
@@ -16,7 +17,7 @@ def scene_get(scene: Scene, param: str) -> Any:
     Supported parameters are ``photons``, ``wave``, ``n_wave``/``nwave``,
     ``name``, and ``luminance``.
     """
-    key = param.lower().replace(" ", "")
+    key = ie_param_format(param)
     if key == "photons":
         return scene.photons
     if key == "wave":

--- a/python/isetcam/scene/scene_set.py
+++ b/python/isetcam/scene/scene_set.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 
 from .scene_class import Scene
+from ..ie_param_format import ie_param_format
 
 
 def scene_set(scene: Scene, param: str, val: Any) -> None:
@@ -15,7 +16,7 @@ def scene_set(scene: Scene, param: str, val: Any) -> None:
     Supported parameters are ``photons``, ``wave`` and ``name``. ``n_wave`` and
     ``luminance`` are derived values and therefore cannot be set.
     """
-    key = param.lower().replace(" ", "")
+    key = ie_param_format(param)
     if key == "photons":
         scene.photons = np.asarray(val)
         return

--- a/python/tests/test_camera_get_set.py
+++ b/python/tests/test_camera_get_set.py
@@ -13,18 +13,18 @@ def test_camera_get_set():
     oi = OpticalImage(photons=photons.copy(), wave=wave)
     cam = Camera(sensor=sensor, optical_image=oi, name="orig")
 
-    assert camera_get(cam, "sensor") is sensor
-    assert camera_get(cam, "optical image") is oi
-    assert camera_get(cam, "n wave") == 3
-    assert camera_get(cam, "name") == "orig"
+    assert camera_get(cam, "Sensor") is sensor
+    assert camera_get(cam, "OPTICAL IMAGE") is oi
+    assert camera_get(cam, "N WAVE") == 3
+    assert camera_get(cam, " NAME ") == "orig"
 
     new_sensor = Sensor(volts=np.zeros_like(volts), wave=wave, exposure_time=0.02)
-    camera_set(cam, "sensor", new_sensor)
-    assert camera_get(cam, "sensor") is new_sensor
+    camera_set(cam, " SENSOR ", new_sensor)
+    assert camera_get(cam, " SENSOR") is new_sensor
 
     new_oi = OpticalImage(photons=np.zeros_like(photons), wave=wave)
-    camera_set(cam, "optical_image", new_oi)
+    camera_set(cam, " OPTICAL_image", new_oi)
     assert camera_get(cam, "oi") is new_oi
 
-    camera_set(cam, "name", "new")
-    assert camera_get(cam, "name") == "new"
+    camera_set(cam, " NaMe", "new")
+    assert camera_get(cam, " NaMe ") == "new"

--- a/python/tests/test_display_get_set.py
+++ b/python/tests/test_display_get_set.py
@@ -9,24 +9,24 @@ def test_display_get_set():
     gamma = np.array([[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]])
     disp = Display(spd=spd.copy(), wave=wave, gamma=gamma.copy(), name="orig")
 
-    assert np.allclose(display_get(disp, "spd"), spd)
-    assert np.array_equal(display_get(disp, "wave"), wave)
-    assert display_get(disp, "n wave") == 3
-    assert np.array_equal(display_get(disp, "gamma"), gamma)
-    assert display_get(disp, "name") == "orig"
+    assert np.allclose(display_get(disp, " SpD " ), spd)
+    assert np.array_equal(display_get(disp, "WAVE"), wave)
+    assert display_get(disp, "N WaVe") == 3
+    assert np.array_equal(display_get(disp, "  gAmMa"), gamma)
+    assert display_get(disp, " NAME ") == "orig"
 
     new_spd = np.zeros_like(spd)
-    display_set(disp, "spd", new_spd)
-    assert np.allclose(display_get(disp, "spd"), new_spd)
+    display_set(disp, " SpD ", new_spd)
+    assert np.allclose(display_get(disp, " Spd"), new_spd)
 
     new_wave = np.array([400, 500])
-    display_set(disp, "wave", new_wave)
-    assert np.array_equal(display_get(disp, "wave"), new_wave)
-    assert display_get(disp, "n_wave") == len(new_wave)
+    display_set(disp, " WAVE ", new_wave)
+    assert np.array_equal(display_get(disp, "wAvE"), new_wave)
+    assert display_get(disp, "N_WAVE") == len(new_wave)
 
     new_gamma = gamma * 2
-    display_set(disp, "gamma", new_gamma)
-    assert np.array_equal(display_get(disp, "gamma"), new_gamma)
+    display_set(disp, " gAmMa", new_gamma)
+    assert np.array_equal(display_get(disp, " GAMMA"), new_gamma)
 
-    display_set(disp, "name", "new")
-    assert display_get(disp, "name") == "new"
+    display_set(disp, " NaMe ", "new")
+    assert display_get(disp, " name ") == "new"

--- a/python/tests/test_oi_get_set.py
+++ b/python/tests/test_oi_get_set.py
@@ -9,22 +9,22 @@ def test_oi_get_set():
     photons = np.ones((2, 2, 3))
     oi = OpticalImage(photons=photons.copy(), wave=wave, name="orig")
 
-    assert np.allclose(oi_get(oi, "photons"), photons)
-    assert np.array_equal(oi_get(oi, "wave"), wave)
-    assert oi_get(oi, "n wave") == 3
-    assert oi_get(oi, "name") == "orig"
+    assert np.allclose(oi_get(oi, "PHOTONS"), photons)
+    assert np.array_equal(oi_get(oi, " wAvE"), wave)
+    assert oi_get(oi, "N WAVE") == 3
+    assert oi_get(oi, " NAme ") == "orig"
 
     expected_lum = luminance_from_photons(photons, wave)
-    assert np.allclose(oi_get(oi, "luminance"), expected_lum)
+    assert np.allclose(oi_get(oi, " LUMINANCE"), expected_lum)
 
     new_photons = np.zeros_like(photons)
-    oi_set(oi, "photons", new_photons)
-    assert np.allclose(oi_get(oi, "photons"), new_photons)
+    oi_set(oi, " PhoTonS", new_photons)
+    assert np.allclose(oi_get(oi, " phOtOnS"), new_photons)
 
     new_wave = np.array([400, 500])
-    oi_set(oi, "wave", new_wave)
-    assert np.array_equal(oi_get(oi, "wave"), new_wave)
-    assert oi_get(oi, "n_wave") == len(new_wave)
+    oi_set(oi, "WAVE", new_wave)
+    assert np.array_equal(oi_get(oi, " WAVE"), new_wave)
+    assert oi_get(oi, "N_WAVE") == len(new_wave)
 
-    oi_set(oi, "name", "new")
-    assert oi_get(oi, "name") == "new"
+    oi_set(oi, " NaMe ", "new")
+    assert oi_get(oi, "Name" ) == "new"

--- a/python/tests/test_scene_get_set.py
+++ b/python/tests/test_scene_get_set.py
@@ -9,22 +9,22 @@ def test_scene_get_set():
     photons = np.ones((2, 2, 3))
     sc = Scene(photons=photons.copy(), wave=wave, name="orig")
 
-    assert np.allclose(scene_get(sc, "photons"), photons)
-    assert np.array_equal(scene_get(sc, "wave"), wave)
-    assert scene_get(sc, "n wave") == 3
-    assert scene_get(sc, "name") == "orig"
+    assert np.allclose(scene_get(sc, " PhoTonS "), photons)
+    assert np.array_equal(scene_get(sc, "WAVE"), wave)
+    assert scene_get(sc, "N WAVE") == 3
+    assert scene_get(sc, " NAME ") == "orig"
 
     expected_lum = luminance_from_photons(photons, wave)
-    assert np.allclose(scene_get(sc, "luminance"), expected_lum)
+    assert np.allclose(scene_get(sc, " LuMiNaNcE"), expected_lum)
 
     new_photons = np.zeros_like(photons)
-    scene_set(sc, "photons", new_photons)
-    assert np.allclose(scene_get(sc, "photons"), new_photons)
+    scene_set(sc, " PhoTonS", new_photons)
+    assert np.allclose(scene_get(sc, " PHOTONS"), new_photons)
 
     new_wave = np.array([400, 500])
-    scene_set(sc, "wave", new_wave)
-    assert np.array_equal(scene_get(sc, "wave"), new_wave)
-    assert scene_get(sc, "n_wave") == len(new_wave)
+    scene_set(sc, " WaVe ", new_wave)
+    assert np.array_equal(scene_get(sc, "waVe"), new_wave)
+    assert scene_get(sc, "N_WAVE") == len(new_wave)
 
-    scene_set(sc, "name", "new")
-    assert scene_get(sc, "name") == "new"
+    scene_set(sc, " NaMe", "new")
+    assert scene_get(sc, " NAME ") == "new"

--- a/python/tests/test_sensor_get_set.py
+++ b/python/tests/test_sensor_get_set.py
@@ -8,23 +8,23 @@ def test_sensor_get_set():
     volts = np.ones((2, 2, 3))
     s = Sensor(volts=volts.copy(), wave=wave, exposure_time=0.01, name="orig")
 
-    assert np.allclose(sensor_get(s, "volts"), volts)
-    assert np.array_equal(sensor_get(s, "wave"), wave)
-    assert sensor_get(s, "n wave") == 3
-    assert sensor_get(s, "exposure time") == 0.01
-    assert sensor_get(s, "name") == "orig"
+    assert np.allclose(sensor_get(s, " VOLTS"), volts)
+    assert np.array_equal(sensor_get(s, " WAVE"), wave)
+    assert sensor_get(s, "N WAVE") == 3
+    assert sensor_get(s, "EXPOSURE TIME") == 0.01
+    assert sensor_get(s, " NaMe") == "orig"
 
     new_volts = np.zeros_like(volts)
-    sensor_set(s, "volts", new_volts)
-    assert np.allclose(sensor_get(s, "volts"), new_volts)
+    sensor_set(s, " VolTs ", new_volts)
+    assert np.allclose(sensor_get(s, "vOlTs"), new_volts)
 
     new_wave = np.array([400, 500])
-    sensor_set(s, "wave", new_wave)
-    assert np.array_equal(sensor_get(s, "wave"), new_wave)
-    assert sensor_get(s, "n_wave") == len(new_wave)
+    sensor_set(s, " wAvE", new_wave)
+    assert np.array_equal(sensor_get(s, "WAVE"), new_wave)
+    assert sensor_get(s, "N_WAVE") == len(new_wave)
 
-    sensor_set(s, "exposure_time", 0.02)
-    assert sensor_get(s, "exposure time") == 0.02
+    sensor_set(s, "Exposure_Time", 0.02)
+    assert sensor_get(s, "ExPosure TiMe") == 0.02
 
-    sensor_set(s, "name", "new")
-    assert sensor_get(s, "name") == "new"
+    sensor_set(s, " NAME ", "new")
+    assert sensor_get(s, " Name ") == "new"


### PR DESCRIPTION
## Summary
- rely on `ie_param_format` to normalize parameter names in camera, scene, display, and optical image accessor functions
- expand unit tests to check parameter case and spacing are handled uniformly

## Testing
- `pytest -q`