### PR TITLE
Add display_from_file utility

### DIFF
--- a/python/isetcam/display/__init__.py
+++ b/python/isetcam/display/__init__.py
@@ -1,10 +1,16 @@
-"""Display-related functions."""
+"""Display-related functions.
+
+Use :func:`display_create` to load one of the calibration files that ship
+with ISETCam, or :func:`display_from_file` to load a display definition from a
+MAT-file.
+"""
 
 from .display_class import Display
 from .display_create import display_create
 from .display_get import display_get
 from .display_set import display_set
 from .display_apply_gamma import display_apply_gamma
+from .display_from_file import display_from_file
 
 __all__ = [
     "Display",
@@ -12,4 +18,5 @@ __all__ = [
     "display_get",
     "display_set",
     "display_apply_gamma",
+    "display_from_file",
 ]

--- a/python/isetcam/display/display_from_file.py
+++ b/python/isetcam/display/display_from_file.py
@@ -1,0 +1,20 @@
+"""Load a :class:`Display` from a MATLAB ``.mat`` file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .display_create import _load_display
+from .display_class import Display
+
+
+def display_from_file(path: str | Path) -> Display:
+    """Load ``path`` and return a :class:`Display`.
+
+    Parameters
+    ----------
+    path : str or Path
+        MAT-file containing a display structure ``d``.
+    """
+    wave, spd, gamma = _load_display(Path(path))
+    return Display(spd=spd, wave=wave, gamma=gamma)

--- a/python/tests/test_display_from_file.py
+++ b/python/tests/test_display_from_file.py
@@ -1,0 +1,22 @@
+import numpy as np
+import scipy.io
+from dataclasses import asdict
+
+from isetcam.display import Display, display_from_file
+
+
+def test_display_from_file_roundtrip(tmp_path):
+    disp = Display(
+        spd=np.ones((2, 3)),
+        wave=np.array([500, 510]),
+        gamma=np.linspace(0, 1, 4).reshape(4, 1).repeat(3, axis=1),
+        name="demo",
+    )
+    path = tmp_path / "d.mat"
+    scipy.io.savemat(path, {"d": asdict(disp)})
+
+    loaded = display_from_file(path)
+    assert isinstance(loaded, Display)
+    assert np.allclose(loaded.spd, disp.spd)
+    assert np.array_equal(loaded.wave, disp.wave)
+    assert loaded.gamma is not None and np.allclose(loaded.gamma, disp.gamma)


### PR DESCRIPTION
## Summary
- load Display objects from a MAT-file
- re-export display_from_file in the display module
- test roundtrip saving/loading of Display data

## Testing
- `pytest -q`