### PR TITLE
Add daylight helper

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -20,6 +20,7 @@ from .color_block_matrix import color_block_matrix
 from .chromaticity import chromaticity
 from .cct import cct
 from .cct_to_sun import cct_to_sun
+from .daylight import daylight
 from .circle_points import circle_points
 from .ie_param_format import ie_param_format
 from .ie_session_get import ie_session_get
@@ -90,6 +91,7 @@ __all__ = [
     'chromaticity',
     'cct',
     'cct_to_sun',
+    'daylight',
     'circle_points',
     'ie_param_format',
     'ie_session_get',

--- a/python/isetcam/daylight.py
+++ b/python/isetcam/daylight.py
@@ -1,0 +1,56 @@
+"""Generate a daylight SPD normalized to 100 cd/m^2."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .cct_to_sun import cct_to_sun, Units
+from .luminance_from_energy import luminance_from_energy
+from .luminance_from_photons import luminance_from_photons
+
+
+_DEF_CCT = 6500
+
+
+def daylight(wave: np.ndarray, cct: np.ndarray | float = _DEF_CCT, units: Units = "energy") -> np.ndarray:
+    """Return daylight spectrum scaled to 100 cd/m^2.
+
+    Parameters
+    ----------
+    wave : array-like
+        Sampled wavelengths in nanometers.
+    cct : array-like or float, optional
+        Correlated color temperature(s) in Kelvin. Defaults to ``6500``.
+    units : {"energy", "photons", "quanta"}, optional
+        Desired output units. Defaults to ``"energy"``.
+
+    Returns
+    -------
+    np.ndarray
+        Daylight spectral power distribution with shape ``(len(wave), len(cct))``
+        or ``(len(wave),)`` when ``cct`` is scalar. The first spectrum has a
+        luminance of 100 cd/m^2.
+    """
+    wave = np.asarray(wave, dtype=float).reshape(-1)
+    cct = np.asarray(cct if cct is not None else _DEF_CCT, dtype=float).reshape(-1)
+
+    spd = cct_to_sun(wave, cct, units=units)
+    if spd.ndim == 1:
+        spd_mat = spd[:, np.newaxis]
+    else:
+        spd_mat = spd
+
+    if units.lower() in {"photons", "quanta"}:
+        lum = luminance_from_photons(spd_mat[:, 0], wave)
+    else:
+        lum = luminance_from_energy(spd_mat[:, 0], wave)
+
+    if lum == 0:
+        scale = 0.0
+    else:
+        scale = 100.0 / float(lum)
+    spd_mat = spd_mat * scale
+
+    if spd_mat.shape[1] == 1:
+        return spd_mat[:, 0]
+    return spd_mat

--- a/python/tests/test_daylight.py
+++ b/python/tests/test_daylight.py
@@ -1,0 +1,33 @@
+import numpy as np
+from scipy.io import loadmat
+
+from isetcam import daylight, energy_to_quanta, luminance_from_energy, iset_root_path
+
+
+def _expected_d65(wave: np.ndarray) -> np.ndarray:
+    root = iset_root_path()
+    mat = loadmat(root / "data" / "lights" / "D65.mat")
+    d_wave = mat["wavelength"].ravel()
+    d_spd = np.interp(wave, d_wave, mat["data"].ravel())
+    lum = luminance_from_energy(d_spd[np.newaxis, :], wave)[0]
+    return d_spd / lum * 100.0
+
+
+def test_daylight_matches_matlab_d65():
+    wave = np.arange(400, 701, 10)
+    spd = daylight(wave, 6500)
+    expected = _expected_d65(wave)
+    assert spd.shape == wave.shape
+    assert np.allclose(spd, expected, atol=1e-6)
+
+
+def test_daylight_photons_multi():
+    wave = np.arange(420, 681, 20)
+    ccts = np.array([4000, 6500])
+    spd_energy = daylight(wave, ccts, units="energy")
+    spd_photons = daylight(wave, ccts, units="photons")
+
+    assert spd_energy.shape == (len(wave), len(ccts))
+    assert spd_photons.shape == spd_energy.shape
+    expected = energy_to_quanta(wave, spd_energy)
+    assert np.allclose(spd_photons, expected)


### PR DESCRIPTION
## Summary
- add `daylight` wrapper for `cct_to_sun`
- export new function via `isetcam.__init__`
- test daylight normalization against MATLAB results

## Testing
- `python -m pytest -q`