### PR TITLE
Add adobergb parameters helper

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -49,6 +49,7 @@ from .srgb_xyz import (
 from .srgb_to_cct import srgb_to_cct
 from .spd_to_cct import spd_to_cct
 from .srgb_parameters import srgb_parameters
+from .adobergb_parameters import adobergb_parameters
 from .ctemp_to_srgb import ctemp_to_srgb
 from .init_default_spectrum import init_default_spectrum
 from .mk_inv_gamma_table import mk_inv_gamma_table
@@ -120,6 +121,7 @@ __all__ = [
     'srgb_to_cct',
     'spd_to_cct',
     'srgb_parameters',
+    'adobergb_parameters',
     'ctemp_to_srgb',
     'init_default_spectrum',
     'mk_inv_gamma_table',

--- a/python/isetcam/adobergb_parameters.py
+++ b/python/isetcam/adobergb_parameters.py
@@ -1,0 +1,42 @@
+"""Return Adobe RGB chromaticity and white point parameters."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .xyy_to_xyz import xyy_to_xyz
+
+
+def adobergb_parameters(val: str = "all") -> np.ndarray:
+    """Return Adobe RGB display parameters.
+
+    Parameters
+    ----------
+    val : {'all', 'chromaticity', 'luminance', 'xyywhite', 'XYZwhite'}, optional
+        Portion of the parameter matrix to return. Defaults to ``'all'``.
+
+    Returns
+    -------
+    np.ndarray
+        Requested parameters from the Adobe RGB standard.
+    """
+    adobergbP = np.array([
+        [0.64, 0.21, 0.15, 0.3127],
+        [0.33, 0.71, 0.06, 0.3290],
+        [47.5744, 100.3776, 12.0320, 160.0],
+    ], dtype=float)
+
+    val = val.lower()
+    if val == "all":
+        return adobergbP
+    if val == "chromaticity":
+        return adobergbP[0:2, 0:3]
+    if val == "luminance":
+        return adobergbP[2, 0:3]
+    if val == "xyywhite":
+        return adobergbP[:, 3]
+    if val == "xyzwhite":
+        xyY = adobergbP[:, 3]
+        return xyy_to_xyz(xyY.reshape(1, 3)).reshape(3)
+    raise ValueError(f"Unknown request '{val}'")
+

--- a/python/tests/test_adobergb_parameters.py
+++ b/python/tests/test_adobergb_parameters.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from isetcam import adobergb_parameters, xyy_to_xyz
+
+
+def test_adobergb_parameters_all():
+    params = adobergb_parameters()
+    expected = np.array([
+        [0.64, 0.21, 0.15, 0.3127],
+        [0.33, 0.71, 0.06, 0.3290],
+        [47.5744, 100.3776, 12.0320, 160.0],
+    ])
+    assert np.allclose(params, expected)
+
+
+def test_adobergb_parameters_subvalues():
+    chroma = adobergb_parameters("chromaticity")
+    lum = adobergb_parameters("luminance")
+    xyY = adobergb_parameters("xyywhite")
+    xyz = adobergb_parameters("XYZwhite")
+
+    base = np.array([
+        [0.64, 0.21, 0.15, 0.3127],
+        [0.33, 0.71, 0.06, 0.3290],
+        [47.5744, 100.3776, 12.0320, 160.0],
+    ])
+
+    assert np.allclose(chroma, base[0:2, 0:3])
+    assert np.allclose(lum, base[2, 0:3])
+    assert np.allclose(xyY, base[:, 3])
+
+    expected_xyz = xyy_to_xyz(xyY.reshape(1, 3)).reshape(3)
+    assert np.allclose(xyz, expected_xyz)
+


### PR DESCRIPTION
## Summary
- port `adobergbParameters.m` to Python
- export via `isetcam` package
- test the new helper

## Testing
- `PYTHONPATH=python pytest -q`