### PR TITLE
Add sensor photon noise utility

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -836,17 +836,20 @@ inv = mk_inv_gamma_table(gamma)
 
 Run `pytest -q` after changing the gamma utilities.
 
-## Scene and Optical Image Photon Noise
+## Scene, Optical Image and Sensor Photon Noise
 
-`scene_photon_noise` and `oi_photon_noise` add Poisson noise to the
-photon data stored in a scene or optical image.
+`scene_photon_noise`, `oi_photon_noise` and `sensor_photon_noise` add
+Poisson noise to the photon or voltage data stored in a scene, optical
+image or sensor.
 
 ```python
 from isetcam.scene import scene_photon_noise
 from isetcam.opticalimage import oi_photon_noise
+from isetcam.sensor import sensor_photon_noise
 
 noisy_sc, sc_noise = scene_photon_noise(sc)
 noisy_oi, oi_noise = oi_photon_noise(oi)
+noisy_s, s_noise = sensor_photon_noise(sensor)
 ```
 
 Run `pytest -q` after modifying the noise utilities.

--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -9,6 +9,7 @@ from .sensor_get import sensor_get
 from .sensor_set import sensor_set
 from .sensor_from_file import sensor_from_file
 from .sensor_compute import sensor_compute
+from .sensor_photon_noise import sensor_photon_noise
 from .sensor_to_file import sensor_to_file
 from .sensor_create import sensor_create
 
@@ -49,6 +50,7 @@ __all__ = [
     "sensor_set",
     "sensor_from_file",
     "sensor_compute",
+    "sensor_photon_noise",
     "sensor_to_file",
     "sensor_create",
 ]

--- a/python/isetcam/sensor/sensor_photon_noise.py
+++ b/python/isetcam/sensor/sensor_photon_noise.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .sensor_class import Sensor
+
+
+def sensor_photon_noise(sensor: Sensor) -> tuple[np.ndarray, np.ndarray]:
+    """Apply photon noise to sensor volts.
+
+    A Gaussian approximation is used when the mean signal is at least 15;
+    otherwise samples are drawn from a Poisson distribution. The ``sensor``
+    object is updated with the noisy volts.
+
+    Parameters
+    ----------
+    sensor : Sensor
+        Sensor providing the mean voltage data.
+
+    Returns
+    -------
+    tuple of np.ndarray
+        ``(noisy_volts, noise)`` where ``noisy_volts`` are the volts with
+        noise added and ``noise`` is the difference from the mean volts.
+    """
+    volts = np.asarray(sensor.volts, dtype=float)
+
+    noisy = np.empty_like(volts, dtype=float)
+    noise = np.empty_like(volts, dtype=float)
+
+    mask = volts >= 15
+    if np.any(mask):
+        g_noise = np.sqrt(volts[mask]) * np.random.randn(*volts[mask].shape)
+        noisy[mask] = volts[mask] + g_noise
+        noise[mask] = g_noise
+    if np.any(~mask):
+        samples = np.random.poisson(volts[~mask])
+        noisy[~mask] = samples
+        noise[~mask] = samples - volts[~mask]
+
+    sensor.volts = noisy
+    return noisy, noise

--- a/python/tests/test_sensor_photon_noise.py
+++ b/python/tests/test_sensor_photon_noise.py
@@ -1,0 +1,27 @@
+import numpy as np
+from isetcam.sensor import Sensor, sensor_photon_noise
+
+
+def test_sensor_photon_noise_gaussian():
+    np.random.seed(0)
+    volts = np.full((100, 100), 20.0, dtype=float)
+    s = Sensor(volts=volts.copy(), wave=np.array([550]), exposure_time=0.01)
+    noisy, noise = sensor_photon_noise(s)
+
+    assert noisy.shape == volts.shape
+    assert np.allclose(noisy - volts, noise)
+    assert np.allclose(s.volts, noisy)
+    assert abs(noise.mean()) < 0.1
+    assert abs(noise.var() - 20.0) < 2.0
+
+
+def test_sensor_photon_noise_poisson():
+    np.random.seed(1)
+    volts = np.full((100, 100), 5.0, dtype=float)
+    s = Sensor(volts=volts.copy(), wave=np.array([550]), exposure_time=0.01)
+    noisy, noise = sensor_photon_noise(s)
+
+    assert np.allclose(s.volts, noisy)
+    assert abs(noisy.mean() - 5.0) < 0.1
+    assert abs(noise.mean()) < 0.1
+    assert abs(noise.var() - 5.0) < 1.0


### PR DESCRIPTION
## Summary
- implement `sensor_photon_noise` for adding photon noise to sensor voltages
- export the new helper via `isetcam.sensor`
- test noise statistics
- document the noise utility in the migration guide

## Testing
- `pytest -q`