### PR TITLE
Add covariance ellipsoid utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -52,6 +52,7 @@ from .srgb_parameters import srgb_parameters
 from .ctemp_to_srgb import ctemp_to_srgb
 from .init_default_spectrum import init_default_spectrum
 from .mk_inv_gamma_table import mk_inv_gamma_table
+from .ie_cov_ellipsoid import ie_cov_ellipsoid
 from .imgproc import (
     image_distort,
     ie_internal_to_display,
@@ -122,6 +123,7 @@ __all__ = [
     'ctemp_to_srgb',
     'init_default_spectrum',
     'mk_inv_gamma_table',
+    'ie_cov_ellipsoid',
     'ie_spectra_sphere',
     'image_distort',
     'ie_internal_to_display',

--- a/python/isetcam/ie_cov_ellipsoid.py
+++ b/python/isetcam/ie_cov_ellipsoid.py
@@ -1,0 +1,70 @@
+"""Generate ellipsoid coordinates from a covariance matrix."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.linalg import eigh
+
+
+def ie_cov_ellipsoid(
+    cov: np.ndarray, center: np.ndarray | None = None, n_points: int = 20
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``(X, Y, Z)`` points forming the ellipsoid described by ``cov``.
+
+    The function computes a surface corresponding to one standard deviation
+    of a multivariate normal distribution with covariance ``cov``.  The points
+    can be visualized using ``matplotlib``::
+
+        X, Y, Z = ie_cov_ellipsoid(cov)
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection="3d")
+        ax.plot_surface(X, Y, Z, rstride=1, cstride=1, alpha=0.3)
+
+    Parameters
+    ----------
+    cov : array-like of shape (3, 3)
+        Covariance matrix defining the ellipsoid axes and orientation.
+    center : array-like of length 3, optional
+        Center of the ellipsoid.  Defaults to the origin.
+    n_points : int, optional
+        Number of sample points along each angular dimension of the unit
+        sphere. Higher values yield a finer mesh.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, np.ndarray]
+        Arrays ``(X, Y, Z)`` with shape ``(n_points, n_points)`` describing the
+        ellipsoid surface.
+    """
+    cov = np.asarray(cov, dtype=float)
+    if cov.shape != (3, 3):
+        raise ValueError("cov must be a 3x3 matrix")
+    if center is None:
+        center = np.zeros(3, dtype=float)
+    else:
+        center = np.asarray(center, dtype=float).reshape(3)
+
+    # Eigen-decomposition of the covariance matrix
+    eigvals, eigvecs = eigh(cov)
+    if np.any(eigvals < 0):
+        raise ValueError("covariance matrix must be positive semi-definite")
+    radii = np.sqrt(eigvals)
+
+    # Points on a unit sphere
+    phi = np.linspace(0.0, 2 * np.pi, n_points)
+    theta = np.linspace(0.0, np.pi, n_points)
+    x = np.outer(np.cos(phi), np.sin(theta))
+    y = np.outer(np.sin(phi), np.sin(theta))
+    z = np.outer(np.ones_like(phi), np.cos(theta))
+    sphere = np.stack((x, y, z), axis=-1)
+
+    # Transform unit sphere to the ellipsoid
+    transform = eigvecs @ np.diag(radii)
+    pts = sphere.reshape(-1, 3).T
+    ellipsoid = transform @ pts
+    ellipsoid += center[:, None]
+    ellipsoid = ellipsoid.T.reshape(n_points, n_points, 3)
+    X = ellipsoid[:, :, 0]
+    Y = ellipsoid[:, :, 1]
+    Z = ellipsoid[:, :, 2]
+    return X, Y, Z

--- a/python/tests/test_ie_cov_ellipsoid.py
+++ b/python/tests/test_ie_cov_ellipsoid.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+
+from isetcam import ie_cov_ellipsoid
+
+
+def test_unit_sphere():
+    cov = np.eye(3)
+    X, Y, Z = ie_cov_ellipsoid(cov, n_points=10)
+    r = X**2 + Y**2 + Z**2
+    assert np.allclose(r, 1.0, atol=1e-6)
+
+
+def test_scaled_shifted_ellipsoid():
+    cov = np.diag([4.0, 9.0, 16.0])
+    center = np.array([1.0, 2.0, 3.0])
+    X, Y, Z = ie_cov_ellipsoid(cov, center=center, n_points=8)
+    val = ((X - center[0]) ** 2) / 4 + ((Y - center[1]) ** 2) / 9 + ((Z - center[2]) ** 2) / 16
+    assert np.allclose(val, 1.0, atol=1e-6)
+
+
+def test_bad_shape():
+    with pytest.raises(ValueError):
+        ie_cov_ellipsoid(np.eye(2))
+


### PR DESCRIPTION
## Summary
- implement `ie_cov_ellipsoid` for plotting covariance ellipsoids
- expose the function in the `isetcam` package
- test ellipsoid generation

## Testing
- `pytest -q`
