### PR TITLE
Implement oi_adjust_illuminance

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -15,6 +15,7 @@ from .oi_spatial_support import oi_spatial_support
 from .oi_spatial_resample import oi_spatial_resample
 from .oi_frequency_support import oi_frequency_support
 from .oi_frequency_resample import oi_frequency_resample
+from .oi_adjust_illuminance import oi_adjust_illuminance
 
 __all__ = [
     "OpticalImage",
@@ -34,4 +35,5 @@ __all__ = [
     "oi_frequency_resample",
     "oi_photon_noise",
     "oi_to_file",
+    "oi_adjust_illuminance",
 ]

--- a/python/isetcam/opticalimage/oi_adjust_illuminance.py
+++ b/python/isetcam/opticalimage/oi_adjust_illuminance.py
@@ -1,0 +1,34 @@
+"""Adjust optical image illuminance by scaling photon data."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+from ..luminance_from_photons import luminance_from_photons
+
+
+def oi_adjust_illuminance(oi: OpticalImage, new_illuminance: float) -> OpticalImage:
+    """Scale ``oi`` so the mean illuminance equals ``new_illuminance``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image to scale.
+    new_illuminance : float
+        Desired mean illuminance level in lux.
+
+    Returns
+    -------
+    OpticalImage
+        New optical image with scaled photon data.
+    """
+
+    photons = np.asarray(oi.photons, dtype=float)
+    illum = luminance_from_photons(photons, oi.wave)
+    current = float(illum.mean())
+
+    if current > 0:
+        photons = photons * (new_illuminance / current)
+
+    return OpticalImage(photons=photons, wave=oi.wave, name=oi.name)

--- a/python/tests/test_oi_adjust_illuminance.py
+++ b/python/tests/test_oi_adjust_illuminance.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from isetcam.opticalimage import OpticalImage, oi_adjust_illuminance
+from isetcam.luminance_from_photons import luminance_from_photons
+
+
+def _simple_oi(scale: float) -> OpticalImage:
+    wave = np.array([500, 510])
+    photons = np.ones((2, 2, 2)) * scale
+    return OpticalImage(photons=photons, wave=wave)
+
+
+def test_oi_adjust_illuminance_scale_up():
+    oi = _simple_oi(1.0)
+    target = 10.0
+    out = oi_adjust_illuminance(oi, target)
+    illum = luminance_from_photons(out.photons, out.wave)
+    assert np.isclose(illum.mean(), target)
+
+
+def test_oi_adjust_illuminance_scale_down():
+    oi = _simple_oi(5.0)
+    target = 1.0
+    out = oi_adjust_illuminance(oi, target)
+    illum = luminance_from_photons(out.photons, out.wave)
+    assert np.isclose(illum.mean(), target)


### PR DESCRIPTION
## Summary
- implement `oi_adjust_illuminance` for optical images
- export the new function in `opticalimage.__init__`
- add unit tests covering illuminance scaling

## Testing
- `pytest -q python/tests/test_oi_adjust_illuminance.py`