### PR TITLE
Add optics module to Python package

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -60,7 +60,7 @@ from .metrics.ssim_metric import ssim_metric
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc, metrics
+from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc, metrics, optics
 from .opticalimage import oi_to_file
 from .sensor import sensor_to_file
 from .display import display_to_file
@@ -127,6 +127,7 @@ __all__ = [
     'ie_init',
     'ie_init_session',
     'camera',
+    'optics',
     'scene',
     'opticalimage',
     'sensor',

--- a/python/isetcam/optics/__init__.py
+++ b/python/isetcam/optics/__init__.py
@@ -1,0 +1,13 @@
+"""Optics-related functions."""
+
+from .optics_class import Optics
+from .optics_get import optics_get
+from .optics_set import optics_set
+from .optics_create import optics_create
+
+__all__ = [
+    "Optics",
+    "optics_get",
+    "optics_set",
+    "optics_create",
+]

--- a/python/isetcam/optics/optics_class.py
+++ b/python/isetcam/optics/optics_class.py
@@ -1,0 +1,30 @@
+"""Basic :class:`Optics` dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from ..init_default_spectrum import init_default_spectrum
+
+
+@dataclass
+class Optics:
+    """Minimal representation of ISETCam optics."""
+
+    f_number: float
+    f_length: float
+    wave: np.ndarray | None = None
+    transmittance: np.ndarray | None = None
+    name: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.wave is None:
+            init_default_spectrum(self)
+        else:
+            self.wave = np.asarray(self.wave, dtype=float).reshape(-1)
+        if self.transmittance is None:
+            self.transmittance = np.ones_like(self.wave, dtype=float)
+        else:
+            self.transmittance = np.asarray(self.transmittance, dtype=float)

--- a/python/isetcam/optics/optics_create.py
+++ b/python/isetcam/optics/optics_create.py
@@ -1,0 +1,36 @@
+"""Factory function for :class:`Optics` objects."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .optics_class import Optics
+
+
+_DEF_FNUMBER = 4.0
+_DEF_FLENGTH = 0.004  # 4 mm
+
+
+def optics_create(name: str = "default", wave: Optional[np.ndarray] = None) -> Optics:
+    """Create an :class:`Optics` by ``name``."""
+    flag = name.lower().replace(" ", "")
+    if flag in {"default", "diffractionlimited"}:
+        trans = None
+    elif flag == "diffuser":
+        trans = 0.5
+    else:
+        raise ValueError(f"Unknown optics type '{name}'")
+
+    if trans is None:
+        optics = Optics(f_number=_DEF_FNUMBER, f_length=_DEF_FLENGTH, wave=wave, name=name)
+    else:
+        if wave is None:
+            optics = Optics(f_number=_DEF_FNUMBER, f_length=_DEF_FLENGTH, wave=None, name=name)
+            optics.transmittance *= trans
+        else:
+            wave_arr = np.asarray(wave, dtype=float).reshape(-1)
+            optics = Optics(f_number=_DEF_FNUMBER, f_length=_DEF_FLENGTH, wave=wave_arr,
+                            transmittance=np.full(wave_arr.shape, trans, dtype=float), name=name)
+    return optics

--- a/python/isetcam/optics/optics_get.py
+++ b/python/isetcam/optics/optics_get.py
@@ -1,0 +1,28 @@
+"""Retrieve parameters from :class:`Optics` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .optics_class import Optics
+from ..ie_param_format import ie_param_format
+
+
+def optics_get(optics: Optics, param: str) -> Any:
+    """Return a parameter value from ``optics``."""
+    key = ie_param_format(param)
+    if key in {"fnumber", "f_number"}:
+        return optics.f_number
+    if key in {"flength", "focallength", "f_length"}:
+        return optics.f_length
+    if key == "wave":
+        return optics.wave
+    if key in {"nwave", "n_wave"}:
+        return len(optics.wave)
+    if key == "transmittance":
+        return optics.transmittance
+    if key == "name":
+        return getattr(optics, "name", None)
+    raise KeyError(f"Unknown optics parameter '{param}'")

--- a/python/isetcam/optics/optics_set.py
+++ b/python/isetcam/optics/optics_set.py
@@ -1,0 +1,33 @@
+"""Assign parameters on :class:`Optics` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .optics_class import Optics
+from ..ie_param_format import ie_param_format
+
+
+def optics_set(optics: Optics, param: str, val: Any) -> None:
+    """Set a parameter value on ``optics``."""
+    key = ie_param_format(param)
+    if key in {"fnumber", "f_number"}:
+        optics.f_number = float(val)
+        return
+    if key in {"flength", "focallength", "f_length"}:
+        optics.f_length = float(val)
+        return
+    if key == "wave":
+        optics.wave = np.asarray(val, dtype=float).reshape(-1)
+        if optics.transmittance is not None and optics.transmittance.size != optics.wave.size:
+            optics.transmittance = np.ones_like(optics.wave, dtype=float)
+        return
+    if key == "transmittance":
+        optics.transmittance = np.asarray(val, dtype=float)
+        return
+    if key == "name":
+        optics.name = None if val is None else str(val)
+        return
+    raise KeyError(f"Unknown or read-only optics parameter '{param}'")

--- a/python/tests/test_optics_create.py
+++ b/python/tests/test_optics_create.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from isetcam.optics import optics_create, Optics
+
+
+def test_optics_create_default():
+    opt = optics_create()
+    assert isinstance(opt, Optics)
+    assert opt.f_number == 4.0
+    assert opt.f_length == 0.004
+    assert opt.transmittance.shape == opt.wave.shape
+
+
+def test_optics_create_diffuser():
+    opt = optics_create("diffuser", wave=np.array([500, 510]))
+    assert np.allclose(opt.transmittance, 0.5)
+    assert opt.wave.size == 2

--- a/python/tests/test_optics_get_set.py
+++ b/python/tests/test_optics_get_set.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from isetcam.optics import Optics, optics_get, optics_set
+
+
+def test_optics_get_set():
+    wave = np.array([500, 510, 520])
+    trans = np.array([1.0, 0.9, 0.8])
+    opt = Optics(f_number=4.0, f_length=0.004, wave=wave, transmittance=trans.copy(), name="orig")
+
+    assert optics_get(opt, "f_number") == 4.0
+    assert optics_get(opt, "f Length") == 0.004
+    assert np.array_equal(optics_get(opt, "wave"), wave)
+    assert optics_get(opt, "n wave") == 3
+    assert np.allclose(optics_get(opt, "transmittance"), trans)
+    assert optics_get(opt, "NaMe") == "orig"
+
+    optics_set(opt, "f_number", 2.8)
+    assert optics_get(opt, "fnumber") == 2.8
+
+    optics_set(opt, "f_length", 0.005)
+    assert optics_get(opt, "flength") == 0.005
+
+    new_wave = np.array([600, 610])
+    optics_set(opt, "wave", new_wave)
+    assert np.array_equal(optics_get(opt, "wave"), new_wave)
+    assert optics_get(opt, "n_wave") == len(new_wave)
+
+    new_trans = np.array([0.5, 0.4])
+    optics_set(opt, "transmittance", new_trans)
+    assert np.allclose(optics_get(opt, "transmittance"), new_trans)
+
+    optics_set(opt, "name", "new")
+    assert optics_get(opt, "name") == "new"


### PR DESCRIPTION
## Summary
- implement basic `optics` subpackage with dataclass and helpers
- allow creating simple optics models
- expose `optics` through package entry points
- test accessor helpers and factory

## Testing
- `pytest -q`