### PR TITLE
Add ie_read_spectra utility with tests

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -55,6 +55,7 @@ from .ctemp_to_srgb import ctemp_to_srgb
 from .init_default_spectrum import init_default_spectrum
 from .mk_inv_gamma_table import mk_inv_gamma_table
 from .ie_cov_ellipsoid import ie_cov_ellipsoid
+from .ie_read_spectra import ie_read_spectra
 from .imgproc import (
     image_distort,
     ie_internal_to_display,
@@ -130,6 +131,7 @@ __all__ = [
     'init_default_spectrum',
     'mk_inv_gamma_table',
     'ie_cov_ellipsoid',
+    'ie_read_spectra',
     'ie_spectra_sphere',
     'image_distort',
     'ie_internal_to_display',

--- a/python/isetcam/ie_read_spectra.py
+++ b/python/isetcam/ie_read_spectra.py
@@ -1,0 +1,85 @@
+"""Load spectral data from a MATLAB file and interpolate.
+
+This function reads variables ``data`` and ``wavelength`` from a MAT-file,
+optionally interpolates to a new wavelength sampling, and returns the data
+along with any ``comment`` variable found in the file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import numpy as np
+from scipy.io import loadmat
+
+
+def ie_read_spectra(
+    fname: str | Path,
+    wave: Iterable[float] | None = None,
+    extrap_val: float = 0.0,
+    make_positive: bool = False,
+) -> Tuple[np.ndarray, np.ndarray, str | None, Path]:
+    """Read spectral data from ``fname`` and interpolate to ``wave``.
+
+    Parameters
+    ----------
+    fname:
+        Path to a MATLAB ``.mat`` file containing ``data`` and ``wavelength``
+        variables.
+    wave:
+        Optional wavelength samples to interpolate the data to. If ``None``,
+        the data are returned at their native sampling.
+    extrap_val:
+        Value used for extrapolation outside the wavelength range in the file.
+    make_positive:
+        If ``True``, flip the sign of the data so that the mean of the first
+        column is positive.
+
+    Returns
+    -------
+    res:
+        Spectral data interpolated to ``wave`` when provided.
+    wave:
+        Wavelength samples corresponding to ``res``.
+    comment:
+        Comment string from the file if present, otherwise ``None``.
+    fname:
+        Path to the loaded file.
+    """
+    path = Path(fname)
+    mat = loadmat(path)
+
+    if "data" not in mat or "wavelength" not in mat:
+        raise KeyError("File must contain 'data' and 'wavelength'")
+
+    data = np.asarray(mat["data"], dtype=float)
+    src_wave = np.asarray(mat["wavelength"], dtype=float).reshape(-1)
+    comment = mat.get("comment")
+    if isinstance(comment, np.ndarray):
+        comment = str(comment.squeeze())
+
+    if data.shape[0] != src_wave.size:
+        raise ValueError("Mis-match between wavelength and data variables")
+
+    if wave is None:
+        wave_out = src_wave
+        res = data.astype(float)
+    else:
+        wave_out = np.asarray(list(wave), dtype=float).reshape(-1)
+        if data.ndim == 1:
+            res = np.interp(wave_out, src_wave, data, left=extrap_val, right=extrap_val)
+        else:
+            res = np.column_stack(
+                [
+                    np.interp(wave_out, src_wave, data[:, i], left=extrap_val, right=extrap_val)
+                    for i in range(data.shape[1])
+                ]
+            )
+
+    if make_positive:
+        first = res if res.ndim == 1 else res[:, 0]
+        if np.mean(first) < 0:
+            res = -res
+
+    return res, wave_out, comment, path

--- a/python/tests/test_ie_read_spectra.py
+++ b/python/tests/test_ie_read_spectra.py
@@ -1,0 +1,37 @@
+import numpy as np
+from scipy.io import loadmat
+
+from isetcam import ie_read_spectra, iset_root_path
+
+
+def test_ie_read_spectra_interpolation():
+    root = iset_root_path()
+    path = root / "data" / "lights" / "D65.mat"
+    mat = loadmat(path)
+    wave = np.arange(400, 701, 10)
+    data = np.interp(wave, mat["wavelength"].ravel(), mat["data"].ravel()).reshape(-1, 1)
+
+    res, out_wave, comment, fname = ie_read_spectra(path, wave)
+    assert np.array_equal(out_wave, wave)
+    assert fname == path
+    assert isinstance(comment, str)
+    assert res.shape == data.shape
+    assert np.allclose(res, data)
+
+
+def test_ie_read_spectra_extrapolation():
+    root = iset_root_path()
+    path = root / "data" / "lights" / "D65.mat"
+    mat = loadmat(path)
+    wave = np.array([295, 300, 320, 835])
+    expected = np.interp(
+        wave,
+        mat["wavelength"].ravel(),
+        mat["data"].ravel(),
+        left=-1.0,
+        right=-1.0,
+    ).reshape(-1, 1)
+    res, out_wave, _, _ = ie_read_spectra(path, wave, extrap_val=-1.0)
+    assert np.array_equal(out_wave, wave)
+    assert res.shape == expected.shape
+    assert np.allclose(res, expected)


### PR DESCRIPTION
## Summary
- port `ieReadSpectra.m` to Python as `ie_read_spectra`
- export the function in `isetcam.__init__`
- add regression tests for interpolation and extrapolation

## Testing
- `pytest -q`