### PR TITLE
Add scene_adjust_illuminant and tests

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -7,6 +7,7 @@ from .scene_from_file import scene_from_file
 from .scene_get import scene_get
 from .scene_set import scene_set
 from .scene_adjust_luminance import scene_adjust_luminance
+from .scene_adjust_illuminant import scene_adjust_illuminant
 from .scene_crop import scene_crop
 from .scene_pad import scene_pad
 from .scene_translate import scene_translate
@@ -21,6 +22,7 @@ __all__ = [
     "scene_get",
     "scene_set",
     "scene_adjust_luminance",
+    "scene_adjust_illuminant",
     "scene_crop",
     "scene_pad",
     "scene_translate",

--- a/python/isetcam/scene/scene_adjust_illuminant.py
+++ b/python/isetcam/scene/scene_adjust_illuminant.py
@@ -1,0 +1,69 @@
+"""Adjust the illuminant of a :class:`Scene`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+from scipy.io import loadmat
+
+from .scene_class import Scene
+from ..luminance_from_photons import luminance_from_photons
+
+
+def _load_spd(path: Path) -> tuple[np.ndarray, np.ndarray | None]:
+    """Return spectral data and wavelength from ``path``."""
+    mat = loadmat(str(path))
+    if "data" not in mat:
+        raise KeyError("MAT-file must contain 'data'")
+    spd = np.asarray(mat["data"], dtype=float).reshape(-1)
+    wave = None
+    if "wavelength" in mat:
+        wave = np.asarray(mat["wavelength"], dtype=float).reshape(-1)
+    elif "wave" in mat:
+        wave = np.asarray(mat["wave"], dtype=float).reshape(-1)
+    return spd, wave
+
+
+def scene_adjust_illuminant(
+    scene: Scene, illuminant: Union[np.ndarray, str, Path], preserve_mean: bool = True
+) -> Scene:
+    """Scale ``scene`` photon data by ``illuminant``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene to adjust.
+    illuminant : array-like or path-like
+        Spectral power distribution to apply. A path should point to a
+        MATLAB ``.mat`` file containing ``wavelength`` and ``data`` arrays.
+    preserve_mean : bool, optional
+        When ``True`` (default) the mean luminance of ``scene`` is
+        preserved after applying the illuminant.
+
+    Returns
+    -------
+    Scene
+        New scene with scaled photon data.
+    """
+
+    orig_mean = float(luminance_from_photons(scene.photons, scene.wave).mean())
+
+    if isinstance(illuminant, (str, Path)):
+        spd, wave = _load_spd(Path(illuminant))
+        if wave is not None and not np.array_equal(wave, scene.wave):
+            spd = np.interp(scene.wave, wave, spd, left=0.0, right=0.0)
+    else:
+        spd = np.asarray(illuminant, dtype=float).reshape(-1)
+        if spd.size != len(scene.wave):
+            raise ValueError("Illuminant vector length must match scene wave")
+
+    photons = scene.photons * spd[np.newaxis, np.newaxis, :]
+
+    if preserve_mean:
+        new_mean = float(luminance_from_photons(photons, scene.wave).mean())
+        if new_mean > 0:
+            photons = photons * (orig_mean / new_mean)
+
+    return Scene(photons=photons, wave=scene.wave, name=scene.name)

--- a/python/tests/test_scene_adjust_illuminant.py
+++ b/python/tests/test_scene_adjust_illuminant.py
@@ -1,0 +1,32 @@
+import numpy as np
+from pathlib import Path
+
+from isetcam.scene import Scene, scene_adjust_illuminant
+from isetcam.luminance_from_photons import luminance_from_photons
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([500, 510, 520])
+    photons = np.ones((2, 2, 3))
+    return Scene(photons=photons, wave=wave)
+
+
+def test_scene_adjust_illuminant_vector():
+    sc = _simple_scene()
+    spd = np.array([1.0, 2.0, 3.0])
+    out = scene_adjust_illuminant(sc, spd)
+    lum_before = luminance_from_photons(sc.photons, sc.wave).mean()
+    lum_after = luminance_from_photons(out.photons, out.wave).mean()
+    assert np.isclose(lum_after, lum_before)
+    assert not np.allclose(out.photons, sc.photons)
+
+
+def test_scene_adjust_illuminant_matfile():
+    sc = _simple_scene()
+    root = Path(__file__).resolve().parents[2]
+    path = root / "data" / "lights" / "D65.mat"
+    out = scene_adjust_illuminant(sc, path)
+    lum_before = luminance_from_photons(sc.photons, sc.wave).mean()
+    lum_after = luminance_from_photons(out.photons, out.wave).mean()
+    assert np.isclose(lum_after, lum_before)
+    assert not np.allclose(out.photons, sc.photons)


### PR DESCRIPTION
## Summary
- add `scene_adjust_illuminant` for applying a new illuminant
- export the function from `isetcam.scene`
- test both vector and MAT‑file inputs

## Testing
- `pytest -q`