### PR TITLE
Add frequency support utilities

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -713,6 +713,25 @@ oi2 = oi_spatial_resample(oi, 1e-3)
 
 Run `pytest -q` after editing the spatial routines.
 
+## Scene and Optical Image Frequency Support
+
+Helpers `scene_frequency_support` and `oi_frequency_support` return the spatial
+frequency coordinates of each sample. Use `scene_frequency_resample` and
+`oi_frequency_resample` to change the number of frequency samples while keeping
+the field of view constant.
+
+```python
+from isetcam.scene import scene_frequency_support, scene_frequency_resample
+from isetcam.opticalimage import oi_frequency_support, oi_frequency_resample
+
+f_sup = scene_frequency_support(sc)
+sc_f = scene_frequency_resample(sc, 32, 32)
+oi_f_sup = oi_frequency_support(oi)
+oi_f = oi_frequency_resample(oi, 64, 64)
+```
+
+Run `pytest -q` after editing the frequency routines.
+
 ## Scene and Optical Image Padding
 
 Scenes and optical images can be padded, shifted or cropped using small helper functions.

--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -13,6 +13,8 @@ from .oi_pad import oi_pad
 from .oi_rotate import oi_rotate
 from .oi_spatial_support import oi_spatial_support
 from .oi_spatial_resample import oi_spatial_resample
