### PR TITLE
Add dependency metadata for python package

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -2,7 +2,8 @@
 
 This directory contains experimental Python code that mirrors portions of the
 MATLAB ISETCam toolbox.  To use these modules, activate the Python environment
-that accompanies the MATLAB examples.
+that accompanies the MATLAB examples. Installing the package will pull in
+`numpy`, `scipy`, `pillow`, `imageio`, and `scikit-image` automatically.
 
 ```bash
 # Create the environment
@@ -14,7 +15,7 @@ conda activate py39
 # Install the dependencies
 pip install -r requirements.txt
 
-# Install the package in editable mode
+# Install the package in editable mode (installs the requirements as well)
 pip install -e .
 ```
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,5 +11,12 @@ requires-python = ">=3.8"
 authors = [{name = "ISETCam Team"}]
 license = {text = "MIT"}
 
+[project.dependencies]
+numpy = "*"
+scipy = "*"
+pillow = "*"
+imageio = "*"
+scikit-image = "*"
+
 [project.optional-dependencies]
 tests = ["pytest"]


### PR DESCRIPTION
## Summary
- include runtime dependency table in `pyproject.toml`
- document that installing the package installs requirements automatically

## Testing
- `pytest -q`