### PR TITLE
Implement srgb_to_cct helper

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -43,6 +43,7 @@ from .srgb_xyz import (
     srgb_to_xyz,
     xyz_to_srgb,
 )
+from .srgb_to_cct import srgb_to_cct
 from .init_default_spectrum import init_default_spectrum
 from .imgproc import image_distort
 from .metrics.ie_psnr import ie_psnr
@@ -91,6 +92,7 @@ __all__ = [
     'linear_to_srgb',
     'srgb_to_xyz',
     'xyz_to_srgb',
+    'srgb_to_cct',
     'init_default_spectrum',
     'image_distort',
     'ie_psnr',

--- a/python/isetcam/srgb_to_cct.py
+++ b/python/isetcam/srgb_to_cct.py
@@ -1,0 +1,72 @@
+"""Estimate correlated color temperature from an sRGB image."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.io import loadmat
+
+from .srgb_xyz import srgb_to_xyz
+from .rgb_to_xw_format import rgb_to_xw_format
+from .chromaticity import chromaticity
+from .iset_root_path import iset_root_path
+from .illuminant import illuminant_blackbody
+
+__all__ = ["srgb_to_cct"]
+
+
+def _default_table() -> np.ndarray:
+    """Return lookup table of xy chromaticities for sample color temperatures."""
+    wave = np.arange(400, 701, 10)
+    ctemps = np.arange(2500, 10501, 500)
+    root = iset_root_path()
+    data = loadmat(root / "data" / "human" / "XYZEnergy.mat")
+    src_wave = data["wavelength"].ravel()
+    XYZ = np.zeros((len(wave), 3))
+    for i in range(3):
+        XYZ[:, i] = np.interp(wave, src_wave, data["data"][:, i], left=0.0, right=0.0)
+
+    xy = np.zeros((len(ctemps), 2))
+    for i, t in enumerate(ctemps):
+        spd = illuminant_blackbody(t, wave)
+        cieXYZ = XYZ.T @ spd
+        xy[i] = chromaticity(cieXYZ.reshape(1, 3))[0]
+    return np.column_stack([ctemps, xy])
+
+
+def srgb_to_cct(rgb: np.ndarray, *, table: np.ndarray | None = None) -> tuple[float, np.ndarray]:
+    """Estimate correlated color temperature from an sRGB image.
+
+    Parameters
+    ----------
+    rgb : np.ndarray
+        sRGB image data in RGB or XW format. Values are expected in ``[0, 1]``.
+    table : np.ndarray, optional
+        Precomputed lookup table returned from a previous call.
+
+    Returns
+    -------
+    float
+        Estimated color temperature in Kelvin.
+    np.ndarray
+        The lookup table used for the estimation.
+    """
+    rgb = np.asarray(rgb, dtype=float)
+    if table is None:
+        table = _default_table()
+    ctemps = table[:, 0]
+    xy_table = table[:, 1:]
+
+    img_xyz = srgb_to_xyz(rgb)
+    if img_xyz.ndim == 3:
+        xw, _, _ = rgb_to_xw_format(img_xyz)
+    else:
+        xw = img_xyz
+
+    Y = xw[:, 1]
+    topY = np.percentile(Y, 98)
+    topXYZ = xw[Y > topY]
+    topxy = chromaticity(topXYZ).mean(axis=0)
+
+    diffs = np.linalg.norm(xy_table - topxy, axis=1)
+    idx = np.argmin(diffs)
+    return float(ctemps[idx]), table

--- a/python/tests/test_srgb_to_cct.py
+++ b/python/tests/test_srgb_to_cct.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from isetcam import srgb_to_cct, ie_xyz_from_energy
+from isetcam.srgb_xyz import xyz_to_srgb
+from isetcam.illuminant import illuminant_blackbody
+
+np.random.seed(0)
+
+
+def _srgb_from_temp(temp: float) -> np.ndarray:
+    wave = np.arange(400, 701, 10)
+    spd = illuminant_blackbody(temp, wave)
+    xyz = ie_xyz_from_energy(spd[np.newaxis, :], wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    base = srgb.reshape(1, 1, 3)
+    # create a small image with variation so percentile computation works
+    scales = np.random.uniform(0.5, 1.0, (10, 10, 1))
+    img = np.clip(base * scales, 0.0, 1.0)
+    return img
+
+
+def test_srgb_to_cct_basic():
+    temps = [3500, 5500, 8000]
+    expected = [4000, 6000, 6500]
+    for t, exp in zip(temps, expected):
+        srgb = _srgb_from_temp(t)
+        est, _ = srgb_to_cct(srgb)
+        assert np.isclose(est, exp, atol=500)
+
+
+def test_srgb_to_cct_reuse_table():
+    srgb = _srgb_from_temp(6500)
+    est, table = srgb_to_cct(srgb)
+    assert np.isclose(est, 6500, atol=500)
+    srgb2 = _srgb_from_temp(4500)
+    est2, table2 = srgb_to_cct(srgb2, table=table)
+    assert table2 is table
+    assert np.isclose(est2, 5000, atol=500)


### PR DESCRIPTION
## Summary
- port MATLAB `srgb2colortemp` to Python as `srgb_to_cct`
- export `srgb_to_cct` from `isetcam`
- add tests for the new helper

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_srgb_to_cct.py`
- `PYTHONPATH=python pytest -q`