### PR TITLE
Implement waveband extraction utilities

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -16,6 +16,7 @@ from .oi_spatial_resample import oi_spatial_resample
 from .oi_frequency_support import oi_frequency_support
 from .oi_frequency_resample import oi_frequency_resample
 from .oi_adjust_illuminance import oi_adjust_illuminance
+from .oi_extract_waveband import oi_extract_waveband
 
 __all__ = [
     "OpticalImage",
@@ -36,4 +37,5 @@ __all__ = [
     "oi_photon_noise",
     "oi_to_file",
     "oi_adjust_illuminance",
+    "oi_extract_waveband",
 ]

--- a/python/isetcam/opticalimage/oi_extract_waveband.py
+++ b/python/isetcam/opticalimage/oi_extract_waveband.py
@@ -1,0 +1,52 @@
+"""Extract a subset of wavelengths from an :class:`OpticalImage`."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .oi_class import OpticalImage
+from ..luminance_from_photons import luminance_from_photons
+
+
+def oi_extract_waveband(
+    oi: OpticalImage, wave_list: Sequence[float], illuminance: bool = False
+) -> OpticalImage:
+    """Return a new optical image containing only wavelengths in ``wave_list``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image to subset.
+    wave_list : sequence of float
+        Wavelengths in nanometers to extract from ``oi``.
+    illuminance : bool, optional
+        When ``True``, compute and attach an ``illuminance`` attribute
+        based on the extracted photon data.
+
+    Returns
+    -------
+    OpticalImage
+        Optical image with photon data restricted to the requested
+        wavelengths.
+    """
+
+    wv = np.asarray(oi.wave, dtype=float).reshape(-1)
+    target = np.asarray(wave_list, dtype=float).reshape(-1)
+
+    indices = []
+    for w in target:
+        matches = np.where(np.isclose(wv, w))[0]
+        if matches.size == 0:
+            raise ValueError(f"Wavelength {w} not found in oi.wave")
+        indices.append(matches[0])
+
+    photons = oi.photons[:, :, indices].copy()
+    new_wave = wv[indices]
+    out = OpticalImage(photons=photons, wave=new_wave, name=oi.name)
+
+    if illuminance:
+        out.illuminance = luminance_from_photons(photons, new_wave)
+
+    return out

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -20,6 +20,7 @@ from .scene_spatial_resample import scene_spatial_resample
 from .scene_frequency_support import scene_frequency_support
 from .scene_frequency_resample import scene_frequency_resample
 from .scene_to_file import scene_to_file
+from .scene_extract_waveband import scene_extract_waveband
 
 __all__ = [
     "Scene",
@@ -44,4 +45,5 @@ __all__ = [
     "scene_create",
     "scene_photon_noise",
     "scene_to_file",
+    "scene_extract_waveband",
 ]

--- a/python/isetcam/scene/scene_extract_waveband.py
+++ b/python/isetcam/scene/scene_extract_waveband.py
@@ -1,0 +1,40 @@
+"""Extract a subset of wavelengths from a :class:`Scene`."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def scene_extract_waveband(scene: Scene, wave_list: Sequence[float]) -> Scene:
+    """Return a new scene containing only wavelengths in ``wave_list``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene to subset.
+    wave_list : sequence of float
+        Wavelengths in nanometers to extract from ``scene``.
+
+    Returns
+    -------
+    Scene
+        Scene with photon data restricted to the requested wavelengths.
+    """
+
+    wv = np.asarray(scene.wave, dtype=float).reshape(-1)
+    target = np.asarray(wave_list, dtype=float).reshape(-1)
+
+    indices = []
+    for w in target:
+        matches = np.where(np.isclose(wv, w))[0]
+        if matches.size == 0:
+            raise ValueError(f"Wavelength {w} not found in scene.wave")
+        indices.append(matches[0])
+
+    photons = scene.photons[:, :, indices].copy()
+    new_wave = wv[indices]
+    return Scene(photons=photons, wave=new_wave, name=scene.name)

--- a/python/tests/test_extract_waveband.py
+++ b/python/tests/test_extract_waveband.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pytest
+
+from isetcam.scene import Scene, scene_extract_waveband
+from isetcam.opticalimage import OpticalImage, oi_extract_waveband
+from isetcam.luminance_from_photons import luminance_from_photons
+
+
+def _simple_scene(n_wave: int = 4) -> Scene:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(2 * 2 * n_wave, dtype=float).reshape((2, 2, n_wave))
+    return Scene(photons=photons, wave=wave)
+
+
+def _simple_oi(n_wave: int = 4) -> OpticalImage:
+    wave = np.arange(500, 500 + 10 * n_wave, 10)
+    photons = np.arange(2 * 2 * n_wave, dtype=float).reshape((2, 2, n_wave))
+    return OpticalImage(photons=photons, wave=wave)
+
+
+def test_scene_extract_waveband_basic():
+    sc = _simple_scene(4)
+    out = scene_extract_waveband(sc, [sc.wave[1], sc.wave[3]])
+    assert np.array_equal(out.photons, sc.photons[:, :, [1, 3]])
+    assert np.array_equal(out.wave, sc.wave[[1, 3]])
+
+
+def test_scene_extract_waveband_invalid():
+    sc = _simple_scene(3)
+    with pytest.raises(ValueError):
+        scene_extract_waveband(sc, [999])
+
+
+def test_oi_extract_waveband_basic():
+    oi = _simple_oi(3)
+    out = oi_extract_waveband(oi, [oi.wave[0], oi.wave[2]])
+    assert np.array_equal(out.photons, oi.photons[:, :, [0, 2]])
+    assert np.array_equal(out.wave, oi.wave[[0, 2]])
+    assert not hasattr(out, "illuminance")
+
+
+def test_oi_extract_waveband_illuminance():
+    oi = _simple_oi(2)
+    out = oi_extract_waveband(oi, [oi.wave[1]], illuminance=True)
+    expected = luminance_from_photons(oi.photons[:, :, [1]], oi.wave[[1]])
+    assert hasattr(out, "illuminance")
+    assert np.allclose(out.illuminance, expected)


### PR DESCRIPTION
## Summary
- add `scene_extract_waveband` and `oi_extract_waveband`
- export new helpers in package `__init__` files
- test extraction of spectral bands and optional illuminance recompute

## Testing
- `pytest python/tests/test_extract_waveband.py -q`
- `pip install -e python` *(fails: could not resolve packages)*