### PR TITLE
Add srgb_parameters utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -46,6 +46,7 @@ from .srgb_xyz import (
     xyz_to_srgb,
 )
 from .srgb_to_cct import srgb_to_cct
+from .srgb_parameters import srgb_parameters
 from .ctemp_to_srgb import ctemp_to_srgb
 from .init_default_spectrum import init_default_spectrum
 from .mk_inv_gamma_table import mk_inv_gamma_table
@@ -101,6 +102,7 @@ __all__ = [
     'srgb_to_xyz',
     'xyz_to_srgb',
     'srgb_to_cct',
+    'srgb_parameters',
     'ctemp_to_srgb',
     'init_default_spectrum',
     'mk_inv_gamma_table',

--- a/python/isetcam/srgb_parameters.py
+++ b/python/isetcam/srgb_parameters.py
@@ -1,0 +1,42 @@
+"""Return sRGB chromaticity and white point parameters."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .xyy_to_xyz import xyy_to_xyz
+
+
+def srgb_parameters(val: str = "all") -> np.ndarray:
+    """Return sRGB display parameters.
+
+    Parameters
+    ----------
+    val : {'all', 'chromaticity', 'luminance', 'xyywhite', 'XYZwhite'}, optional
+        Portion of the parameter matrix to return. Defaults to ``'all'``.
+
+    Returns
+    -------
+    np.ndarray
+        Requested parameters from the sRGB standard.
+    """
+    srgbP = np.array([
+        [0.6400, 0.3000, 0.1500, 0.3127],
+        [0.3300, 0.6000, 0.0600, 0.3290],
+        [0.2126, 0.7152, 0.0722, 1.0000],
+    ], dtype=float)
+
+    val = val.lower()
+    if val == "all":
+        return srgbP
+    if val == "chromaticity":
+        return srgbP[0:2, 0:3]
+    if val == "luminance":
+        return srgbP[2, 0:3]
+    if val == "xyywhite":
+        return srgbP[:, 3]
+    if val == "xyzwhite":
+        xyY = srgbP[:, 3]
+        return xyy_to_xyz(xyY.reshape(1, 3)).reshape(3)
+    raise ValueError(f"Unknown request '{val}'")
+

--- a/python/tests/test_srgb_parameters.py
+++ b/python/tests/test_srgb_parameters.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from isetcam import srgb_parameters, xyy_to_xyz
+
+
+def test_srgb_parameters_all():
+    params = srgb_parameters()
+    expected = np.array([
+        [0.6400, 0.3000, 0.1500, 0.3127],
+        [0.3300, 0.6000, 0.0600, 0.3290],
+        [0.2126, 0.7152, 0.0722, 1.0000],
+    ])
+    assert np.allclose(params, expected)
+
+
+def test_srgb_parameters_subvalues():
+    chroma = srgb_parameters("chromaticity")
+    lum = srgb_parameters("luminance")
+    xyY = srgb_parameters("xyywhite")
+    xyz = srgb_parameters("XYZwhite")
+
+    base = np.array([
+        [0.6400, 0.3000, 0.1500, 0.3127],
+        [0.3300, 0.6000, 0.0600, 0.3290],
+        [0.2126, 0.7152, 0.0722, 1.0000],
+    ])
+
+    assert np.allclose(chroma, base[0:2, 0:3])
+    assert np.allclose(lum, base[2, 0:3])
+    assert np.allclose(xyY, base[:, 3])
+
+    expected_xyz = xyy_to_xyz(xyY.reshape(1, 3)).reshape(3)
+    assert np.allclose(xyz, expected_xyz)
+


### PR DESCRIPTION
## Summary
- port srgbParameters.m to `srgb_parameters` Python function
- export new helper in package `__init__`
- add tests for srgb parameters

## Testing
- `PYTHONPATH=python pytest -q`