+from .oi_frequency_support import oi_frequency_support
+from .oi_frequency_resample import oi_frequency_resample
 
 __all__ = [
     "OpticalImage",
@@ -28,6 +30,8 @@ __all__ = [
     "oi_rotate",
     "oi_spatial_support",
     "oi_spatial_resample",
+    "oi_frequency_support",
+    "oi_frequency_resample",
     "oi_photon_noise",
     "oi_to_file",
 ]

--- a/python/isetcam/opticalimage/oi_frequency_resample.py
+++ b/python/isetcam/opticalimage/oi_frequency_resample.py
@@ -1,0 +1,38 @@
+"""Resample an :class:`OpticalImage` in the frequency domain."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import zoom as nd_zoom
+
+from .oi_class import OpticalImage
+
+
+def oi_frequency_resample(
+    oi: OpticalImage, n_rows: int, n_cols: int, method: str = "linear"
+) -> OpticalImage:
+    """Resample ``oi`` so the frequency grid has ``n_rows`` by ``n_cols`` samples.
+
+    The spatial field of view is preserved by adjusting the pixel spacing.
+    """
+    height, width = oi.photons.shape[:2]
+    old_spacing = getattr(oi, "sample_spacing", 1.0)
+
+    width_m = width * old_spacing
+    height_m = height * old_spacing
+
+    new_spacing_x = width_m / int(n_cols)
+    new_spacing_y = height_m / int(n_rows)
+    new_spacing = (new_spacing_x + new_spacing_y) / 2.0
+
+    zoom_factors = (n_rows / height, n_cols / width, 1)
+
+    orders = {"nearest": 0, "linear": 1, "cubic": 3}
+    if method not in orders:
+        raise ValueError("Unknown interpolation method")
+    order = orders[method]
+
+    resampled = nd_zoom(oi.photons, zoom_factors, order=order)
+    out = OpticalImage(photons=resampled, wave=oi.wave, name=oi.name)
+    out.sample_spacing = new_spacing
+    return out

--- a/python/isetcam/opticalimage/oi_frequency_support.py
+++ b/python/isetcam/opticalimage/oi_frequency_support.py
@@ -1,0 +1,59 @@
+"""Frequency support for :class:`OpticalImage` objects."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+def _unit_frequency_list(n: int) -> np.ndarray:
+    idx = np.arange(n)
+    mid = n // 2
+    if n % 2:
+        mid = (n - 1) // 2
+    c = idx - mid
+    if c.max() == 0:
+        return c.astype(float)
+    return c / np.max(np.abs(c))
+
+
+def _freq_scale(units: str) -> float:
+    units = units.lower()
+    if units in {"cyclesperdegree", "cycperdeg", "cpd"}:
+        return 1.0
+    if units in {"cyclespermeter", "cpm", "m", "meter", "meters"}:
+        return 1.0
+    if units in {"cyclespermillimeter", "mm", "millimeter", "millimeters"}:
+        return 1e-3
+    if units in {"cyclespermicron", "um", "micron", "microns", "micrometer", "micrometers"}:
+        return 1e-6
+    raise ValueError(f"Unknown frequency unit '{units}'")
+
+
+def oi_frequency_support(oi: OpticalImage, units: str = "cyclesPerDegree") -> dict[str, np.ndarray]:
+    """Return frequency support of ``oi``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image.
+    units : str, optional
+        Output units. Defaults to ``"cyclesPerDegree"``.
+
+    Returns
+    -------
+    dict
+        ``{"fx": fx, "fy": fy}`` arrays giving spatial frequency coordinates.
+    """
+    spacing = getattr(oi, "sample_spacing", 1.0)
+    height, width = oi.photons.shape[:2]
+
+    nyquist_x = 1.0 / (2 * spacing)
+    nyquist_y = 1.0 / (2 * spacing)
+
+    fx = _unit_frequency_list(width) * nyquist_x
+    fy = _unit_frequency_list(height) * nyquist_y
+
+    scale = _freq_scale(units)
+    return {"fx": fx / scale, "fy": fy / scale}

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -16,6 +16,8 @@ from .scene_translate import scene_translate
 from .scene_rotate import scene_rotate
 from .scene_spatial_support import scene_spatial_support
 from .scene_spatial_resample import scene_spatial_resample
+from .scene_frequency_support import scene_frequency_support
+from .scene_frequency_resample import scene_frequency_resample
 from .scene_to_file import scene_to_file
 
 __all__ = [
@@ -35,6 +37,8 @@ __all__ = [
     "scene_rotate",
     "scene_spatial_support",
     "scene_spatial_resample",
+    "scene_frequency_support",
+    "scene_frequency_resample",
     "scene_create",
     "scene_photon_noise",
     "scene_to_file",

--- a/python/isetcam/scene/scene_frequency_resample.py
+++ b/python/isetcam/scene/scene_frequency_resample.py
@@ -1,0 +1,38 @@
+"""Resample a :class:`Scene` in the frequency domain."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import zoom as nd_zoom
+
+from .scene_class import Scene
+
+
+def scene_frequency_resample(
+    scene: Scene, n_rows: int, n_cols: int, method: str = "linear"
+) -> Scene:
+    """Resample ``scene`` so the frequency grid has ``n_rows`` by ``n_cols`` samples.
+
+    The spatial field of view is preserved by adjusting the pixel spacing.
+    """
+    height, width = scene.photons.shape[:2]
+    old_spacing = getattr(scene, "sample_spacing", 1.0)
+
+    width_m = width * old_spacing
+    height_m = height * old_spacing
+
+    new_spacing_x = width_m / int(n_cols)
+    new_spacing_y = height_m / int(n_rows)
+    new_spacing = (new_spacing_x + new_spacing_y) / 2.0
+
+    zoom_factors = (n_rows / height, n_cols / width, 1)
+
+    orders = {"nearest": 0, "linear": 1, "cubic": 3}
+    if method not in orders:
+        raise ValueError("Unknown interpolation method")
+    order = orders[method]
+
+    resampled = nd_zoom(scene.photons, zoom_factors, order=order)
+    out = Scene(photons=resampled, wave=scene.wave, name=scene.name)
+    out.sample_spacing = new_spacing
+    return out

--- a/python/isetcam/scene/scene_frequency_support.py
+++ b/python/isetcam/scene/scene_frequency_support.py
@@ -1,0 +1,61 @@
+"""Frequency support for :class:`Scene` objects."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def _unit_frequency_list(n: int) -> np.ndarray:
+    idx = np.arange(n)
+    mid = n // 2
+    if n % 2:
+        mid = (n - 1) // 2
+    c = idx - mid
+    if c.max() == 0:
+        return c.astype(float)
+    return c / np.max(np.abs(c))
+
+
+def _freq_scale(units: str) -> float:
+    units = units.lower()
+    if units in {"cyclesperdegree", "cycperdeg", "cpd"}:
+        # cycles per degree is the default. Without distance information we
+        # treat this the same as cycles per meter.
+        return 1.0
+    if units in {"cyclespermeter", "cpm", "m", "meter", "meters"}:
+        return 1.0
+    if units in {"cyclespermillimeter", "mm", "millimeter", "millimeters"}:
+        return 1e-3
+    if units in {"cyclespermicron", "um", "micron", "microns", "micrometer", "micrometers"}:
+        return 1e-6
+    raise ValueError(f"Unknown frequency unit '{units}'")
+
+
+def scene_frequency_support(scene: Scene, units: str = "cyclesPerDegree") -> dict[str, np.ndarray]:
+    """Return frequency support of ``scene``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene.
+    units : str, optional
+        Output units. Defaults to ``"cyclesPerDegree"``.
+
+    Returns
+    -------
+    dict
+        ``{"fx": fx, "fy": fy}`` arrays giving spatial frequency coordinates.
+    """
+    spacing = getattr(scene, "sample_spacing", 1.0)  # meters
+    height, width = scene.photons.shape[:2]
+
+    nyquist_x = 1.0 / (2 * spacing)
+    nyquist_y = 1.0 / (2 * spacing)
+
+    fx = _unit_frequency_list(width) * nyquist_x
+    fy = _unit_frequency_list(height) * nyquist_y
+
+    scale = _freq_scale(units)
+    return {"fx": fx / scale, "fy": fy / scale}

--- a/python/tests/test_frequency_functions.py
+++ b/python/tests/test_frequency_functions.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from isetcam.scene import (
+    Scene,
+    scene_frequency_support,
+    scene_frequency_resample,
+)
+from isetcam.opticalimage import (
+    OpticalImage,
+    oi_frequency_support,
+    oi_frequency_resample,
+)
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([550])
+    photons = np.arange(16, dtype=float).reshape(4, 4, 1)
+    sc = Scene(photons=photons, wave=wave)
+    sc.sample_spacing = 1e-3
+    return sc
+
+
+def _simple_oi() -> OpticalImage:
+    wave = np.array([550])
+    photons = np.arange(9, dtype=float).reshape(3, 3, 1)
+    oi = OpticalImage(photons=photons, wave=wave)
+    oi.sample_spacing = 2e-3
+    return oi
+
+
+def test_scene_frequency_support_size():
+    sc = _simple_scene()
+    sup = scene_frequency_support(sc)
+    assert sup["fx"].size == sc.photons.shape[1]
+    assert sup["fy"].size == sc.photons.shape[0]
+
+
+def test_scene_frequency_resample_fov():
+    sc = _simple_scene()
+    out = scene_frequency_resample(sc, 8, 8)
+    assert out.photons.shape[:2] == (8, 8)
+    old_width = sc.photons.shape[1] * sc.sample_spacing
+    new_width = out.photons.shape[1] * out.sample_spacing
+    assert np.isclose(old_width, new_width)
+
+
+def test_oi_frequency_support_and_resample():
+    oi = _simple_oi()
+    sup = oi_frequency_support(oi)
+    assert sup["fx"].size == oi.photons.shape[1]
+    out = oi_frequency_resample(oi, 6, 6)
+    assert out.photons.shape[:2] == (6, 6)
+    old_width = oi.photons.shape[1] * oi.sample_spacing
+    new_width = out.photons.shape[1] * out.sample_spacing
+    assert np.isclose(old_width, new_width)


### PR DESCRIPTION
## Summary
- implement scene and optical image frequency support/resample helpers
- expose new helpers via package initializers
- test that frequency resampling keeps the field of view
- document frequency helper usage

## Testing
- `pytest -q`