### PR TITLE
Add bayer_indices helper and tests

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -59,6 +59,7 @@ from .imgproc import (
     ie_internal_to_display,
     ie_nearest_neighbor,
     ie_bilinear,
+    bayer_indices,
 )
 from .ie_spectra_sphere import ie_spectra_sphere
 from .metrics.ie_psnr import ie_psnr
@@ -131,6 +132,7 @@ __all__ = [
     'ie_internal_to_display',
     'ie_nearest_neighbor',
     'ie_bilinear',
+    'bayer_indices',
     'ie_psnr',
     'scielab',
     'sc_params',

--- a/python/isetcam/imgproc/__init__.py
+++ b/python/isetcam/imgproc/__init__.py
@@ -2,11 +2,12 @@
 
 from .image_distort import image_distort
 from .ie_internal_to_display import ie_internal_to_display
-from .demosaic import ie_nearest_neighbor, ie_bilinear
+from .demosaic import ie_nearest_neighbor, ie_bilinear, bayer_indices
 
 __all__ = [
     "image_distort",
     "ie_internal_to_display",
     "ie_nearest_neighbor",
     "ie_bilinear",
+    "bayer_indices",
 ]

--- a/python/isetcam/imgproc/demosaic/__init__.py
+++ b/python/isetcam/imgproc/demosaic/__init__.py
@@ -2,5 +2,6 @@
 
 from .ie_nearest_neighbor import ie_nearest_neighbor
 from .ie_bilinear import ie_bilinear
+from .bayer_indices import bayer_indices
 
-__all__ = ["ie_nearest_neighbor", "ie_bilinear"]
+__all__ = ["ie_nearest_neighbor", "ie_bilinear", "bayer_indices"]

--- a/python/isetcam/imgproc/demosaic/bayer_indices.py
+++ b/python/isetcam/imgproc/demosaic/bayer_indices.py
@@ -1,0 +1,71 @@
+"""Determine pixel positions for a Bayer mosaic."""
+
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import numpy as np
+
+
+def bayer_indices(
+    pattern: str,
+    size: int | Sequence[int],
+    clip: int = 0,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return index arrays for R, B, G1 and G2 pixels.
+
+    Parameters
+    ----------
+    pattern : str
+        CFA pattern such as ``"rggb"`` or ``"grbg"``.
+    size : int | Sequence[int]
+        Image size given either as ``(rows, cols)`` or a single integer for
+        square images.
+    clip : int, optional
+        Number of pixels to ignore at each border. Default is ``0``.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        Arrays ``(rx, ry, bx, by, g1x, g1y, g2x, g2y)`` containing zero-based
+        column and row indices of the respective pixel types.
+    """
+
+    if isinstance(size, int):
+        vex = hex_ = int(size)
+    else:
+        if len(size) != 2:
+            raise ValueError("size must be an int or a length-2 sequence")
+        vex, hex_ = int(size[0]), int(size[1])
+
+    pattern = pattern.lower()
+    if pattern not in {"rggb", "grbg", "gbrg", "bggr"}:
+        raise ValueError("Unsupported Bayer pattern")
+
+    c0 = np.arange(clip, hex_ - clip, 2, dtype=int)
+    c1 = np.arange(1 + clip, hex_ - clip, 2, dtype=int)
+    r0 = np.arange(clip, vex - clip, 2, dtype=int)
+    r1 = np.arange(1 + clip, vex - clip, 2, dtype=int)
+
+    if pattern == "grbg":
+        g1x, g1y = c0, r0
+        rx, ry = c1, r0
+        bx, by = c0, r1
+        g2x, g2y = c1, r1
+    elif pattern == "rggb":
+        g1x, g1y = c1, r0
+        rx, ry = c0, r0
+        bx, by = c1, r1
+        g2x, g2y = c0, r1
+    elif pattern == "gbrg":
+        g1x, g1y = c0, r0
+        rx, ry = c0, r1
+        bx, by = c1, r0
+        g2x, g2y = c1, r1
+    else:  # pattern == "bggr"
+        g1x, g1y = c1, r0
+        rx, ry = c1, r1
+        bx, by = c0, r0
+        g2x, g2y = c0, r1
+
+    return rx, ry, bx, by, g1x, g1y, g2x, g2y

--- a/python/tests/test_bayer_indices.py
+++ b/python/tests/test_bayer_indices.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from isetcam.imgproc.demosaic import bayer_indices
+
+
+def test_bayer_indices_rggb():
+    rx, ry, bx, by, g1x, g1y, g2x, g2y = bayer_indices("rggb", (4, 4))
+    assert np.array_equal(rx, np.array([0, 2]))
+    assert np.array_equal(ry, np.array([0, 2]))
+    assert np.array_equal(bx, np.array([1, 3]))
+    assert np.array_equal(by, np.array([1, 3]))
+    assert np.array_equal(g1x, np.array([1, 3]))
+    assert np.array_equal(g1y, np.array([0, 2]))
+    assert np.array_equal(g2x, np.array([0, 2]))
+    assert np.array_equal(g2y, np.array([1, 3]))
+
+
+def test_bayer_indices_grbg():
+    rx, ry, bx, by, g1x, g1y, g2x, g2y = bayer_indices("grbg", (4, 4))
+    assert np.array_equal(rx, np.array([1, 3]))
+    assert np.array_equal(ry, np.array([0, 2]))
+    assert np.array_equal(bx, np.array([0, 2]))
+    assert np.array_equal(by, np.array([1, 3]))
+    assert np.array_equal(g1x, np.array([0, 2]))
+    assert np.array_equal(g1y, np.array([0, 2]))
+    assert np.array_equal(g2x, np.array([1, 3]))
+    assert np.array_equal(g2y, np.array([1, 3]))
+
+
+def test_bayer_indices_gbrg():
+    rx, ry, bx, by, g1x, g1y, g2x, g2y = bayer_indices("gbrg", (4, 4))
+    assert np.array_equal(rx, np.array([0, 2]))
+    assert np.array_equal(ry, np.array([1, 3]))
+    assert np.array_equal(bx, np.array([1, 3]))
+    assert np.array_equal(by, np.array([0, 2]))
+    assert np.array_equal(g1x, np.array([0, 2]))
+    assert np.array_equal(g1y, np.array([0, 2]))
+    assert np.array_equal(g2x, np.array([1, 3]))
+    assert np.array_equal(g2y, np.array([1, 3]))
+
+
+def test_bayer_indices_bggr():
+    rx, ry, bx, by, g1x, g1y, g2x, g2y = bayer_indices("bggr", (4, 4))
+    assert np.array_equal(rx, np.array([1, 3]))
+    assert np.array_equal(ry, np.array([1, 3]))
+    assert np.array_equal(bx, np.array([0, 2]))
+    assert np.array_equal(by, np.array([0, 2]))
+    assert np.array_equal(g1x, np.array([1, 3]))
+    assert np.array_equal(g1y, np.array([0, 2]))
+    assert np.array_equal(g2x, np.array([0, 2]))
+    assert np.array_equal(g2y, np.array([1, 3]))


### PR DESCRIPTION
## Summary
- port `bayerIndices.m` logic to Python as `bayer_indices`
- expose helper from `imgproc.demosaic` and top level package
- test `bayer_indices` for four Bayer patterns

## Testing
- `python -m pytest -q`