### PR TITLE
Add responsivity conversion utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -5,6 +5,7 @@ from .iset_root_path import iset_root_path
 from .vc_get_image_format import vc_get_image_format
 from .quanta2energy import quanta_to_energy
 from .energy_to_quanta import energy_to_quanta
+from .ie_responsivity_convert import ie_responsivity_convert
 from .ie_init import ie_init
 from .ie_init_session import ie_init_session
 from .luminance_from_energy import luminance_from_energy
@@ -61,6 +62,7 @@ __all__ = [
     'vc_get_image_format',
     'quanta_to_energy',
     'energy_to_quanta',
+    'ie_responsivity_convert',
     'luminance_from_energy',
     'luminance_from_photons',
     'scotopic_luminance_from_energy',

--- a/python/isetcam/ie_responsivity_convert.py
+++ b/python/isetcam/ie_responsivity_convert.py
@@ -1,0 +1,52 @@
+"""Convert spectral responsivity between energy and photon units."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .energy_to_quanta import energy_to_quanta
+from .quanta2energy import quanta_to_energy
+
+
+def ie_responsivity_convert(
+    responsivity: np.ndarray,
+    wavelength: np.ndarray,
+    method: str = "e2q",
+) -> tuple[np.ndarray, np.ndarray]:
+    """Convert responsivity curves between energy and quanta.
+
+    Parameters
+    ----------
+    responsivity : np.ndarray
+        Responsivity functions with wavelength along rows.
+    wavelength : array-like
+        Sampled wavelengths in nanometers.
+    method : str, optional
+        ``"e2q"`` converts energy-based responsivities for use with photon
+        inputs. ``"q2e"`` converts the opposite way.
+
+    Returns
+    -------
+    tuple of np.ndarray
+        ``(converted, scale)`` where ``converted`` is the converted
+        responsivity and ``scale`` is the per-wavelength scaling factor.
+    """
+    responsivity = np.asarray(responsivity, dtype=float)
+    wavelength = np.asarray(wavelength).reshape(-1)
+
+    if responsivity.shape[0] != len(wavelength):
+        raise ValueError("wavelength length must match responsivity rows")
+
+    method = method.lower()
+    max_trans = responsivity.max()
+    if method in {"e2q", "energy2quanta", "e2p", "energy2photons"}:
+        s_factor = quanta_to_energy(wavelength, np.ones(len(wavelength))).reshape(-1)
+    elif method in {"q2e", "quanta2energy", "p2e", "photons2energy"}:
+        s_factor = energy_to_quanta(wavelength, np.ones(len(wavelength))).reshape(-1)
+    else:
+        raise ValueError("Unknown method")
+
+    converted = s_factor[:, np.newaxis] * responsivity
+    converted *= max_trans / converted.max()
+
+    return converted, s_factor

--- a/python/tests/test_ie_responsivity_convert.py
+++ b/python/tests/test_ie_responsivity_convert.py
@@ -1,0 +1,18 @@
+import numpy as np
+from isetcam import ie_responsivity_convert
+
+
+def test_e2q_q2e_round_trip():
+    wave = np.arange(400, 501, 20)
+    resp = np.random.rand(len(wave), 3)
+    resp_q, _ = ie_responsivity_convert(resp, wave, 'e2q')
+    resp_e, _ = ie_responsivity_convert(resp_q, wave, 'q2e')
+    assert np.allclose(resp_e, resp)
+
+
+def test_q2e_e2q_round_trip():
+    wave = np.arange(450, 551, 25)
+    resp = np.random.rand(len(wave), 2)
+    resp_e, _ = ie_responsivity_convert(resp, wave, 'q2e')
+    resp_q, _ = ie_responsivity_convert(resp_e, wave, 'e2q')
+    assert np.allclose(resp_q, resp)


### PR DESCRIPTION
## Summary
- add `ie_responsivity_convert` to convert responsivity curves between energy and quanta
- export `ie_responsivity_convert`
- test round-trip of responsivity conversion

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_ie_responsivity_convert.py`
- `PYTHONPATH=python pytest -q`