### PR TITLE
Add DeltaE metrics in Python

### DIFF
--- a/python/isetcam/metrics/__init__.py
+++ b/python/isetcam/metrics/__init__.py
@@ -2,5 +2,18 @@
 
 from .ie_psnr import ie_psnr
 from .scielab import scielab, sc_params, SCIELABParams
+from .delta_e_ab import delta_e_ab
+from .delta_e_94 import delta_e_94
+from .delta_e_2000 import delta_e_2000
+from .delta_e_uv import delta_e_uv
 
-__all__ = ["ie_psnr", "scielab", "sc_params", "SCIELABParams"]
+__all__ = [
+    "ie_psnr",
+    "scielab",
+    "sc_params",
+    "SCIELABParams",
+    "delta_e_ab",
+    "delta_e_94",
+    "delta_e_2000",
+    "delta_e_uv",
+]

--- a/python/isetcam/metrics/delta_e_2000.py
+++ b/python/isetcam/metrics/delta_e_2000.py
@@ -1,0 +1,84 @@
+"""CIEDE2000 color difference."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def delta_e_2000(lab1: np.ndarray, lab2: np.ndarray) -> np.ndarray:
+    """Return CIEDE2000 color difference between ``lab1`` and ``lab2``.
+
+    Parameters
+    ----------
+    lab1, lab2 : np.ndarray
+        Arrays of CIELAB values with final dimension of length 3.
+
+    Returns
+    -------
+    np.ndarray
+        Delta E values with the same shape as ``lab1`` without the last
+        dimension.
+    """
+    lab1 = np.asarray(lab1, dtype=float)
+    lab2 = np.asarray(lab2, dtype=float)
+    if lab1.shape != lab2.shape:
+        raise ValueError("lab1 and lab2 must have the same shape")
+
+    L1, a1, b1 = lab1[..., 0], lab1[..., 1], lab1[..., 2]
+    L2, a2, b2 = lab2[..., 0], lab2[..., 1], lab2[..., 2]
+
+    C1 = np.sqrt(a1 ** 2 + b1 ** 2)
+    C2 = np.sqrt(a2 ** 2 + b2 ** 2)
+    C_bar = (C1 + C2) / 2
+
+    G = 0.5 * (1 - np.sqrt((C_bar ** 7) / (C_bar ** 7 + 25 ** 7)))
+    a1p = (1 + G) * a1
+    a2p = (1 + G) * a2
+
+    C1p = np.sqrt(a1p ** 2 + b1 ** 2)
+    C2p = np.sqrt(a2p ** 2 + b2 ** 2)
+
+    h1p = np.degrees(np.arctan2(b1, a1p)) % 360
+    h2p = np.degrees(np.arctan2(b2, a2p)) % 360
+
+    dLp = L2 - L1
+    dCp = C2p - C1p
+
+    dhp = h2p - h1p
+    dhp = np.where(dhp > 180, dhp - 360, dhp)
+    dhp = np.where(dhp < -180, dhp + 360, dhp)
+    dhp = np.where((C1p * C2p) == 0, 0, dhp)
+
+    dHp = 2 * np.sqrt(C1p * C2p) * np.sin(np.radians(dhp) / 2)
+
+    Lp_bar = (L1 + L2) / 2
+    Cp_bar = (C1p + C2p) / 2
+
+    hp_bar = h1p + h2p
+    hp_bar = np.where(np.abs(h1p - h2p) > 180, hp_bar + 360, hp_bar)
+    hp_bar = np.where((C1p * C2p) == 0, h1p + h2p, hp_bar)
+    hp_bar /= 2
+
+    T = (
+        1
+        - 0.17 * np.cos(np.radians(hp_bar - 30))
+        + 0.24 * np.cos(np.radians(2 * hp_bar))
+        + 0.32 * np.cos(np.radians(3 * hp_bar + 6))
+        - 0.2 * np.cos(np.radians(4 * hp_bar - 63))
+    )
+
+    dtheta = 30 * np.exp(-((hp_bar - 275) / 25) ** 2)
+    Rc = 2 * np.sqrt((Cp_bar ** 7) / (Cp_bar ** 7 + 25 ** 7))
+
+    Sl = 1 + (0.015 * ((Lp_bar - 50) ** 2)) / np.sqrt(20 + (Lp_bar - 50) ** 2)
+    Sc = 1 + 0.045 * Cp_bar
+    Sh = 1 + 0.015 * Cp_bar * T
+
+    Rt = -Rc * np.sin(2 * np.radians(dtheta))
+
+    dE = np.sqrt(
+        (dLp / Sl) ** 2 + (dCp / Sc) ** 2 + (dHp / Sh) ** 2 + Rt * (dCp / Sc) * (dHp / Sh)
+    )
+    return dE
+
+__all__ = ["delta_e_2000"]

--- a/python/isetcam/metrics/delta_e_94.py
+++ b/python/isetcam/metrics/delta_e_94.py
@@ -1,0 +1,52 @@
+"""CIE94 color difference."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def delta_e_94(lab1: np.ndarray, lab2: np.ndarray, k: tuple[float, float, float] | np.ndarray = (1.0, 1.0, 1.0)) -> np.ndarray:
+    """Return CIE94 color difference between ``lab1`` and ``lab2``.
+
+    Parameters
+    ----------
+    lab1, lab2 : np.ndarray
+        Arrays of CIELAB values with final dimension 3.
+    k : sequence of float, optional
+        Parametric weighting factors ``(kL, kC, kH)``.
+
+    Returns
+    -------
+    np.ndarray
+        Delta E values.
+    """
+    lab1 = np.asarray(lab1, dtype=float)
+    lab2 = np.asarray(lab2, dtype=float)
+    if lab1.shape != lab2.shape:
+        raise ValueError("lab1 and lab2 must have the same shape")
+    k = np.asarray(k, dtype=float).reshape(3)
+
+    L1, a1, b1 = lab1[..., 0], lab1[..., 1], lab1[..., 2]
+    L2, a2, b2 = lab2[..., 0], lab2[..., 1], lab2[..., 2]
+
+    Cab1 = np.sqrt(a1 ** 2 + b1 ** 2)
+    Cab2 = np.sqrt(a2 ** 2 + b2 ** 2)
+    deltaL = L1 - L2
+    deltaC = Cab1 - Cab2
+
+    diff = lab1 - lab2
+    deltaE = np.sqrt(np.sum(diff ** 2, axis=-1))
+    deltaH = np.sqrt(np.maximum(deltaE ** 2 - deltaL ** 2 - deltaC ** 2, 0))
+
+    sL = 1.0
+    sC = 1.0 + 0.045 * Cab1
+    sH = 1.0 + 0.015 * Cab1
+
+    eL = deltaL / (sL * k[0])
+    eC = deltaC / (sC * k[1])
+    eH = deltaH / (sH * k[2])
+
+    de94 = np.sqrt(eL ** 2 + eC ** 2 + eH ** 2)
+    return de94
+
+__all__ = ["delta_e_94"]

