### PR TITLE
Add Optics MAT-file IO utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -71,6 +71,7 @@ from .opticalimage import oi_to_file
 from .sensor import sensor_to_file
 from .display import display_to_file
 from .camera import camera_to_file
+from .optics import optics_to_file, optics_from_file
 from .io import openexr_read, openexr_write
 
 __all__ = [
@@ -148,6 +149,8 @@ __all__ = [
     'sensor_to_file',
     'display_to_file',
     'camera_to_file',
+    'optics_to_file',
+    'optics_from_file',
     'openexr_read',
     'openexr_write',
 ]

--- a/python/isetcam/optics/__init__.py
+++ b/python/isetcam/optics/__init__.py
@@ -4,10 +4,14 @@ from .optics_class import Optics
 from .optics_get import optics_get
 from .optics_set import optics_set
 from .optics_create import optics_create
+from .optics_to_file import optics_to_file
+from .optics_from_file import optics_from_file
 
 __all__ = [
     "Optics",
     "optics_get",
     "optics_set",
     "optics_create",
+    "optics_to_file",
+    "optics_from_file",
 ]

--- a/python/isetcam/optics/optics_from_file.py
+++ b/python/isetcam/optics/optics_from_file.py
@@ -1,0 +1,62 @@
+"""Load an :class:`Optics` from a MATLAB ``.mat`` file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from scipy.io import loadmat
+
+from .optics_class import Optics
+
+
+def _get_attr(obj: object, name: str):
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def optics_from_file(path: str | Path, *, candidate_vars: Iterable[str] | None = None) -> Optics:
+    """Load ``path`` and return an :class:`Optics`.
+
+    Parameters
+    ----------
+    path:
+        MAT-file containing an optics structure.
+    candidate_vars:
+        Optional sequence of variable names to search for. Defaults to
+        ``('optics',)``.
+    """
+    if candidate_vars is None:
+        candidate_vars = ("optics",)
+
+    mat = loadmat(str(Path(path)), squeeze_me=True, struct_as_record=False)
+
+    opt_struct = None
+    for key in candidate_vars:
+        if key in mat:
+            opt_struct = mat[key]
+            break
+    if opt_struct is None:
+        raise KeyError("No optics structure found in file")
+
+    f_number = float(_get_attr(opt_struct, "f_number"))
+    f_length = float(_get_attr(opt_struct, "f_length"))
+    wave = _get_attr(opt_struct, "wave")
+    if wave is not None:
+        wave = np.asarray(wave).reshape(-1)
+    transmittance = _get_attr(opt_struct, "transmittance")
+    if transmittance is not None:
+        transmittance = np.asarray(transmittance, dtype=float)
+    name = _get_attr(opt_struct, "name")
+    if isinstance(name, np.ndarray):
+        name = str(name.squeeze())
+
+    return Optics(
+        f_number=f_number,
+        f_length=f_length,
+        wave=wave,
+        transmittance=transmittance,
+        name=name,
+    )

--- a/python/isetcam/optics/optics_to_file.py
+++ b/python/isetcam/optics/optics_to_file.py
@@ -1,0 +1,25 @@
+"""Utilities for saving :class:`Optics` objects to disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scipy.io import savemat
+
+from .optics_class import Optics
+
+
+def optics_to_file(optics: Optics, path: str | Path) -> None:
+    """Save ``optics`` to ``path`` as a MATLAB ``.mat`` file.
+
+    The structure is stored under the variable name ``'optics'``.
+    """
+    data = {
+        "f_number": optics.f_number,
+        "f_length": optics.f_length,
+        "wave": optics.wave,
+        "transmittance": optics.transmittance,
+    }
+    if optics.name is not None:
+        data["name"] = optics.name
+    savemat(str(Path(path)), {"optics": data})

--- a/python/tests/test_optics_file_io.py
+++ b/python/tests/test_optics_file_io.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from isetcam.optics import Optics, optics_from_file, optics_to_file
+
+
+def test_optics_file_roundtrip(tmp_path):
+    opt = Optics(
+        f_number=4.0,
+        f_length=0.004,
+        wave=np.array([500, 510]),
+        transmittance=np.array([1.0, 0.9]),
+        name="demo",
+    )
+    path = tmp_path / "optics.mat"
+    optics_to_file(opt, path)
+
+    loaded = optics_from_file(path)
+    assert isinstance(loaded, Optics)
+    assert loaded.f_number == opt.f_number
+    assert loaded.f_length == opt.f_length
+    assert np.array_equal(loaded.wave, opt.wave)
+    assert np.allclose(loaded.transmittance, opt.transmittance)
+    assert loaded.name == opt.name


### PR DESCRIPTION
## Summary
- implement `optics_to_file` and `optics_from_file`
- export new helpers from `optics` package and top-level `isetcam`
- test roundtrip MAT-file IO for `Optics`

## Testing
- `PYTHONPATH=$PWD/python pytest -q`