### PR TITLE
Add SSIM metric wrapper

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -647,6 +647,19 @@ print(f"PSNR: {score:.2f} dB")
 ```
 
 As always, run `pytest -q` to confirm these functions behave as expected.
+
+## Structural Similarity (SSIM)
+
+Use `ssim_metric` to compute the structural similarity index and map
+between two images.
+
+```python
+from isetcam.metrics import ssim_metric
+
+score, ssim_map = ssim_metric(img1, img2)
+```
+
+Run `pytest -q` after modifying the SSIM implementation.
 ## Scene and Optical Image Rotation
 
 The helpers `scene_rotate` and `oi_rotate` rotate photon data while optionally filling empty regions. Pass an angle in degrees.

--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -52,6 +52,7 @@ from .imgproc import image_distort, ie_internal_to_display
 from .metrics.ie_psnr import ie_psnr
 from .metrics.scielab import scielab, sc_params, SCIELABParams
 from .metrics.xyz_to_vsnr import xyz_to_vsnr
+from .metrics.ssim_metric import ssim_metric
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
@@ -108,6 +109,7 @@ __all__ = [
     'sc_params',
     'SCIELABParams',
     'xyz_to_vsnr',
+    'ssim_metric',
     'iset_root_path',
     'ie_init',
     'ie_init_session',

--- a/python/isetcam/metrics/__init__.py
+++ b/python/isetcam/metrics/__init__.py
@@ -7,6 +7,7 @@ from .delta_e_94 import delta_e_94
 from .delta_e_2000 import delta_e_2000
 from .delta_e_uv import delta_e_uv
 from .xyz_to_vsnr import xyz_to_vsnr
+from .ssim_metric import ssim_metric
 
 __all__ = [
     "ie_psnr",
@@ -18,4 +19,5 @@ __all__ = [
     "delta_e_2000",
     "delta_e_uv",
     "xyz_to_vsnr",
+    "ssim_metric",
 ]

--- a/python/isetcam/metrics/ssim_metric.py
+++ b/python/isetcam/metrics/ssim_metric.py
@@ -1,0 +1,37 @@
+"""Structural Similarity (SSIM) image quality metric."""
+
+from __future__ import annotations
+
+import numpy as np
+from skimage.metrics import structural_similarity
+
+
+def ssim_metric(img1: np.ndarray, img2: np.ndarray) -> tuple[float, np.ndarray]:
+    """Return SSIM value and per-pixel map between ``img1`` and ``img2``.
+
+    Parameters
+    ----------
+    img1, img2 : np.ndarray
+        Input images with the same shape. Values are assumed to lie in
+        the range [0, 1].
+
+    Returns
+    -------
+    float
+        Overall SSIM value.
+    np.ndarray
+        SSIM map with the same shape as the inputs.
+    """
+    img1 = np.asarray(img1, dtype=float)
+    img2 = np.asarray(img2, dtype=float)
+    if img1.shape != img2.shape:
+        raise ValueError("Input images must have the same shape")
+
+    kwargs = {"data_range": 1.0}
+    if img1.ndim == 3:
+        kwargs["channel_axis"] = -1
+    score, s_map = structural_similarity(img1, img2, full=True, **kwargs)
+    return score, s_map
+
+
+__all__ = ["ssim_metric"]

--- a/python/tests/test_ssim_metric.py
+++ b/python/tests/test_ssim_metric.py
@@ -1,0 +1,29 @@
+import numpy as np
+from isetcam.metrics import ssim_metric
+
+
+def test_ssim_identical():
+    img = np.random.rand(8, 8)
+    val, s_map = ssim_metric(img, img)
+    assert val == 1.0
+    assert np.allclose(s_map, 1.0)
+
+
+def test_ssim_known_difference():
+    img1 = np.zeros((8, 8))
+    img2 = np.ones((8, 8))
+    val, s_map = ssim_metric(img1, img2)
+    expected = 9.999000099990002e-05
+    assert np.isclose(val, expected)
+    assert np.allclose(s_map, expected)
+
+
+def test_ssim_shape_mismatch():
+    img1 = np.zeros((8, 8))
+    img2 = np.zeros((8, 9))
+    try:
+        ssim_metric(img1, img2)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("ValueError not raised for mismatched shapes")


### PR DESCRIPTION
## Summary
- implement `ssim_metric` wrapper for `skimage.metrics.structural_similarity`
- expose `ssim_metric` in package exports
- document SSIM usage
- add unit tests for SSIM metric

## Testing
- `pytest -q`
- `pytest -q python/tests/test_ssim_metric.py`