--- a/python/isetcam/metrics/delta_e_ab.py
+++ b/python/isetcam/metrics/delta_e_ab.py
@@ -1,0 +1,43 @@
+"""Wrapper for various CIELAB color difference metrics."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .delta_e_2000 import delta_e_2000
+from .delta_e_94 import delta_e_94
+
+
+def delta_e_ab(lab1: np.ndarray, lab2: np.ndarray, version: str = "2000") -> np.ndarray:
+    """Return CIELAB color difference between ``lab1`` and ``lab2``.
+
+    Parameters
+    ----------
+    lab1, lab2 : np.ndarray
+        Arrays of CIELAB values with final dimension 3.
+    version : str, optional
+        Which DeltaE formula to use. Supported values are ``"2000"``,
+        ``"1994"`` and ``"1976"``. The default is ``"2000"``.
+
+    Returns
+    -------
+    np.ndarray
+        Delta E values.
+    """
+    lab1 = np.asarray(lab1, dtype=float)
+    lab2 = np.asarray(lab2, dtype=float)
+    if lab1.shape != lab2.shape:
+        raise ValueError("lab1 and lab2 must have the same shape")
+
+    v = version.lower()
+    if v in {"2000", "de2000", "ciede2000"}:
+        return delta_e_2000(lab1, lab2)
+    elif v in {"1994", "94"}:
+        return delta_e_94(lab1, lab2)
+    elif v in {"1976", "lab", "76"}:
+        diff = lab1 - lab2
+        return np.sqrt(np.sum(diff ** 2, axis=-1))
+    else:
+        raise ValueError(f"Unsupported deltaE version: {version}")
+
+__all__ = ["delta_e_ab"]

--- a/python/isetcam/metrics/delta_e_uv.py
+++ b/python/isetcam/metrics/delta_e_uv.py
@@ -1,0 +1,30 @@
+"""CIELUV color difference."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def delta_e_uv(luv1: np.ndarray, luv2: np.ndarray) -> np.ndarray:
+    """Return CIELUV color difference between ``luv1`` and ``luv2``.
+
+    Parameters
+    ----------
+    luv1, luv2 : np.ndarray
+        Arrays of CIELUV values with final dimension 3.
+
+    Returns
+    -------
+    np.ndarray
+        Delta E values.
+    """
+    luv1 = np.asarray(luv1, dtype=float)
+    luv2 = np.asarray(luv2, dtype=float)
+    if luv1.shape != luv2.shape:
+        raise ValueError("luv1 and luv2 must have the same shape")
+
+    diff = luv1 - luv2
+    de = np.sqrt(np.sum(diff ** 2, axis=-1))
+    return de
+
+__all__ = ["delta_e_uv"]

