### PR TITLE
Add color_block_matrix utility

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -446,6 +446,25 @@ M2 = color_transform_matrix(src=src, dst=dst, offset=True)
 After adding these modules remember to run the unit tests again with
 `pytest -q` to confirm everything works.
 
+## Color Block Matrix
+
+Use `color_block_matrix` to visualize a spectral distribution as RGB values.
+The default matrix spans 400--700 nm in 10 nm steps.  Other wavelength
+sampling is handled through interpolation with optional extrapolation for
+out‑of‑range values.
+
+```python
+from isetcam import color_block_matrix
+
+wave = np.arange(400, 701, 10)
+B = color_block_matrix(wave)
+
+wave2 = np.array([350, 400, 500, 650, 750])
+B2 = color_block_matrix(wave2, extrap_val=0.1)
+```
+
+Run `pytest -q` after modifying the block matrix routine.
+
 ## Internal Color to Display Transform
 
 `ie_internal_to_display` computes a matrix that maps values in an internal

--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -16,6 +16,7 @@ from .ie_xyz_from_energy import ie_xyz_from_energy
 from .ie_xyz_from_photons import ie_xyz_from_photons
 from .ie_color_transform import ie_color_transform
 from .color_transform_matrix import color_transform_matrix
+from .color_block_matrix import color_block_matrix
 from .chromaticity import chromaticity
 from .cct import cct
 from .cct_to_sun import cct_to_sun
@@ -72,6 +73,7 @@ __all__ = [
     'ie_xyz_from_photons',
     'ie_color_transform',
     'color_transform_matrix',
+    'color_block_matrix',
     'chromaticity',
     'cct',
     'cct_to_sun',

--- a/python/isetcam/color_block_matrix.py
+++ b/python/isetcam/color_block_matrix.py
@@ -1,0 +1,66 @@
+"""Block matrix used to visualize spectral data as RGB."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def color_block_matrix(
+    wave: np.ndarray,
+    extrap_val: float = 0.0,
+    white_spd: np.ndarray | None = None,
+) -> np.ndarray:
+    """Return a block matrix mapping a spectrum to RGB values.
+
+    Parameters
+    ----------
+    wave : array-like
+        Wavelength samples in nanometers.
+    extrap_val : float, optional
+        Value used outside the 400--700 nm range when ``wave`` extends
+        beyond the defaults. Default ``0.0``.
+    white_spd : array-like, optional
+        Photon spectrum that should map to ``(1, 1, 1)``. When provided the
+        returned matrix is premultiplied by ``diag(1 / white_spd)``.
+
+    Returns
+    -------
+    np.ndarray
+        Matrix with shape ``(len(wave), 3)`` that converts spectra to RGB.
+    """
+    wave = np.asarray(wave, dtype=float).ravel()
+    if wave.ndim != 1:
+        raise ValueError("wave must be a 1-D array")
+
+    default_wave = np.arange(400, 701, 10, dtype=float)
+
+    b = 10
+    g = 8
+    r = 31 - b - g
+    default_matrix = np.vstack(
+        [
+            np.concatenate([np.zeros(b), np.zeros(g), np.ones(r)]),
+            np.concatenate([np.zeros(b), np.ones(g), np.zeros(r)]),
+            np.concatenate([np.ones(b), np.zeros(g), np.zeros(r)]),
+        ]
+    ).T
+
+    if wave.size == default_wave.size and np.allclose(wave, default_wave):
+        b_matrix = default_matrix.copy()
+    else:
+        b_matrix = np.zeros((wave.size, 3), dtype=float)
+        for i in range(3):
+            b_matrix[:, i] = np.interp(
+                wave, default_wave, default_matrix[:, i], left=extrap_val, right=extrap_val
+            )
+
+    # Normalize so that each column sums to one
+    b_matrix /= b_matrix.sum(axis=0, keepdims=True)
+
+    if white_spd is not None:
+        white_spd = np.asarray(white_spd, dtype=float).ravel()
+        if white_spd.size != wave.size:
+            raise ValueError("white_spd must match wave length")
+        b_matrix = np.diag(1.0 / white_spd) @ b_matrix
+
+    return b_matrix

--- a/python/tests/test_color_block_matrix.py
+++ b/python/tests/test_color_block_matrix.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from isetcam import color_block_matrix
+
+
+def test_default_block_matrix():
+    wave = np.arange(400, 701, 10)
+    M = color_block_matrix(wave)
+    assert M.shape == (wave.size, 3)
+    # Each column sums to 1
+    assert np.allclose(M.sum(axis=0), 1.0)
+    # Check regions
+    assert np.allclose(M[:10, 2], 0.1)  # blue region
+    assert np.allclose(M[10:18, 1], 1 / 8)  # green region
+    assert np.allclose(M[18:, 0], 1 / 13)  # red region
+
+
+def test_extrapolation():
+    wave = np.array([350, 400, 500, 650, 750])
+    M = color_block_matrix(wave, extrap_val=0.1)
+    # matrix size
+    assert M.shape == (wave.size, 3)
+    assert np.allclose(M.sum(axis=0), 1.0)
+    # extrapolated entries should be non-zero
+    assert np.all(M[0] > 0)
+    assert np.all(M[-1] > 0)


### PR DESCRIPTION
## Summary
- implement `color_block_matrix` to generate a block RGB matrix
- export the new helper in the package
- document its usage in the migration guide
- test default matrix generation and extrapolation behavior

## Testing
- `pytest -q`