### PR TITLE
Add scene_to_file utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -16,6 +16,7 @@ from .scene_translate import scene_translate
 from .scene_rotate import scene_rotate
 from .scene_spatial_support import scene_spatial_support
 from .scene_spatial_resample import scene_spatial_resample
+from .scene_to_file import scene_to_file
 
 __all__ = [
     "Scene",
@@ -36,4 +37,5 @@ __all__ = [
     "scene_spatial_resample",
     "scene_create",
     "scene_photon_noise",
+    "scene_to_file",
 ]

--- a/python/isetcam/scene/scene_to_file.py
+++ b/python/isetcam/scene/scene_to_file.py
@@ -1,0 +1,27 @@
+"""Utilities for saving :class:`Scene` objects to disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scipy.io import savemat
+
+from .scene_class import Scene
+
+
+def scene_to_file(scene: Scene, path: str | Path) -> None:
+    """Save ``scene`` to ``path`` as a MATLAB ``.mat`` file.
+
+    Only the ``photons`` and ``wave`` fields are stored. The data is saved
+    under the variable name ``'scene'``.
+
+    Parameters
+    ----------
+    scene:
+        Scene instance to be saved.
+    path:
+        Destination of the MAT-file.
+    """
+    data = {"photons": scene.photons, "wave": scene.wave}
+    savemat(str(Path(path)), {"scene": data})
+

--- a/python/tests/test_scene_to_file.py
+++ b/python/tests/test_scene_to_file.py
@@ -1,0 +1,22 @@
+import numpy as np
+import scipy.io
+
+from isetcam.scene import scene_from_file, scene_to_file
+from isetcam import iset_root_path
+
+
+def test_scene_to_file_roundtrip(tmp_path):
+    root = iset_root_path()
+    fpath = root / 'data' / 'images' / 'rgb' / 'adelson.png'
+    wave = np.array([450, 550, 650, 750])
+    scene = scene_from_file(fpath, wave=wave)
+
+    mat_path = tmp_path / 'scene.mat'
+    scene_to_file(scene, mat_path)
+
+    mat = scipy.io.loadmat(mat_path, squeeze_me=True, struct_as_record=False)
+    assert 'scene' in mat
+    saved = mat['scene']
+    assert np.allclose(saved.photons, scene.photons)
+    assert np.array_equal(saved.wave.reshape(-1), scene.wave)
+


### PR DESCRIPTION
## Summary
- implement `scene_to_file` to save a scene's photons and wave to a MAT-file
- export `scene_to_file` from `isetcam.scene`
- test round‑tripping from `scene_from_file` via `scene_to_file`

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_scene_to_file.py`
- `PYTHONPATH=python pytest -q`