### PR TITLE
Add scene_insert function

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -162,10 +162,11 @@ Scenes can be manipulated after creation. Use `scene_adjust_luminance` to
 scale the luminance statistic and `scene_crop` to extract a region:
 
 ```python
-from isetcam.scene import scene_adjust_luminance, scene_crop
+from isetcam.scene import scene_adjust_luminance, scene_crop, scene_insert
 
 sc2 = scene_adjust_luminance(sc, 'mean', 50)
 cropped = scene_crop(sc2, (10, 10, 64, 64))
+sc3 = scene_insert(sc2, cropped, (0, 0))
 ```
 
 ## Adjusting Scene Illuminant

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -12,6 +12,7 @@ from .scene_create import scene_create
 from .scene_photon_noise import scene_photon_noise
 from .scene_crop import scene_crop
 from .scene_pad import scene_pad
+from .scene_insert import scene_insert
 from .scene_translate import scene_translate
 from .scene_rotate import scene_rotate
 from .scene_spatial_support import scene_spatial_support
@@ -33,6 +34,7 @@ __all__ = [
     "scene_adjust_illuminant",
     "scene_crop",
     "scene_pad",
+    "scene_insert",
     "scene_translate",
     "scene_rotate",
     "scene_spatial_support",

--- a/python/isetcam/scene/scene_insert.py
+++ b/python/isetcam/scene/scene_insert.py
@@ -1,0 +1,70 @@
+"""Insert one scene into another."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .scene_class import Scene
+from .scene_utils import get_photons
+
+
+def scene_insert(
+    base_scene: Scene, insert_scene: Scene, location: Sequence[int]
+) -> Scene:
+    """Overlay ``insert_scene`` onto ``base_scene`` starting at ``location``.
+
+    Parameters
+    ----------
+    base_scene : Scene
+        Scene providing the background photon data.
+    insert_scene : Scene
+        Scene to insert. Must share the same wavelength samples as
+        ``base_scene``.
+    location : sequence of int
+        ``(x, y)`` coordinates of the upper-left pixel where the insertion
+        begins using 0-based indexing. Values may be negative or extend
+        past the size of ``base_scene``; only the overlapping region is
+        copied.
+
+    Returns
+    -------
+    Scene
+        New scene with photons from ``insert_scene`` written into the
+        specified region of ``base_scene``.
+    """
+
+    if len(location) != 2:
+        raise ValueError("location must have two elements (x, y)")
+
+    if not np.array_equal(base_scene.wave, insert_scene.wave):
+        raise ValueError("Scenes must share the same wavelength samples")
+
+    x, y = [int(v) for v in location]
+
+    base_photons = get_photons(base_scene).copy()
+    insert_photons = get_photons(insert_scene)
+
+    base_h, base_w = base_photons.shape[:2]
+    ins_h, ins_w = insert_photons.shape[:2]
+
+    # Determine overlap region in base scene coordinates
+    x0 = max(x, 0)
+    y0 = max(y, 0)
+    x1 = min(x + ins_w, base_w)
+    y1 = min(y + ins_h, base_h)
+
+    if x0 >= x1 or y0 >= y1:
+        # No overlap
+        return Scene(photons=base_photons, wave=base_scene.wave, name=base_scene.name)
+
+    # Corresponding region in insert scene coordinates
+    src_x0 = x0 - x
+    src_y0 = y0 - y
+    src_x1 = src_x0 + (x1 - x0)
+    src_y1 = src_y0 + (y1 - y0)
+
+    base_photons[y0:y1, x0:x1, :] = insert_photons[src_y0:src_y1, src_x0:src_x1, :]
+
+    return Scene(photons=base_photons, wave=base_scene.wave, name=base_scene.name)

--- a/python/tests/test_scene_insert.py
+++ b/python/tests/test_scene_insert.py
@@ -1,0 +1,36 @@
+import numpy as np
+from isetcam.scene import Scene, scene_insert
+
+
+def _base_scene(width: int = 4, height: int = 4, n_wave: int = 1) -> Scene:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.zeros((height, width, n_wave), dtype=float)
+    return Scene(photons=photons, wave=wave)
+
+
+def _insert_scene(width: int = 2, height: int = 2, n_wave: int = 1) -> Scene:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    return Scene(photons=photons, wave=wave)
+
+
+def test_scene_insert_in_bounds():
+    base = _base_scene(4, 4, 1)
+    ins = _insert_scene(2, 2, 1)
+    out = scene_insert(base, ins, (1, 1))
+    expected = base.photons.copy()
+    expected[1:3, 1:3, :] = ins.photons
+    assert np.array_equal(out.photons, expected)
+    assert np.array_equal(out.wave, base.wave)
+
+
+def test_scene_insert_partial_out_of_bounds():
+    base = _base_scene(4, 4, 1)
+    ins = _insert_scene(3, 3, 1)
+    out = scene_insert(base, ins, (3, 2))
+    expected = base.photons.copy()
+    expected[2:4, 3:4, :] = ins.photons[0:2, 0:1, :]
+    assert np.array_equal(out.photons, expected)
+


### PR DESCRIPTION
## Summary
- implement `scene_insert` for overlaying photon data
- export via `scene/__init__.py`
- document usage in migration guide
- add unit tests for in-bounds and out-of-bounds cases

## Testing
- `pytest python/tests/test_scene_insert.py -q`
- `pytest -q` *(fails: ImportError while importing modules)*