### PR TITLE
Introduce iset_root_path helper

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -1,6 +1,7 @@
 """Python utilities migrated from ISETCam."""
 
 from .vc_constants import vc_constants
+from .iset_root_path import iset_root_path
 from .vc_get_image_format import vc_get_image_format
 from .quanta2energy import quanta_to_energy
 from .energy_to_quanta import energy_to_quanta
@@ -94,6 +95,7 @@ __all__ = [
     'scielab',
     'sc_params',
     'SCIELABParams',
+    'iset_root_path',
     'ie_init',
     'ie_init_session',
     'camera',

--- a/python/isetcam/cct.py
+++ b/python/isetcam/cct.py
@@ -6,10 +6,12 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
+from .iset_root_path import iset_root_path
+
 
 def _load_cct_table() -> np.ndarray:
     """Load isotemperature line data."""
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     # Prefer data in human subfolder if available
     path = root / "data" / "human" / "cct.mat"
     if not path.exists():

--- a/python/isetcam/cct_to_sun.py
+++ b/python/isetcam/cct_to_sun.py
@@ -8,6 +8,7 @@ from typing import Literal
 import numpy as np
 from scipy.io import loadmat
 
+from .iset_root_path import iset_root_path
 from .energy_to_quanta import energy_to_quanta
 
 
@@ -16,7 +17,7 @@ _DEF_FILE = "cieDaylightBasis.mat"
 
 def _load_daylight_basis(wave: np.ndarray) -> np.ndarray:
     """Return daylight basis functions interpolated to ``wave``."""
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     mat = loadmat(root / "data" / "lights" / _DEF_FILE)
     src_wave = mat["wavelength"].ravel()
     data = mat["data"]

--- a/python/isetcam/display/display_create.py
+++ b/python/isetcam/display/display_create.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
+from ..iset_root_path import iset_root_path
+
 from .display_class import Display
 
 _DEFAULT_NAME = "LCD-Apple"
@@ -36,7 +38,7 @@ def display_create(name: str | None = None) -> Display:
     """
     if name is None:
         name = _DEFAULT_NAME
-    root = Path(__file__).resolve().parents[3]
+    root = iset_root_path()
     path = root / _DEF_DIR / "displays" / f"{name}.mat"
     if not path.exists():
         raise FileNotFoundError(f"Unknown display '{name}'")

--- a/python/isetcam/ie_color_transform.py
+++ b/python/isetcam/ie_color_transform.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
+from .iset_root_path import iset_root_path
 from .illuminant import illuminant_create
 
 
@@ -24,7 +25,7 @@ def _interp_data(src_wave: np.ndarray, data: np.ndarray, wave: np.ndarray) -> np
 
 
 def _load_surfaces(name: str, wave: np.ndarray) -> np.ndarray:
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     if name.lower() in {"mcc", "macbeth"}:
         path = root / "data" / "surfaces" / "reflectances" / "macbethChart.mat"
     else:
@@ -36,7 +37,7 @@ def _load_surfaces(name: str, wave: np.ndarray) -> np.ndarray:
 
 
 def _load_xyz(wave: np.ndarray) -> np.ndarray:
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     data = loadmat(root / "data" / "human" / "XYZ.mat")
     src_wave = data["wavelength"].ravel()
     xyz = data["data"]

--- a/python/isetcam/ie_xyz_from_energy.py
+++ b/python/isetcam/ie_xyz_from_energy.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
+from .iset_root_path import iset_root_path
+
 from .vc_get_image_format import vc_get_image_format
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
@@ -13,7 +15,7 @@ from .xw_to_rgb_format import xw_to_rgb_format
 
 def _xyz_color_matching(wave: np.ndarray) -> np.ndarray:
     """Interpolate the CIE XYZ color matching functions to ``wave``."""
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     data = loadmat(root / "data" / "human" / "XYZ.mat")
     src_wave = data["wavelength"].ravel()
     xyz = data["data"]

--- a/python/isetcam/illuminant/illuminant_create.py
+++ b/python/isetcam/illuminant/illuminant_create.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
+from ..iset_root_path import iset_root_path
+
 from .illuminant_class import Illuminant
 
 
@@ -22,7 +24,7 @@ def _load_spd(path: Path) -> tuple[np.ndarray, np.ndarray]:
 
 def illuminant_create(name: str, wave: np.ndarray | None = None) -> Illuminant:
     """Create an illuminant by name, optionally interpolated to ``wave``."""
-    root = Path(__file__).resolve().parents[3]
+    root = iset_root_path()
     fname = name.strip().upper() + '.mat'
     path = root / _DEF_DIR / 'lights' / fname
     if not path.exists():

--- a/python/isetcam/iset_root_path.py
+++ b/python/isetcam/iset_root_path.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def iset_root_path() -> Path:
+    """Return the root directory of the ISETCam project."""
+    return Path(__file__).resolve().parents[2]

--- a/python/isetcam/luminance_from_energy.py
+++ b/python/isetcam/luminance_from_energy.py
@@ -9,13 +9,14 @@ import numpy as np
 from scipy.io import loadmat
 
 from .vc_get_image_format import vc_get_image_format
+from .iset_root_path import iset_root_path
 
 _DEF_BINWIDTH = 10
 
 
 def _photopic_luminosity(wave: np.ndarray) -> np.ndarray:
     """Return the photopic luminosity function interpolated to ``wave``."""
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     fpath = root / 'data' / 'human' / 'luminosity.mat'
     data = loadmat(fpath)
     src_wave = data['wavelength'].ravel()

--- a/python/isetcam/scene/scene_create.py
+++ b/python/isetcam/scene/scene_create.py
@@ -10,6 +10,7 @@ from scipy.io import loadmat
 
 from .scene_class import Scene
 from ..luminance_from_photons import luminance_from_photons
+from ..iset_root_path import iset_root_path
 
 
 _DEF_DIR = "data"
@@ -17,7 +18,7 @@ _DEF_DIR = "data"
 
 def _load_macbeth_data(wave: Optional[np.ndarray]) -> tuple[np.ndarray, np.ndarray]:
     """Return reflectance data and wavelength array for the Macbeth chart."""
-    root = Path(__file__).resolve().parents[3]
+    root = iset_root_path()
     mat = loadmat(root / _DEF_DIR / "surfaces" / "reflectances" / "macbethChart.mat")
     src_wave = mat["wavelength"].ravel().astype(float)
     refl = mat["data"].astype(float)
@@ -32,7 +33,7 @@ def _load_macbeth_data(wave: Optional[np.ndarray]) -> tuple[np.ndarray, np.ndarr
 
 def _load_d65(wave: np.ndarray) -> np.ndarray:
     """Return D65 spectral power distribution sampled at ``wave``."""
-    root = Path(__file__).resolve().parents[3]
+    root = iset_root_path()
     mat = loadmat(root / _DEF_DIR / "lights" / "D65.mat")
     src_wave = mat["wavelength"].ravel().astype(float)
     spd = mat["data"].ravel().astype(float)

--- a/python/isetcam/scotopic_luminance_from_energy.py
+++ b/python/isetcam/scotopic_luminance_from_energy.py
@@ -9,13 +9,14 @@ import numpy as np
 from scipy.io import loadmat
 
 from .vc_get_image_format import vc_get_image_format
+from .iset_root_path import iset_root_path
 
 _DEF_BINWIDTH = 10
 
 
 def _scotopic_luminosity(wave: np.ndarray) -> np.ndarray:
     """Return the scotopic luminosity function interpolated to ``wave``."""
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     fpath = root / 'data' / 'human' / 'rods.mat'
     data = loadmat(fpath)
     src_wave = data['wavelength'].ravel()

--- a/python/isetcam/xyz_to_lms.py
+++ b/python/isetcam/xyz_to_lms.py
@@ -14,6 +14,7 @@ from scipy.io import loadmat
 
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
+from .iset_root_path import iset_root_path
 
 # XYZ to LMS conversion matrix (Stockman fundamentals)
 _XYZ2LMS = np.array([
@@ -23,9 +24,7 @@ _XYZ2LMS = np.array([
 ])
 
 
-_def_stockman_path = (
-    Path(__file__).resolve().parents[2] / "data" / "human" / "stockman.mat"
-)
+_def_stockman_path = iset_root_path() / "data" / "human" / "stockman.mat"
 
 
 def _stockman_values(wavelengths: list[float]) -> np.ndarray:

--- a/python/tests/test_cct_to_sun.py
+++ b/python/tests/test_cct_to_sun.py
@@ -2,14 +2,14 @@ import numpy as np
 from pathlib import Path
 from scipy.io import loadmat
 
-from isetcam import cct_to_sun, energy_to_quanta
+from isetcam import cct_to_sun, energy_to_quanta, iset_root_path
 
 
 def test_cct_to_sun_matches_d65():
     wave = np.arange(380, 781, 5)
     spd = cct_to_sun(wave, 6500)
 
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     d65 = loadmat(root / "data" / "lights" / "D65.mat")
     d_wave = d65["wavelength"].ravel()
     d_spd = d65["data"].ravel()

--- a/python/tests/test_ie_color_transform.py
+++ b/python/tests/test_ie_color_transform.py
@@ -2,7 +2,7 @@ import numpy as np
 from pathlib import Path
 from scipy.io import loadmat
 
-from isetcam import ie_color_transform
+from isetcam import ie_color_transform, iset_root_path
 from isetcam.illuminant import illuminant_create
 
 
@@ -27,7 +27,7 @@ def test_ie_color_transform_xyz():
     T = ie_color_transform(sensor_qe, wave, "XYZ", illum)
     assert T.shape == (3, 3)
 
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     sur = loadmat(root / "data" / "surfaces" / "reflectances" / "macbethChart.mat")
     sur_ref = _interp(sur["wavelength"].ravel(), sur["data"], wave)
     cmf = loadmat(root / "data" / "human" / "XYZ.mat")

--- a/python/tests/test_luminance.py
+++ b/python/tests/test_luminance.py
@@ -2,6 +2,8 @@ import numpy as np
 from pathlib import Path
 from scipy.io import loadmat
 
+from isetcam import iset_root_path
+
 from isetcam import (
     luminance_from_energy,
     luminance_from_photons,
@@ -10,7 +12,7 @@ from isetcam import (
 
 
 def _expected_luminance(wave, energy):
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     mat = loadmat(root / 'data' / 'human' / 'luminosity.mat')
     V = np.interp(wave, mat['wavelength'].ravel(), mat['data'].ravel(), left=0.0, right=0.0)
     binwidth = wave[1] - wave[0] if len(wave) > 1 else 10

--- a/python/tests/test_scene_adjust_illuminant.py
+++ b/python/tests/test_scene_adjust_illuminant.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from isetcam.scene import Scene, scene_adjust_illuminant
 from isetcam.luminance_from_photons import luminance_from_photons
+from isetcam import iset_root_path
 
 
 def _simple_scene() -> Scene:
@@ -23,7 +24,7 @@ def test_scene_adjust_illuminant_vector():
 
 def test_scene_adjust_illuminant_matfile():
     sc = _simple_scene()
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     path = root / "data" / "lights" / "D65.mat"
     out = scene_adjust_illuminant(sc, path)
     lum_before = luminance_from_photons(sc.photons, sc.wave).mean()

--- a/python/tests/test_scene_from_file.py
+++ b/python/tests/test_scene_from_file.py
@@ -2,11 +2,11 @@ import numpy as np
 from pathlib import Path
 
 from isetcam.scene import scene_from_file, Scene
-from isetcam import luminance_from_energy
+from isetcam import luminance_from_energy, iset_root_path
 
 
 def test_scene_from_file_rgb():
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     fpath = root / 'data' / 'images' / 'rgb' / 'adelson.png'
     wave = np.array([450, 550, 650, 750])
     sc = scene_from_file(fpath, wave=wave)
@@ -17,7 +17,7 @@ def test_scene_from_file_rgb():
 
 
 def test_scene_from_file_mean_luminance():
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     fpath = root / 'data' / 'images' / 'rgb' / 'adelson.png'
     wave = np.array([450, 550, 650, 750])
     target = 10.0
@@ -27,7 +27,7 @@ def test_scene_from_file_mean_luminance():
 
 
 def test_scene_from_file_gray():
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     fpath = root / 'data' / 'images' / 'targets' / 'usaf1951' / 'USAF1951-72dpi.jpg'
     wave = np.array([550])
     sc = scene_from_file(fpath, wave=wave)

--- a/python/tests/test_scotopic_luminance.py
+++ b/python/tests/test_scotopic_luminance.py
@@ -2,11 +2,13 @@ import numpy as np
 from pathlib import Path
 from scipy.io import loadmat
 
+from isetcam import iset_root_path
+
 from isetcam import scotopic_luminance_from_energy
 
 
 def _expected_scotopic_luminance(wave, energy):
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     mat = loadmat(root / 'data' / 'human' / 'rods.mat')
     Vp = np.interp(wave, mat['wavelength'].ravel(), mat['data'].ravel(), left=0.0, right=0.0)
     binwidth = wave[1] - wave[0] if len(wave) > 1 else 10

--- a/python/tests/test_xyz_chromaticity.py
+++ b/python/tests/test_xyz_chromaticity.py
@@ -2,6 +2,8 @@ import numpy as np
 from pathlib import Path
 from scipy.io import loadmat
 
+from isetcam import iset_root_path
+
 from isetcam import (
     energy_to_quanta,
     ie_xyz_from_energy,
@@ -12,7 +14,7 @@ from isetcam import (
 
 
 def _expected_xyz(wave: np.ndarray, energy: np.ndarray) -> np.ndarray:
-    root = Path(__file__).resolve().parents[2]
+    root = iset_root_path()
     mat = loadmat(root / 'data' / 'human' / 'XYZ.mat')
     src_wave = mat['wavelength'].ravel()
     data = mat['data']


### PR DESCRIPTION
## Summary
- implement `iset_root_path` utility for locating repo root
- update modules to rely on `iset_root_path`
- re-export new helper from package init
- adjust tests to use `iset_root_path`

## Testing
- `PYTHONPATH=$PWD/python pytest -q`