### PR TITLE
Add oi_rotate function with tests

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -8,6 +8,7 @@ from .oi_set import oi_set
 from .oi_from_file import oi_from_file
 from .oi_crop import oi_crop
 from .oi_pad import oi_pad
+from .oi_rotate import oi_rotate
 
 __all__ = [
     "OpticalImage",
@@ -20,4 +21,5 @@ __all__ = [
     "oi_from_file",
     "oi_crop",
     "oi_pad",
+    "oi_rotate",
 ]

--- a/python/isetcam/opticalimage/oi_rotate.py
+++ b/python/isetcam/opticalimage/oi_rotate.py
@@ -1,0 +1,38 @@
+"""Rotate the photon data of an OpticalImage."""
+
+from __future__ import annotations
+
+from scipy.ndimage import rotate as nd_rotate
+
+from .oi_class import OpticalImage
+
+
+def oi_rotate(oi: OpticalImage, angle: float, fill: float = 0) -> OpticalImage:
+    """Rotate ``oi`` by ``angle`` degrees.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image to rotate.
+    angle : float
+        Rotation angle in degrees. Positive values rotate counter-clockwise.
+    fill : float, optional
+        Value used to fill areas created by the rotation. Defaults to 0.
+
+    Returns
+    -------
+    OpticalImage
+        New optical image containing the rotated photon data with the same
+        wavelength samples and name.
+    """
+
+    rotated = nd_rotate(
+        oi.photons,
+        angle,
+        axes=(1, 0),
+        reshape=True,
+        order=1,
+        mode="constant",
+        cval=float(fill),
+    )
+    return OpticalImage(photons=rotated, wave=oi.wave, name=oi.name)

--- a/python/tests/test_oi_rotate.py
+++ b/python/tests/test_oi_rotate.py
@@ -1,0 +1,39 @@
+import numpy as np
+from scipy.ndimage import rotate as nd_rotate
+
+from isetcam.opticalimage import OpticalImage, oi_rotate
+
+
+def _simple_oi(width: int = 3, height: int = 3, n_wave: int = 1) -> OpticalImage:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    return OpticalImage(photons=photons, wave=wave, name="simple")
+
+
+def test_oi_rotate_90():
+    oi = _simple_oi(2, 3, 1)
+    out = oi_rotate(oi, 90)
+    expected = np.rot90(oi.photons, axes=(0, 1))
+    assert np.array_equal(out.photons, expected)
+    assert np.array_equal(out.wave, oi.wave)
+    assert out.name == oi.name
+
+
+def test_oi_rotate_general():
+    oi = _simple_oi(3, 3, 1)
+    angle = 30
+    out = oi_rotate(oi, angle, fill=-1)
+    expected = nd_rotate(
+        oi.photons,
+        angle,
+        axes=(1, 0),
+        reshape=True,
+        order=1,
+        mode="constant",
+        cval=-1,
+    )
+    assert np.allclose(out.photons, expected)
+    assert np.array_equal(out.wave, oi.wave)
+    assert out.name == oi.name


### PR DESCRIPTION
## Summary
- implement `oi_rotate` to rotate optical image photon data
- export `oi_rotate` from opticalimage package
- add unit tests for rotation angles and fill behavior

## Testing
- `PYTHONPATH=$PWD/python pytest -q`