--- a/python/tests/test_delta_e.py
+++ b/python/tests/test_delta_e.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from isetcam.metrics import (
+    delta_e_ab,
+    delta_e_94,
+    delta_e_2000,
+    delta_e_uv,
+)
+
+
+def test_delta_e_2000_known_example():
+    lab1 = np.array([50.0, 2.6772, -79.7751])
+    lab2 = np.array([50.0, 0.0, -82.7485])
+    expected = 2.0425
+    val = float(delta_e_2000(lab1, lab2))
+    assert np.isclose(val, expected, atol=1e-4)
+
+
+def test_delta_e_94_basic():
+    lab1 = np.array([60.0, 20.0, 30.0])
+    lab2 = np.array([60.0, 20.0, 30.0])
+    assert delta_e_94(lab1, lab2) == 0
+
+
+def test_delta_e_uv_simple():
+    luv1 = np.array([[50.0, 10.0, -20.0], [70.0, 5.0, 5.0]])
+    luv2 = luv1 + 1
+    expected = np.sqrt(np.sum((luv1 - luv2) ** 2, axis=1))
+    assert np.allclose(delta_e_uv(luv1, luv2), expected)
+
+
+def test_delta_e_ab_versions():
+    lab1 = np.array([[50.0, 2.0, 3.0], [20.0, -5.0, 1.0]])
+    lab2 = lab1 + 1
+    assert np.allclose(delta_e_ab(lab1, lab2, "2000"), delta_e_2000(lab1, lab2))
+    assert np.allclose(delta_e_ab(lab1, lab2, "1994"), delta_e_94(lab1, lab2))
+    diff = np.sqrt(np.sum((lab1 - lab2) ** 2, axis=1))
+    assert np.allclose(delta_e_ab(lab1, lab2, "1976"), diff)


### PR DESCRIPTION
## Summary
- implement delta_e_ab, delta_e_94, delta_e_2000 and delta_e_uv
- expose new metrics in package init
- test Lab/Luv color difference calculations

## Testing
- `pytest -q`