### PR TITLE
Add sensor and camera creation helpers

### DIFF
--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -4,10 +4,12 @@ from .camera_class import Camera
 from .camera_get import camera_get
 from .camera_set import camera_set
 from .camera_to_file import camera_to_file
+from .camera_create import camera_create
 
 __all__ = [
     "Camera",
     "camera_get",
     "camera_set",
     "camera_to_file",
+    "camera_create",
 ]

--- a/python/isetcam/camera/camera_create.py
+++ b/python/isetcam/camera/camera_create.py
@@ -1,0 +1,35 @@
+"""Factory function for :class:`Camera` objects."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .camera_class import Camera
+from ..sensor import sensor_create, Sensor
+from ..optics import optics_create, Optics
+from ..opticalimage import OpticalImage
+
+
+def camera_create(sensor: Optional[Sensor] = None,
+                  optics: Optional[Optics] = None,
+                  name: Optional[str] = None) -> Camera:
+    """Create a :class:`Camera` composed of a sensor and optics."""
+    if sensor is None:
+        sensor = sensor_create()
+    if optics is None:
+        optics = optics_create()
+
+    if sensor.wave is not None:
+        wave = sensor.wave
+    else:
+        wave = optics.wave
+
+    photons = np.zeros((1, 1, wave.size), dtype=float)
+    oi = OpticalImage(photons=photons, wave=wave, name=name)
+
+    cam = Camera(sensor=sensor, optical_image=oi, name=name)
+    # attach the optics instance for reference
+    cam.optics = optics
+    return cam

--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -10,6 +10,7 @@ from .sensor_set import sensor_set
 from .sensor_from_file import sensor_from_file
 from .sensor_compute import sensor_compute
 from .sensor_to_file import sensor_to_file
+from .sensor_create import sensor_create
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -49,4 +50,5 @@ __all__ = [
     "sensor_from_file",
     "sensor_compute",
     "sensor_to_file",
+    "sensor_create",
 ]

--- a/python/isetcam/sensor/sensor_create.py
+++ b/python/isetcam/sensor/sensor_create.py
@@ -1,0 +1,35 @@
+"""Factory function for :class:`Sensor` objects."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .sensor_class import Sensor
+
+_DEF_PIXEL_SIZE = 2.8e-6  # meters
+_DEF_EXPOSURE = 0.01  # seconds
+
+
+def sensor_create(kind: str = "bayer", wave: Optional[np.ndarray] = None) -> Sensor:
+    """Create a simple :class:`Sensor` by ``kind``.
+
+    Parameters
+    ----------
+    kind:
+        Type of sensor to create. Only ``'bayer'`` is currently supported.
+    wave:
+        Optional wavelength sampling for the sensor's spectral properties.
+    """
+    flag = kind.lower().replace(" ", "")
+    if flag != "bayer":
+        raise ValueError(f"Unknown sensor type '{kind}'")
+
+    volts = np.zeros((1, 1), dtype=float)
+    s = Sensor(volts=volts, exposure_time=_DEF_EXPOSURE, wave=wave, name=kind)
+
+    # Default quantum efficiency and pixel size information
+    s.qe = np.ones(s.wave.size, dtype=float)
+    s.pixel_size = float(_DEF_PIXEL_SIZE)
+    return s

--- a/python/tests/test_camera_create.py
+++ b/python/tests/test_camera_create.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from isetcam.camera import camera_create, Camera
+from isetcam.sensor import sensor_create, Sensor
+from isetcam.optics import optics_create, Optics
+from isetcam.opticalimage import OpticalImage
+
+
+def test_camera_create_default():
+    cam = camera_create()
+    assert isinstance(cam, Camera)
+    assert isinstance(cam.sensor, Sensor)
+    assert isinstance(cam.optical_image, OpticalImage)
+    assert hasattr(cam, "optics")
+    assert isinstance(cam.optics, Optics)
+    assert np.array_equal(cam.sensor.wave, cam.optical_image.wave)
+
+
+def test_camera_create_custom():
+    wave = np.array([500, 510])
+    s = sensor_create(wave=wave)
+    o = optics_create(wave=wave)
+    cam = camera_create(sensor=s, optics=o, name="demo")
+    assert cam.name == "demo"
+    assert cam.sensor is s
+    assert cam.optics is o
+    assert np.array_equal(cam.optical_image.wave, wave)

--- a/python/tests/test_sensor_create.py
+++ b/python/tests/test_sensor_create.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from isetcam.sensor import sensor_create, Sensor
+
+
+def test_sensor_create_default():
+    s = sensor_create()
+    assert isinstance(s, Sensor)
+    assert s.exposure_time == 0.01
+    assert hasattr(s, "qe")
+    assert hasattr(s, "pixel_size")
+    assert s.qe.size == s.wave.size
+
+
+def test_sensor_create_custom_wave():
+    wave = np.array([500, 510, 520])
+    s = sensor_create(wave=wave)
+    assert np.array_equal(s.wave, wave)
+    assert s.qe.size == wave.size


### PR DESCRIPTION
## Summary
- implement `sensor_create` to generate simple Sensor instances
- implement `camera_create` to connect a Sensor with Optics and an OpticalImage
- export these new functions in package `__init__` files
- add unit tests for camera and sensor creation

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_sensor_create.py python/tests/test_camera_create.py`
- `PYTHONPATH=python pytest -q`