### PR TITLE
Add spatial sampling utilities

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -10,6 +10,8 @@ from .oi_photon_noise import oi_photon_noise
 from .oi_crop import oi_crop
 from .oi_pad import oi_pad
 from .oi_rotate import oi_rotate
+from .oi_spatial_support import oi_spatial_support
+from .oi_spatial_resample import oi_spatial_resample
 
 __all__ = [
     "OpticalImage",
@@ -23,5 +25,7 @@ __all__ = [
     "oi_crop",
     "oi_pad",
     "oi_rotate",
+    "oi_spatial_support",
+    "oi_spatial_resample",
     "oi_photon_noise",
 ]

--- a/python/isetcam/opticalimage/oi_spatial_resample.py
+++ b/python/isetcam/opticalimage/oi_spatial_resample.py
@@ -1,0 +1,65 @@
+"""Resample an :class:`OpticalImage` while preserving field of view."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import zoom as nd_zoom
+
+from .oi_class import OpticalImage
+
+
+def _unit_to_meters(units: str) -> float:
+    units = units.lower()
+    if units in {"m", "meter", "meters"}:
+        return 1.0
+    if units in {"mm", "millimeter", "millimeters"}:
+        return 1e-3
+    if units in {"um", "micron", "microns", "micrometer", "micrometers"}:
+        return 1e-6
+    raise ValueError(f"Unknown spatial unit '{units}'")
+
+
+def oi_spatial_resample(
+    oi: OpticalImage, dx: float, units: str = "m", method: str = "linear"
+) -> OpticalImage:
+    """Resample ``oi`` to new pixel spacing ``dx``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image.
+    dx : float
+        Desired pixel spacing.
+    units : str, optional
+        Units for ``dx``. Defaults to meters.
+    method : {{"linear", "nearest", "cubic"}}, optional
+        Interpolation method. Defaults to "linear".
+
+    Returns
+    -------
+    OpticalImage
+        Optical image resampled to the new pixel spacing with the same field
+        of view.
+    """
+    old_spacing = getattr(oi, "sample_spacing", 1.0)
+    new_spacing = float(dx) * _unit_to_meters(units)
+
+    height, width = oi.photons.shape[:2]
+    width_m = width * old_spacing
+    height_m = height * old_spacing
+
+    new_width = max(int(round(width_m / new_spacing)), 1)
+    new_height = max(int(round(height_m / new_spacing)), 1)
+
+    zoom_factors = (new_height / height, new_width / width, 1)
+
+    orders = {"nearest": 0, "linear": 1, "cubic": 3}
+    if method not in orders:
+        raise ValueError("Unknown interpolation method")
+    order = orders[method]
+
+    resampled = nd_zoom(oi.photons, zoom_factors, order=order)
+    out = OpticalImage(photons=resampled, wave=oi.wave, name=oi.name)
+    out.sample_spacing = new_spacing
+    return out
+

--- a/python/isetcam/opticalimage/oi_spatial_support.py
+++ b/python/isetcam/opticalimage/oi_spatial_support.py
@@ -1,0 +1,43 @@
+"""Spatial support for :class:`OpticalImage` objects."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+def _unit_scale(units: str) -> float:
+    units = units.lower()
+    if units in {"m", "meter", "meters"}:
+        return 1.0
+    if units in {"mm", "millimeter", "millimeters"}:
+        return 1e3
+    if units in {"um", "micron", "microns", "micrometer", "micrometers"}:
+        return 1e6
+    raise ValueError(f"Unknown spatial unit '{units}'")
+
+
+def oi_spatial_support(oi: OpticalImage, units: str = "meters") -> dict[str, np.ndarray]:
+    """Return spatial support of ``oi``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image.
+    units : str, optional
+        Output units. Supported values are "meters"/"m", "millimeters"/"mm",
+        and "microns"/"um".
+
+    Returns
+    -------
+    dict
+        ``{"x": x, "y": y}`` arrays giving sample locations.
+    """
+    spacing = getattr(oi, "sample_spacing", 1.0)
+    height, width = oi.photons.shape[:2]
+    x = (np.arange(width) - (width - 1) / 2) * spacing
+    y = (np.arange(height) - (height - 1) / 2) * spacing
+    scale = _unit_scale(units)
+    return {"x": x * scale, "y": y * scale}
+

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -14,6 +14,8 @@ from .scene_crop import scene_crop
 from .scene_pad import scene_pad
 from .scene_translate import scene_translate
 from .scene_rotate import scene_rotate
+from .scene_spatial_support import scene_spatial_support
+from .scene_spatial_resample import scene_spatial_resample
 
 __all__ = [
     "Scene",
@@ -30,6 +32,8 @@ __all__ = [
     "scene_pad",
     "scene_translate",
     "scene_rotate",
+    "scene_spatial_support",
+    "scene_spatial_resample",
     "scene_create",
     "scene_photon_noise",
 ]

--- a/python/isetcam/scene/scene_spatial_resample.py
+++ b/python/isetcam/scene/scene_spatial_resample.py
@@ -1,0 +1,64 @@
+"""Resample a :class:`Scene` while preserving field of view."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import zoom as nd_zoom
+
+from .scene_class import Scene
+
+
+def _unit_to_meters(units: str) -> float:
+    units = units.lower()
+    if units in {"m", "meter", "meters"}:
+        return 1.0
+    if units in {"mm", "millimeter", "millimeters"}:
+        return 1e-3
+    if units in {"um", "micron", "microns", "micrometer", "micrometers"}:
+        return 1e-6
+    raise ValueError(f"Unknown spatial unit '{units}'")
+
+
+def scene_spatial_resample(
+    scene: Scene, dx: float, units: str = "m", method: str = "linear"
+) -> Scene:
+    """Resample ``scene`` to new pixel spacing ``dx``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene.
+    dx : float
+        Desired pixel spacing.
+    units : str, optional
+        Units for ``dx``. Defaults to meters.
+    method : {{"linear", "nearest", "cubic"}}, optional
+        Interpolation method. Defaults to "linear".
+
+    Returns
+    -------
+    Scene
+        Scene resampled to the new pixel spacing with the same field of view.
+    """
+    old_spacing = getattr(scene, "sample_spacing", 1.0)
+    new_spacing = float(dx) * _unit_to_meters(units)
+
+    height, width = scene.photons.shape[:2]
+    width_m = width * old_spacing
+    height_m = height * old_spacing
+
+    new_width = max(int(round(width_m / new_spacing)), 1)
+    new_height = max(int(round(height_m / new_spacing)), 1)
+
+    zoom_factors = (new_height / height, new_width / width, 1)
+
+    orders = {"nearest": 0, "linear": 1, "cubic": 3}
+    if method not in orders:
+        raise ValueError("Unknown interpolation method")
+    order = orders[method]
+
+    resampled = nd_zoom(scene.photons, zoom_factors, order=order)
+    out = Scene(photons=resampled, wave=scene.wave, name=scene.name)
+    out.sample_spacing = new_spacing
+    return out
+

--- a/python/isetcam/scene/scene_spatial_support.py
+++ b/python/isetcam/scene/scene_spatial_support.py
@@ -1,0 +1,43 @@
+"""Spatial support for :class:`Scene` objects."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def _unit_scale(units: str) -> float:
+    units = units.lower()
+    if units in {"m", "meter", "meters"}:
+        return 1.0
+    if units in {"mm", "millimeter", "millimeters"}:
+        return 1e3
+    if units in {"um", "micron", "microns", "micrometer", "micrometers"}:
+        return 1e6
+    raise ValueError(f"Unknown spatial unit '{units}'")
+
+
+def scene_spatial_support(scene: Scene, units: str = "meters") -> dict[str, np.ndarray]:
+    """Return spatial support of ``scene``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene.
+    units : str, optional
+        Output units. Supported values are "meters"/"m", "millimeters"/"mm",
+        and "microns"/"um".
+
+    Returns
+    -------
+    dict
+        ``{"x": x, "y": y}`` arrays giving sample locations.
+    """
+    spacing = getattr(scene, "sample_spacing", 1.0)  # meters
+    height, width = scene.photons.shape[:2]
+    x = (np.arange(width) - (width - 1) / 2) * spacing
+    y = (np.arange(height) - (height - 1) / 2) * spacing
+    scale = _unit_scale(units)  # scale from meters
+    return {"x": x * scale, "y": y * scale}
+

--- a/python/tests/test_spatial_functions.py
+++ b/python/tests/test_spatial_functions.py
@@ -1,0 +1,68 @@
+import numpy as np
+
+from isetcam.scene import (
+    Scene,
+    scene_spatial_support,
+    scene_spatial_resample,
+)
+from isetcam.opticalimage import (
+    OpticalImage,
+    oi_spatial_support,
+    oi_spatial_resample,
+)
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([550])
+    photons = np.arange(16, dtype=float).reshape(4, 4, 1)
+    sc = Scene(photons=photons, wave=wave)
+    sc.sample_spacing = 1e-3  # 1 mm per pixel
+    return sc
+
+
+def _simple_oi() -> OpticalImage:
+    wave = np.array([550])
+    photons = np.arange(9, dtype=float).reshape(3, 3, 1)
+    oi = OpticalImage(photons=photons, wave=wave)
+    oi.sample_spacing = 2e-3  # 2 mm per pixel
+    return oi
+
+
+def test_scene_spatial_support_units():
+    sc = _simple_scene()
+    sup_m = scene_spatial_support(sc)
+    expected = np.array([-1.5e-3, -0.5e-3, 0.5e-3, 1.5e-3])
+    assert np.allclose(sup_m["x"], expected)
+    assert np.allclose(sup_m["y"], expected)
+    sup_mm = scene_spatial_support(sc, "mm")
+    assert np.allclose(sup_mm["x"], expected * 1e3)
+
+
+def test_scene_spatial_resample_fov():
+    sc = _simple_scene()
+    out = scene_spatial_resample(sc, 0.5e-3, method="nearest")
+    assert out.photons.shape[:2] == (8, 8)
+    old_width = sc.photons.shape[1] * sc.sample_spacing
+    new_width = out.photons.shape[1] * out.sample_spacing
+    assert np.isclose(old_width, new_width)
+
+
+def test_scene_spatial_resample_methods():
+    sc = _simple_scene()
+    lin = scene_spatial_resample(sc, 0.5e-3, method="linear")
+    near = scene_spatial_resample(sc, 0.5e-3, method="nearest")
+    assert lin.photons.shape == near.photons.shape
+    assert not np.allclose(lin.photons, near.photons)
+
+
+def test_oi_spatial_support_and_resample():
+    oi = _simple_oi()
+    sup = oi_spatial_support(oi)
+    expected_x = np.array([-2e-3, 0.0, 2e-3])
+    assert np.allclose(sup["x"], expected_x)
+    out = oi_spatial_resample(oi, 1e-3)
+    assert out.photons.shape[:2] == (6, 6)
+    old_width = oi.photons.shape[1] * oi.sample_spacing
+    new_width = out.photons.shape[1] * out.sample_spacing
+    assert np.isclose(old_width, new_width)
+


### PR DESCRIPTION
## Summary
- implement spatial support and resample for `Scene` and `OpticalImage`
- export new functions in package initializers
- add unit tests for new utilities

## Testing
- `pytest -q`