### PR TITLE
Add spd_to_cct utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -46,6 +46,7 @@ from .srgb_xyz import (
     xyz_to_srgb,
 )
 from .srgb_to_cct import srgb_to_cct
+from .spd_to_cct import spd_to_cct
 from .srgb_parameters import srgb_parameters
 from .ctemp_to_srgb import ctemp_to_srgb
 from .init_default_spectrum import init_default_spectrum
@@ -102,6 +103,7 @@ __all__ = [
     'srgb_to_xyz',
     'xyz_to_srgb',
     'srgb_to_cct',
+    'spd_to_cct',
     'srgb_parameters',
     'ctemp_to_srgb',
     'init_default_spectrum',

--- a/python/isetcam/spd_to_cct.py
+++ b/python/isetcam/spd_to_cct.py
@@ -1,0 +1,47 @@
+"""Estimate correlated color temperature from a spectral power distribution."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .ie_xyz_from_energy import ie_xyz_from_energy
+from .xyz_to_uv import xyz_to_uv
+from .cct import cct
+
+__all__ = ["spd_to_cct"]
+
+
+def spd_to_cct(wave: np.ndarray, spd: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return estimated color temperature and ``uv`` chromaticities.
+
+    Parameters
+    ----------
+    wave : np.ndarray
+        Sampled wavelengths in nanometers.
+    spd : np.ndarray
+        Spectral power distribution. The first dimension should correspond to
+        ``wave``. Multiple SPDs can be provided using additional columns.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        The estimated color temperature(s) in Kelvin and the corresponding
+        ``(u, v)`` coordinates.
+    """
+    wave = np.asarray(wave, dtype=float).reshape(-1)
+    spd = np.asarray(spd, dtype=float)
+
+    if spd.ndim == 1:
+        spd = spd[:, np.newaxis]
+
+    if spd.shape[0] != wave.size:
+        if spd.shape[1] == wave.size:
+            spd = spd.T
+        else:
+            raise ValueError("SPD shape does not match wavelength array")
+
+    xyz = ie_xyz_from_energy(spd.T, wave)
+    uv = xyz_to_uv(xyz, mode="uv")
+    temps = np.array([cct(uv[i].reshape(1, 2)) for i in range(uv.shape[0])])
+
+    return temps.squeeze(), uv

--- a/python/tests/test_spd_to_cct.py
+++ b/python/tests/test_spd_to_cct.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from isetcam import spd_to_cct
+from isetcam.illuminant import illuminant_blackbody
+
+
+def test_spd_to_cct_single():
+    wave = np.arange(400, 701, 10)
+    temp = 6500
+    spd = illuminant_blackbody(temp, wave)
+    est, uv = spd_to_cct(wave, spd)
+    assert np.isclose(est, temp, atol=500)
+    assert uv.shape == (1, 2)
+
+
+def test_spd_to_cct_multi():
+    wave = np.arange(400, 701, 10)
+    temps = np.array([4000, 8000])
+    spd = np.vstack([illuminant_blackbody(t, wave) for t in temps]).T
+    est, uv = spd_to_cct(wave, spd)
+    assert uv.shape == (len(temps), 2)
+    assert np.allclose(est, temps, atol=500)


### PR DESCRIPTION
## Summary
- add `spd_to_cct` for estimating color temperature from SPD data
- export the function in `isetcam.__init__`
- test single and multi-SPD cases

## Testing
- `pytest -q`
