### PR TITLE
Add scene rotation utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -12,6 +12,7 @@ from .scene_create import scene_create
 from .scene_crop import scene_crop
 from .scene_pad import scene_pad
 from .scene_translate import scene_translate
+from .scene_rotate import scene_rotate
 
 __all__ = [
     "Scene",
@@ -27,5 +28,6 @@ __all__ = [
     "scene_crop",
     "scene_pad",
     "scene_translate",
+    "scene_rotate",
     "scene_create",
 ]

--- a/python/isetcam/scene/scene_rotate.py
+++ b/python/isetcam/scene/scene_rotate.py
@@ -1,0 +1,39 @@
+"""Rotate the photon data of a Scene."""
+
+from __future__ import annotations
+
+from scipy.ndimage import rotate as nd_rotate
+
+from .scene_class import Scene
+
+
+def scene_rotate(scene: Scene, angle: float, fill: float = 0) -> Scene:
+    """Rotate ``scene`` by ``angle`` degrees.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene to rotate.
+    angle : float
+        Rotation angle in degrees. Positive values rotate counter-clockwise.
+    fill : float, optional
+        Value used to fill areas created by the rotation. Defaults to 0.
+
+    Returns
+    -------
+    Scene
+        New scene containing the rotated photon data with the same wavelength
+        samples and name.
+    """
+
+    photons = scene.photons
+    rotated = nd_rotate(
+        photons,
+        angle,
+        axes=(1, 0),
+        reshape=True,
+        order=1,
+        mode="constant",
+        cval=float(fill),
+    )
+    return Scene(photons=rotated, wave=scene.wave, name=scene.name)

--- a/python/tests/test_scene_rotate.py
+++ b/python/tests/test_scene_rotate.py
@@ -1,0 +1,39 @@
+import numpy as np
+from scipy.ndimage import rotate as nd_rotate
+
+from isetcam.scene import Scene, scene_rotate
+
+
+def _simple_scene(width: int = 3, height: int = 3, n_wave: int = 1) -> Scene:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    return Scene(photons=photons, wave=wave, name="simple")
+
+
+def test_scene_rotate_90():
+    sc = _simple_scene(2, 3, 1)
+    out = scene_rotate(sc, 90)
+    expected = np.rot90(sc.photons, axes=(0, 1))
+    assert np.array_equal(out.photons, expected)
+    assert np.array_equal(out.wave, sc.wave)
+    assert out.name == sc.name
+
+
+def test_scene_rotate_general():
+    sc = _simple_scene(3, 3, 1)
+    angle = 30
+    out = scene_rotate(sc, angle, fill=-1)
+    expected = nd_rotate(
+        sc.photons,
+        angle,
+        axes=(1, 0),
+        reshape=True,
+        order=1,
+        mode="constant",
+        cval=-1,
+    )
+    assert np.allclose(out.photons, expected)
+    assert np.array_equal(out.wave, sc.wave)
+    assert out.name == sc.name


### PR DESCRIPTION
## Summary
- implement `scene_rotate` for rotating Scene photon data
- expose `scene_rotate` from the scene package
- test scene rotation for right-angle and arbitrary angles

## Testing
- `PYTHONPATH=python pytest -q`