### PR TITLE
Add mk_inv_gamma_table utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -46,6 +46,7 @@ from .srgb_xyz import (
 from .srgb_to_cct import srgb_to_cct
 from .ctemp_to_srgb import ctemp_to_srgb
 from .init_default_spectrum import init_default_spectrum
+from .mk_inv_gamma_table import mk_inv_gamma_table
 from .imgproc import image_distort
 from .metrics.ie_psnr import ie_psnr
 from .metrics.scielab import scielab, sc_params, SCIELABParams
@@ -97,6 +98,7 @@ __all__ = [
     'srgb_to_cct',
     'ctemp_to_srgb',
     'init_default_spectrum',
+    'mk_inv_gamma_table',
     'image_distort',
     'ie_psnr',
     'scielab',

--- a/python/isetcam/mk_inv_gamma_table.py
+++ b/python/isetcam/mk_inv_gamma_table.py
@@ -1,0 +1,60 @@
+"""Generate an inverse gamma lookup table."""
+
+from __future__ import annotations
+
+import numpy as np
+import warnings
+
+
+def mk_inv_gamma_table(
+    gamma_table: np.ndarray, num_entries: int | None = None
+) -> np.ndarray:
+    """Compute inverse gamma mapping from intensity to digital levels.
+
+    Parameters
+    ----------
+    gamma_table : array-like
+        Gamma table mapping digital levels to linear intensity. Can be a
+        1-D or 2-D array.
+    num_entries : int, optional
+        Number of entries in the inverse table. Defaults to
+        ``4 * len(gamma_table)``.
+
+    Returns
+    -------
+    np.ndarray
+        Inverse gamma table with ``num_entries`` rows and the same number of
+        columns as ``gamma_table``.
+    """
+    gamma = np.asarray(gamma_table, dtype=float)
+    orig_shape = gamma.shape
+    if gamma.ndim == 1:
+        gamma = gamma.reshape(-1, 1)
+
+    n_rows, n_cols = gamma.shape
+    if num_entries is None:
+        num_entries = 4 * n_rows
+
+    inv = np.empty((num_entries, n_cols), dtype=float)
+    query = np.linspace(0, 1, num_entries)
+
+    for col in range(n_cols):
+        tbl = gamma[:, col]
+        if np.any(np.diff(tbl) <= 0):
+            warnings.warn(
+                f"Gamma table {col} NOT MONOTONIC. We are adjusting.",
+                UserWarning,
+            )
+            tbl = np.sort(tbl)
+            pos = np.where(np.diff(tbl) > 0)[0] + 1
+            pos = np.insert(pos, 0, 0)
+            mon_table = tbl[pos]
+        else:
+            mon_table = tbl
+            pos = np.arange(len(tbl))
+
+        inv[:, col] = np.interp(query, mon_table, pos)
+
+    if orig_shape == (n_rows,):
+        return inv[:, 0]
+    return inv

--- a/python/tests/test_mk_inv_gamma_table.py
+++ b/python/tests/test_mk_inv_gamma_table.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+
+from isetcam import mk_inv_gamma_table
+
+
+def test_mk_inv_gamma_table_monotonic():
+    gamma = np.linspace(0, 1, 4)
+    n_entries = 4 * len(gamma)
+    inv = mk_inv_gamma_table(gamma)
+    expected = np.interp(np.linspace(0, 1, n_entries), gamma, np.arange(gamma.size))
+    assert inv.shape == (n_entries,)
+    assert np.allclose(inv, expected)
+
+
+def test_mk_inv_gamma_table_nonmonotonic():
+    gamma = np.array([0.0, 0.2, 0.1, 1.0])
+    n_entries = 8
+    with pytest.warns(UserWarning):
+        inv = mk_inv_gamma_table(gamma, n_entries)
+    sorted_gamma = np.sort(gamma)
+    pos = np.where(np.diff(sorted_gamma) > 0)[0] + 1
+    pos = np.insert(pos, 0, 0)
+    expected = np.interp(np.linspace(0, 1, n_entries), sorted_gamma[pos], pos)
+    assert inv.shape == (n_entries,)
+    assert np.allclose(inv, expected)


### PR DESCRIPTION
## Summary
- implement `mk_inv_gamma_table` for inverse display gamma mapping
- export `mk_inv_gamma_table` in package init
- test monotonic and non-monotonic gamma table cases

## Testing
- `PYTHONPATH=$PWD/python pytest -q`