### PR TITLE
Add photon noise utilities

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -6,6 +6,7 @@ from .oi_add import oi_add
 from .oi_get import oi_get
 from .oi_set import oi_set
 from .oi_from_file import oi_from_file
+from .oi_photon_noise import oi_photon_noise
 from .oi_crop import oi_crop
 from .oi_pad import oi_pad
 from .oi_rotate import oi_rotate
@@ -22,4 +23,5 @@ __all__ = [
     "oi_crop",
     "oi_pad",
     "oi_rotate",
+    "oi_photon_noise",
 ]

--- a/python/isetcam/opticalimage/oi_photon_noise.py
+++ b/python/isetcam/opticalimage/oi_photon_noise.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+def oi_photon_noise(oi: OpticalImage) -> tuple[np.ndarray, np.ndarray]:
+    """Apply Poisson photon noise to an optical image.
+
+    A Gaussian approximation is used when the mean photon count is at least
+    15; otherwise samples are drawn from a Poisson distribution.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Optical image providing the mean photon data.
+
+    Returns
+    -------
+    tuple of np.ndarray
+        ``(noisy_photons, noise)`` where ``noisy_photons`` are the photons
+        with noise added and ``noise`` is the difference from the mean
+        photons.
+    """
+    photons = np.asarray(oi.photons, dtype=float)
+
+    noisy = np.empty_like(photons, dtype=float)
+    noise = np.empty_like(photons, dtype=float)
+
+    mask = photons >= 15
+    if np.any(mask):
+        g_noise = np.sqrt(photons[mask]) * np.random.randn(*photons[mask].shape)
+        noisy[mask] = photons[mask] + g_noise
+        noise[mask] = g_noise
+    if np.any(~mask):
+        samples = np.random.poisson(photons[~mask])
+        noisy[~mask] = samples
+        noise[~mask] = samples - photons[~mask]
+
+    return noisy, noise

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -9,6 +9,7 @@ from .scene_set import scene_set
 from .scene_adjust_luminance import scene_adjust_luminance
 from .scene_adjust_illuminant import scene_adjust_illuminant
 from .scene_create import scene_create
+from .scene_photon_noise import scene_photon_noise
 from .scene_crop import scene_crop
 from .scene_pad import scene_pad
 from .scene_translate import scene_translate
@@ -30,4 +31,5 @@ __all__ = [
     "scene_translate",
     "scene_rotate",
     "scene_create",
+    "scene_photon_noise",
 ]

--- a/python/isetcam/scene/scene_photon_noise.py
+++ b/python/isetcam/scene/scene_photon_noise.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def scene_photon_noise(scene: Scene) -> tuple[np.ndarray, np.ndarray]:
+    """Apply Poisson photon noise to ``scene``.
+
+    A Gaussian approximation is used when the mean photon count is
+    at least 15; otherwise samples are drawn from a Poisson
+    distribution.
+
+    Parameters
+    ----------
+    scene : Scene
+        Scene providing the mean photon data.
+
+    Returns
+    -------
+    tuple of np.ndarray
+        ``(noisy_photons, noise)`` where ``noisy_photons`` are the photons
+        with noise added and ``noise`` is the difference from the mean
+        photons.
+    """
+    photons = np.asarray(scene.photons, dtype=float)
+
+    noisy = np.empty_like(photons, dtype=float)
+    noise = np.empty_like(photons, dtype=float)
+
+    mask = photons >= 15
+    if np.any(mask):
+        g_noise = np.sqrt(photons[mask]) * np.random.randn(*photons[mask].shape)
+        noisy[mask] = photons[mask] + g_noise
+        noise[mask] = g_noise
+    if np.any(~mask):
+        samples = np.random.poisson(photons[~mask])
+        noisy[~mask] = samples
+        noise[~mask] = samples - photons[~mask]
+
+    return noisy, noise

--- a/python/tests/test_oi_photon_noise.py
+++ b/python/tests/test_oi_photon_noise.py
@@ -1,0 +1,25 @@
+import numpy as np
+from isetcam.opticalimage import OpticalImage, oi_photon_noise
+
+
+def test_oi_photon_noise_gaussian():
+    np.random.seed(0)
+    photons = np.full((100, 100, 1), 20.0, dtype=float)
+    oi = OpticalImage(photons=photons.copy(), wave=np.array([550]))
+    noisy, noise = oi_photon_noise(oi)
+
+    assert noisy.shape == photons.shape
+    assert np.allclose(noisy - photons, noise)
+    assert abs(noise.mean()) < 0.1
+    assert abs(noise.var() - 20.0) < 2.0
+
+
+def test_oi_photon_noise_poisson():
+    np.random.seed(1)
+    photons = np.full((100, 100, 1), 5.0, dtype=float)
+    oi = OpticalImage(photons=photons.copy(), wave=np.array([550]))
+    noisy, noise = oi_photon_noise(oi)
+
+    assert abs(noisy.mean() - 5.0) < 0.1
+    assert abs(noise.mean()) < 0.1
+    assert abs(noise.var() - 5.0) < 1.0

--- a/python/tests/test_scene_photon_noise.py
+++ b/python/tests/test_scene_photon_noise.py
@@ -1,0 +1,25 @@
+import numpy as np
+from isetcam.scene import Scene, scene_photon_noise
+
+
+def test_scene_photon_noise_gaussian():
+    np.random.seed(0)
+    photons = np.full((100, 100, 1), 20.0, dtype=float)
+    sc = Scene(photons=photons.copy(), wave=np.array([550]))
+    noisy, noise = scene_photon_noise(sc)
+
+    assert noisy.shape == photons.shape
+    assert np.allclose(noisy - photons, noise)
+    assert abs(noise.mean()) < 0.1
+    assert abs(noise.var() - 20.0) < 2.0
+
+
+def test_scene_photon_noise_poisson():
+    np.random.seed(1)
+    photons = np.full((100, 100, 1), 5.0, dtype=float)
+    sc = Scene(photons=photons.copy(), wave=np.array([550]))
+    noisy, noise = scene_photon_noise(sc)
+
+    assert abs(noisy.mean() - 5.0) < 0.1
+    assert abs(noise.mean()) < 0.1
+    assert abs(noise.var() - 5.0) < 1.0


### PR DESCRIPTION
## Summary
- add helper to generate scene photon noise
- add helper to generate optical image photon noise
- export helpers in `__init__` files
- test photon noise utilities

## Testing
- `PYTHONPATH=python pytest -q`
