### PR TITLE
Add OpenEXR IO helpers

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -65,6 +65,7 @@ from .opticalimage import oi_to_file
 from .sensor import sensor_to_file
 from .display import display_to_file
 from .camera import camera_to_file
+from .io import openexr_read, openexr_write
 
 __all__ = [
     'vc_constants',
@@ -137,4 +138,6 @@ __all__ = [
     'sensor_to_file',
     'display_to_file',
     'camera_to_file',
+    'openexr_read',
+    'openexr_write',
 ]

--- a/python/isetcam/io/__init__.py
+++ b/python/isetcam/io/__init__.py
@@ -1,0 +1,6 @@
+"""Input/output utilities."""
+
+from .openexr_read import openexr_read
+from .openexr_write import openexr_write
+
+__all__ = ["openexr_read", "openexr_write"]

--- a/python/isetcam/io/openexr_read.py
+++ b/python/isetcam/io/openexr_read.py
@@ -1,0 +1,71 @@
+"""Read OpenEXR images with optional OpenEXR bindings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import OpenEXR  # type: ignore
+    import Imath  # type: ignore
+except Exception:  # pragma: no cover - library may not be present
+    OpenEXR = None  # type: ignore
+    Imath = None  # type: ignore
+
+import imageio.v2 as iio
+
+
+def _read_with_openexr(path: Path) -> Dict[str, np.ndarray]:
+    """Read using the OpenEXR Python bindings."""
+    assert OpenEXR is not None and Imath is not None
+    exr = OpenEXR.InputFile(str(path))
+    header = exr.header()
+    dw = header["dataWindow"]
+    width = dw.max.x - dw.min.x + 1
+    height = dw.max.y - dw.min.y + 1
+    channels: Dict[str, np.ndarray] = {}
+    for name in header["channels"].keys():
+        pt = Imath.PixelType(Imath.PixelType.FLOAT)
+        raw = exr.channel(name, pt)
+        arr = np.frombuffer(raw, dtype=np.float32)
+        channels[name] = arr.reshape(height, width)
+    exr.close()
+    return channels
+
+
+def _read_with_imageio(path: Path) -> Dict[str, np.ndarray]:
+    """Read using the imageio FreeImage backend."""
+    arr = np.asarray(iio.imread(str(path)), dtype=np.float32)
+    if arr.ndim == 2:
+        arr = arr[:, :, None]
+    n_chan = arr.shape[2]
+    if n_chan == 1:
+        names = ["Y"]
+    elif n_chan == 3:
+        names = ["R", "G", "B"]
+    elif n_chan == 4:
+        names = ["R", "G", "B", "A"]
+    else:
+        names = [f"channel{i}" for i in range(n_chan)]
+    return {name: arr[:, :, i] for i, name in enumerate(names)}
+
+
+def openexr_read(path: str | Path) -> Dict[str, np.ndarray]:
+    """Load an OpenEXR image from ``path``.
+
+    Parameters
+    ----------
+    path:
+        File to read.
+
+    Returns
+    -------
+    dict
+        Mapping of channel names to 2-D ``float32`` arrays.
+    """
+    p = Path(path)
+    if OpenEXR is not None:
+        return _read_with_openexr(p)
+    return _read_with_imageio(p)

--- a/python/isetcam/io/openexr_write.py
+++ b/python/isetcam/io/openexr_write.py
@@ -1,0 +1,55 @@
+"""Write images to OpenEXR files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import OpenEXR  # type: ignore
+    import Imath  # type: ignore
+except Exception:  # pragma: no cover - library may not be present
+    OpenEXR = None  # type: ignore
+    Imath = None  # type: ignore
+
+import imageio.v2 as iio
+
+
+def _write_with_openexr(path: Path, channels: Mapping[str, np.ndarray]) -> None:
+    assert OpenEXR is not None and Imath is not None
+    keys = list(channels.keys())
+    arrays = [np.asarray(channels[k], dtype=np.float32) for k in keys]
+    height, width = arrays[0].shape
+    for arr in arrays:
+        if arr.shape != (height, width):
+            raise ValueError("All channels must have the same shape")
+    header = OpenEXR.Header(width, height)
+    for name in keys:
+        header["channels"][name] = Imath.Channel(Imath.PixelType(Imath.PixelType.FLOAT))
+    exr = OpenEXR.OutputFile(str(path), header)
+    exr.writePixels({name: arr.tobytes() for name, arr in zip(keys, arrays)})
+    exr.close()
+
+
+def _write_with_imageio(path: Path, channels: Mapping[str, np.ndarray]) -> None:
+    keys = list(channels.keys())
+    arrays = [np.asarray(channels[k], dtype=np.float32) for k in keys]
+    height, width = arrays[0].shape
+    for arr in arrays:
+        if arr.shape != (height, width):
+            raise ValueError("All channels must have the same shape")
+    if len(arrays) > 4:
+        raise ValueError("imageio backend supports at most 4 channels")
+    data = np.stack(arrays, axis=-1)
+    iio.imwrite(str(path), data, format="EXR-FI")
+
+
+def openexr_write(path: str | Path, channels: Mapping[str, np.ndarray]) -> None:
+    """Save ``channels`` to ``path`` as an OpenEXR file."""
+    p = Path(path)
+    if OpenEXR is not None:
+        _write_with_openexr(p, channels)
+    else:
+        _write_with_imageio(p, channels)

--- a/python/tests/test_openexr_io.py
+++ b/python/tests/test_openexr_io.py
@@ -1,0 +1,45 @@
+import io
+import numpy as np
+import pytest
+
+from isetcam.io import openexr_read, openexr_write
+
+
+def _backend_available() -> bool:
+    try:
+        import OpenEXR  # noqa: F401
+        return True
+    except Exception:
+        pass
+    import imageio.v2 as iio
+    try:
+        with iio.get_writer(io.BytesIO(), format='EXR-FI'):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _backend_available(), reason="OpenEXR support not available")
+def test_openexr_roundtrip_rgb(tmp_path):
+    channels = {
+        'R': np.full((4, 3), 0.1, dtype=np.float32),
+        'G': np.full((4, 3), 0.2, dtype=np.float32),
+        'B': np.full((4, 3), 0.3, dtype=np.float32),
+    }
+    path = tmp_path / 'rgb.exr'
+    openexr_write(path, channels)
+    loaded = openexr_read(path)
+    assert set(loaded.keys()) == set(channels.keys())
+    for k in channels:
+        assert np.allclose(loaded[k], channels[k])
+
+
+@pytest.mark.skipif(not _backend_available(), reason="OpenEXR support not available")
+def test_openexr_roundtrip_single(tmp_path):
+    channels = {'Y': np.random.rand(2, 2).astype(np.float32)}
+    path = tmp_path / 'single.exr'
+    openexr_write(path, channels)
+    loaded = openexr_read(path)
+    assert list(loaded.keys()) == ['Y']
+    assert np.allclose(loaded['Y'], channels['Y'])


### PR DESCRIPTION
## Summary
- support OpenEXR read/write via OpenEXR library or imageio fallback
- expose the new io helpers
- round‐trip unit tests for OpenEXR images (skipped if backend unavailable)

## Testing
- `pytest -q`
