### PR TITLE
Add MAT-file saving helpers

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -281,6 +281,23 @@ scene_to_file(scene, 'scene.mat')
 disp = display_from_file('display.mat')
 ```
 
+## Saving Objects to MAT-files
+
+Dataclasses can be written back out to MATLAB compatible files using the
+matching ``*_to_file`` helpers.
+
+```python
+from isetcam.sensor import sensor_to_file, sensor_from_file
+from isetcam.opticalimage import oi_to_file, oi_from_file
+from isetcam.display import display_to_file, display_from_file, Display
+from isetcam.camera import camera_to_file, Camera
+
+sensor_to_file(sensor, 'mysensor.mat')
+oi_to_file(oi, 'myoi.mat')
+display_to_file(disp, 'display.mat')
+camera_to_file(Camera(sensor=sensor, optical_image=oi), 'cam.mat')
+```
+
 Remember to run `pytest -q` after using these I/O helpers.
 
 ## Updated Tests

--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -61,6 +61,10 @@ from .metrics.ssim_metric import ssim_metric
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
 from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc, metrics
+from .opticalimage import oi_to_file
+from .sensor import sensor_to_file
+from .display import display_to_file
+from .camera import camera_to_file
 
 __all__ = [
     'vc_constants',
@@ -129,4 +133,8 @@ __all__ = [
     'illuminant',
     'imgproc',
     'metrics',
+    'oi_to_file',
+    'sensor_to_file',
+    'display_to_file',
+    'camera_to_file',
 ]

--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -3,9 +3,11 @@
 from .camera_class import Camera
 from .camera_get import camera_get
 from .camera_set import camera_set
+from .camera_to_file import camera_to_file
 
 __all__ = [
     "Camera",
     "camera_get",
     "camera_set",
+    "camera_to_file",
 ]

--- a/python/isetcam/camera/camera_to_file.py
+++ b/python/isetcam/camera/camera_to_file.py
@@ -1,0 +1,20 @@
+"""Utilities for saving :class:`Camera` objects to disk."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+
+from scipy.io import savemat
+
+from .camera_class import Camera
+
+
+def camera_to_file(camera: Camera, path: str | Path) -> None:
+    """Save ``camera`` to ``path`` as a MATLAB ``.mat`` file.
+
+    The sensor and optical image dataclasses are stored as nested structures
+    under the variable name ``'camera'``.
+    """
+    data = asdict(camera)
+    savemat(str(Path(path)), {"camera": data})

--- a/python/isetcam/display/__init__.py
+++ b/python/isetcam/display/__init__.py
@@ -11,6 +11,7 @@ from .display_get import display_get
 from .display_set import display_set
 from .display_apply_gamma import display_apply_gamma
 from .display_from_file import display_from_file
+from .display_to_file import display_to_file
 
 __all__ = [
     "Display",
@@ -19,4 +20,5 @@ __all__ = [
     "display_set",
     "display_apply_gamma",
     "display_from_file",
+    "display_to_file",
 ]

--- a/python/isetcam/display/display_to_file.py
+++ b/python/isetcam/display/display_to_file.py
@@ -1,0 +1,24 @@
+"""Utilities for saving :class:`Display` objects to disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scipy.io import savemat
+
+from .display_class import Display
+
+
+def display_to_file(display: Display, path: str | Path) -> None:
+    """Save ``display`` to ``path`` as a MATLAB ``.mat`` file.
+
+    The structure is stored under the variable name ``'d'``.
+    """
+    data = {
+        "spd": display.spd,
+        "wave": display.wave,
+        "gamma": display.gamma,
+    }
+    if display.name is not None:
+        data["name"] = display.name
+    savemat(str(Path(path)), {"d": data})

--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -7,6 +7,7 @@ from .oi_get import oi_get
 from .oi_set import oi_set
 from .oi_from_file import oi_from_file
 from .oi_photon_noise import oi_photon_noise
+from .oi_to_file import oi_to_file
 from .oi_crop import oi_crop
 from .oi_pad import oi_pad
 from .oi_rotate import oi_rotate
@@ -28,4 +29,5 @@ __all__ = [
     "oi_spatial_support",
     "oi_spatial_resample",
     "oi_photon_noise",
+    "oi_to_file",
 ]

--- a/python/isetcam/opticalimage/oi_to_file.py
+++ b/python/isetcam/opticalimage/oi_to_file.py
@@ -1,0 +1,21 @@
+"""Utilities for saving :class:`OpticalImage` objects to disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scipy.io import savemat
+
+from .oi_class import OpticalImage
+
+
+def oi_to_file(oi: OpticalImage, path: str | Path) -> None:
+    """Save ``oi`` to ``path`` as a MATLAB ``.mat`` file.
+
+    Only the ``photons`` and ``wave`` fields are stored under the variable
+    name ``'oi'``.
+    """
+    data = {"photons": oi.photons, "wave": oi.wave}
+    if oi.name is not None:
+        data["name"] = oi.name
+    savemat(str(Path(path)), {"oi": data})

--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -9,6 +9,7 @@ from .sensor_get import sensor_get
 from .sensor_set import sensor_set
 from .sensor_from_file import sensor_from_file
 from .sensor_compute import sensor_compute
+from .sensor_to_file import sensor_to_file
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -47,4 +48,5 @@ __all__ = [
     "sensor_set",
     "sensor_from_file",
     "sensor_compute",
+    "sensor_to_file",
 ]

--- a/python/isetcam/sensor/sensor_to_file.py
+++ b/python/isetcam/sensor/sensor_to_file.py
@@ -1,0 +1,21 @@
+"""Utilities for saving :class:`Sensor` objects to disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scipy.io import savemat
+
+from .sensor_class import Sensor
+
+
+def sensor_to_file(sensor: Sensor, path: str | Path) -> None:
+    """Save ``sensor`` to ``path`` as a MATLAB ``.mat`` file."""
+    data = {
+        "volts": sensor.volts,
+        "exposure_time": sensor.exposure_time,
+        "wave": sensor.wave,
+    }
+    if sensor.name is not None:
+        data["name"] = sensor.name
+    savemat(str(Path(path)), {"sensor": data})

--- a/python/tests/test_camera_to_file.py
+++ b/python/tests/test_camera_to_file.py
@@ -1,0 +1,22 @@
+import numpy as np
+import scipy.io
+
+from isetcam.sensor import Sensor
+from isetcam.opticalimage import OpticalImage
+from isetcam.camera import Camera, camera_to_file
+
+
+def test_camera_to_file_nested(tmp_path):
+    sensor = Sensor(volts=np.ones((2, 2)), exposure_time=0.1, wave=np.array([500, 600]), name="s")
+    oi = OpticalImage(photons=np.ones((2, 2, 2)), wave=np.array([500, 600]), name="oi")
+    cam = Camera(sensor=sensor, optical_image=oi, name="cam")
+    path = tmp_path / "cam.mat"
+    camera_to_file(cam, path)
+
+    mat = scipy.io.loadmat(path, squeeze_me=True, struct_as_record=False)
+    assert "camera" in mat
+    saved = mat["camera"]
+    assert np.allclose(saved.sensor.volts, sensor.volts)
+    assert np.array_equal(saved.sensor.wave.reshape(-1), sensor.wave)
+    assert np.allclose(saved.optical_image.photons, oi.photons)
+    assert saved.name == "cam"

--- a/python/tests/test_display_to_file.py
+++ b/python/tests/test_display_to_file.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from isetcam.display import Display, display_from_file, display_to_file
+
+
+def test_display_to_file_roundtrip(tmp_path):
+    disp = Display(
+        spd=np.ones((2, 3)),
+        wave=np.array([500, 510]),
+        gamma=np.linspace(0, 1, 4).reshape(4, 1).repeat(3, axis=1),
+        name="demo",
+    )
+    path = tmp_path / "d.mat"
+    display_to_file(disp, path)
+
+    loaded = display_from_file(path)
+    assert isinstance(loaded, Display)
+    assert np.allclose(loaded.spd, disp.spd)
+    assert np.array_equal(loaded.wave, disp.wave)
+    assert loaded.gamma is not None and np.allclose(loaded.gamma, disp.gamma)

--- a/python/tests/test_oi_to_file.py
+++ b/python/tests/test_oi_to_file.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from isetcam.opticalimage import OpticalImage, oi_from_file, oi_to_file
+
+
+def test_oi_to_file_roundtrip(tmp_path):
+    oi = OpticalImage(photons=np.ones((2, 2, 3)), wave=np.array([450, 550, 650]), name="foo")
+    path = tmp_path / "oi.mat"
+    oi_to_file(oi, path)
+
+    loaded = oi_from_file(path)
+    assert isinstance(loaded, OpticalImage)
+    assert np.allclose(loaded.photons, oi.photons)
+    assert np.array_equal(loaded.wave, oi.wave)
+    assert loaded.name == oi.name

--- a/python/tests/test_sensor_to_file.py
+++ b/python/tests/test_sensor_to_file.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from isetcam.sensor import Sensor, sensor_from_file, sensor_to_file
+
+
+def test_sensor_to_file_roundtrip(tmp_path):
+    s = Sensor(volts=np.array([[1.0, 2.0]]), exposure_time=0.05, wave=np.array([500, 600]), name="demo")
+    path = tmp_path / "sensor.mat"
+    sensor_to_file(s, path)
+
+    loaded = sensor_from_file(path)
+    assert isinstance(loaded, Sensor)
+    assert np.allclose(loaded.volts, s.volts)
+    assert loaded.exposure_time == s.exposure_time
+    assert np.array_equal(loaded.wave, s.wave)
+    assert loaded.name == s.name


### PR DESCRIPTION
## Summary
- add `*_to_file` helpers for optical images, sensors, displays, and cameras
- re-export new helpers through module initializers
- document saving objects to MAT-files
- add unit tests covering new save functions

## Testing
- `pytest -q`