### PR TITLE
Add color temperature to sRGB helper

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -566,6 +566,18 @@ temp, table = srgb_to_cct(srgb)
 
 Run `pytest -q` to confirm the color temperature routine functions correctly.
 
+## Color Temperature to sRGB
+
+`ctemp_to_srgb` converts a blackbody color temperature to an sRGB white point.
+
+```python
+from isetcam import ctemp_to_srgb
+
+srgb = ctemp_to_srgb(6500)
+```
+
+Run `pytest -q` after modifying the temperature conversion helper.
+
 ## Camera Dataclass
 
 A `Camera` bundles a sensor with an optical image. Accessor helpers retrieve or update fields just like the other dataclasses.

--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -44,6 +44,7 @@ from .srgb_xyz import (
     xyz_to_srgb,
 )
 from .srgb_to_cct import srgb_to_cct
+from .ctemp_to_srgb import ctemp_to_srgb
 from .init_default_spectrum import init_default_spectrum
 from .imgproc import image_distort
 from .metrics.ie_psnr import ie_psnr
@@ -94,6 +95,7 @@ __all__ = [
     'srgb_to_xyz',
     'xyz_to_srgb',
     'srgb_to_cct',
+    'ctemp_to_srgb',
     'init_default_spectrum',
     'image_distort',
     'ie_psnr',

--- a/python/isetcam/ctemp_to_srgb.py
+++ b/python/isetcam/ctemp_to_srgb.py
@@ -1,0 +1,42 @@
+"""Convert blackbody color temperature to sRGB."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .illuminant import illuminant_blackbody
+from .ie_xyz_from_energy import ie_xyz_from_energy
+from .srgb_xyz import xyz_to_srgb
+
+__all__ = ["ctemp_to_srgb"]
+
+
+def ctemp_to_srgb(temp: float | np.ndarray, wave: np.ndarray | None = None) -> np.ndarray:
+    """Return sRGB value for a blackbody at the given color temperature.
+
+    Parameters
+    ----------
+    temp : float or array-like
+        Blackbody color temperature(s) in Kelvin.
+    wave : array-like, optional
+        Sampled wavelengths in nanometers. Defaults to 400-700 nm in 10 nm steps.
+
+    Returns
+    -------
+    np.ndarray
+        sRGB values for each temperature. Shape is ``(n, 3)`` where ``n`` is the
+        number of temperatures, or ``(3,)`` when ``temp`` is scalar.
+    """
+    if wave is None:
+        wave = np.arange(400, 701, 10)
+    wave = np.asarray(wave, dtype=float).reshape(-1)
+    temps = np.asarray(temp, dtype=float).reshape(-1)
+
+    spd = np.stack([illuminant_blackbody(t, wave) for t in temps], axis=0)
+    xyz = ie_xyz_from_energy(spd, wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+
+    if srgb.shape[0] == 1:
+        return srgb[0]
+    return srgb
+

--- a/python/tests/test_ctemp_to_srgb.py
+++ b/python/tests/test_ctemp_to_srgb.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from isetcam import ctemp_to_srgb, ie_xyz_from_energy
+from isetcam.illuminant import illuminant_blackbody
+from isetcam.srgb_xyz import xyz_to_srgb
+
+
+def _expected(temp: float, wave: np.ndarray) -> np.ndarray:
+    spd = illuminant_blackbody(temp, wave)
+    xyz = ie_xyz_from_energy(spd[np.newaxis, :], wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    return srgb[0]
+
+
+def _expected_multi(temps: np.ndarray, wave: np.ndarray) -> np.ndarray:
+    spd = np.stack([illuminant_blackbody(t, wave) for t in temps], axis=0)
+    xyz = ie_xyz_from_energy(spd, wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    return srgb
+
+
+def test_ctemp_to_srgb_default_wave():
+    temps = [3000, 5500, 8000]
+    for t in temps:
+        srgb = ctemp_to_srgb(t)
+        wave = np.arange(400, 701, 10)
+        expected = _expected(t, wave)
+        assert np.allclose(srgb, expected)
+
+
+def test_ctemp_to_srgb_multi():
+    wave = np.arange(420, 681, 20)
+    temps = np.array([3500, 6500, 9000])
+    srgb = ctemp_to_srgb(temps, wave)
+    assert srgb.shape == (len(temps), 3)
+    expected = _expected_multi(temps, wave)
+    assert np.allclose(srgb, expected)
+


### PR DESCRIPTION
## Summary
- implement `ctemp_to_srgb` to convert blackbody temperature to sRGB
- expose helper in `isetcam.__init__`
- document usage in migration guide
- test new helper

## Testing
- `pytest -q`
