### PR TITLE
Add sensor SNR utilities

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -12,6 +12,8 @@ from .sensor_compute import sensor_compute
 from .sensor_photon_noise import sensor_photon_noise
 from .sensor_to_file import sensor_to_file
 from .sensor_create import sensor_create
+from .sensor_snr import sensor_snr
+from .sensor_snr_luxsec import sensor_snr_luxsec
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -53,4 +55,6 @@ __all__ = [
     "sensor_photon_noise",
     "sensor_to_file",
     "sensor_create",
+    "sensor_snr",
+    "sensor_snr_luxsec",
 ]

--- a/python/isetcam/sensor/sensor_get.py
+++ b/python/isetcam/sensor/sensor_get.py
@@ -14,7 +14,11 @@ def sensor_get(sensor: Sensor, param: str) -> Any:
     """Return a parameter value from ``sensor``.
 
     Supported parameters are ``volts``, ``wave``, ``n_wave``/``nwave``,
-    ``exposure_time``/``exposure time`` and ``name``.
+    ``exposure_time``/``exposure time`` and ``name``.  Additional optional
+    noise related parameters are ``conversion_gain``, ``read_noise_electrons``,
+    ``gain_sd`` (in percent), ``offset_sd`` and ``voltage_swing``.  These are
+    returned as attributes on ``sensor`` and default to sensible values when
+    absent.
     """
     key = ie_param_format(param)
     if key == "volts":
@@ -27,4 +31,20 @@ def sensor_get(sensor: Sensor, param: str) -> Any:
         return sensor.exposure_time
     if key == "name":
         return getattr(sensor, "name", None)
+    if key in {"conversiongain", "conversion_gain"}:
+        return getattr(sensor, "conversion_gain", 1.0)
+    if key in {"readnoiseelectrons", "read_noise_electrons"}:
+        return getattr(sensor, "read_noise_electrons", 0.0)
+    if key in {"gainsd", "gain_sd"}:
+        return getattr(sensor, "gain_sd", 0.0)
+    if key in {"offsetsd", "offset_sd"}:
+        return getattr(sensor, "offset_sd", 0.0)
+    if key in {"voltageswing", "voltage_swing"}:
+        return getattr(sensor, "voltage_swing", 1.0)
+    if key in {"ncolors", "n_colors"}:
+        if hasattr(sensor, "n_colors") and sensor.n_colors is not None:
+            return sensor.n_colors
+        return sensor.volts.shape[2] if sensor.volts.ndim == 3 else 1
+    if key in {"filtercolorletters", "filter_color_letters"}:
+        return getattr(sensor, "filter_color_letters", None)
     raise KeyError(f"Unknown sensor parameter '{param}'")

--- a/python/isetcam/sensor/sensor_set.py
+++ b/python/isetcam/sensor/sensor_set.py
@@ -15,6 +15,9 @@ def sensor_set(sensor: Sensor, param: str, val: Any) -> None:
 
     Supported parameters are ``volts``, ``wave``, ``exposure_time``/``exposure time``
     and ``name``. ``n_wave`` is derived from ``wave`` and therefore cannot be set.
+    Noise related parameters (``conversion_gain``, ``read_noise_electrons``,
+    ``gain_sd``, ``offset_sd`` and ``voltage_swing``) are stored as attributes on
+    ``sensor`` when supplied.
     """
     key = ie_param_format(param)
     if key == "volts":
@@ -28,5 +31,20 @@ def sensor_set(sensor: Sensor, param: str, val: Any) -> None:
         return
     if key == "name":
         sensor.name = None if val is None else str(val)
+        return
+    if key in {"conversiongain", "conversion_gain"}:
+        sensor.conversion_gain = float(val)
+        return
+    if key in {"readnoiseelectrons", "read_noise_electrons"}:
+        sensor.read_noise_electrons = float(val)
+        return
+    if key in {"gainsd", "gain_sd"}:
+        sensor.gain_sd = float(val)
+        return
+    if key in {"offsetsd", "offset_sd"}:
+        sensor.offset_sd = float(val)
+        return
+    if key in {"voltageswing", "voltage_swing"}:
+        sensor.voltage_swing = float(val)
         return
     raise KeyError(f"Unknown or read-only sensor parameter '{param}'")

--- a/python/isetcam/sensor/sensor_snr.py
+++ b/python/isetcam/sensor/sensor_snr.py
@@ -1,0 +1,77 @@
+"""Estimate sensor SNR as a function of voltage level."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from .sensor_class import Sensor
+from .sensor_get import sensor_get
+
+
+def sensor_snr(
+    sensor: Sensor, volts: np.ndarray | None = None
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return the sensor SNR curve.
+
+    Parameters
+    ----------
+    sensor:
+        Sensor object containing noise related attributes such as
+        ``conversion_gain`` and ``read_noise_electrons``.  If these are not
+        present they default to sensible values (e.g. ``conversion_gain`` of
+        ``1.0`` and no additional noise).
+    volts:
+        Optional voltage levels at which to evaluate the SNR.  When ``None`` a
+        logarithmic range from ``1e-4`` to ``sensor.voltage_swing`` is used.
+
+    Returns
+    -------
+    tuple of arrays
+        ``(snr, volts, snr_shot, snr_read, snr_dsnu, snr_prnu)`` where each
+        element is a 1-D ``numpy.ndarray``.
+    """
+
+    v_swing = sensor_get(sensor, "voltage_swing")
+    if volts is None:
+        volts = np.logspace(-4, 0, 20) * v_swing
+    else:
+        volts = np.asarray(volts, dtype=float)
+
+    conv_gain = sensor_get(sensor, "conversion_gain")
+    read_sd = sensor_get(sensor, "read_noise_electrons")
+    gain_sd = sensor_get(sensor, "gain_sd") / 100.0
+    offset_sd = sensor_get(sensor, "offset_sd")
+
+    shot_sd = np.sqrt(volts / conv_gain)
+    prnu_sd = gain_sd * (volts / conv_gain)
+    dsnu_sd = offset_sd / conv_gain
+
+    signal_power = (volts / conv_gain) ** 2
+    noise_power = shot_sd**2 + read_sd**2 + dsnu_sd**2 + prnu_sd**2
+
+    snr = 10.0 * np.log10(signal_power / noise_power)
+
+    snr_shot = 10.0 * np.log10(signal_power / (shot_sd**2))
+    snr_read = (
+        np.full_like(snr, np.inf)
+        if read_sd == 0
+        else 10.0 * np.log10(signal_power / (read_sd**2))
+    )
+    snr_dsnu = (
+        np.full_like(snr, np.inf)
+        if dsnu_sd == 0
+        else 10.0 * np.log10(signal_power / (dsnu_sd**2))
+    )
+    snr_prnu = (
+        np.full_like(snr, np.inf)
+        if np.all(prnu_sd == 0)
+        else 10.0 * np.log10(signal_power / (prnu_sd**2))
+    )
+
+    return snr, volts, snr_shot, snr_read, snr_dsnu, snr_prnu
+
+
+__all__ = ["sensor_snr"]
+

--- a/python/isetcam/sensor/sensor_snr_luxsec.py
+++ b/python/isetcam/sensor/sensor_snr_luxsec.py
@@ -1,0 +1,42 @@
+"""Sensor SNR as a function of photometric exposure (lux-seconds)."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from .sensor_class import Sensor
+from .sensor_get import sensor_get
+from .sensor_snr import sensor_snr
+
+
+def sensor_snr_luxsec(sensor: Sensor) -> Tuple[np.ndarray, np.ndarray]:
+    """Return sensor SNR versus photometric exposure.
+
+    The conversion from volts to lux-seconds is controlled by the optional
+    ``volts_per_lux_sec`` attribute on ``sensor``.  When absent a value of ``1``
+    is assumed.
+    """
+
+    snr, volts, *_ = sensor_snr(sensor)
+
+    v_per_ls = getattr(sensor, "volts_per_lux_sec", 1.0)
+    n_colors = sensor_get(sensor, "ncolors")
+
+    luxsec = np.zeros((volts.size, n_colors), dtype=float)
+    if np.isscalar(v_per_ls):
+        for i in range(n_colors):
+            luxsec[:, i] = volts / v_per_ls
+    else:
+        v_per_ls = np.asarray(v_per_ls, dtype=float)
+        if v_per_ls.size != n_colors:
+            raise ValueError("volts_per_lux_sec length must match number of colors")
+        for i in range(n_colors):
+            luxsec[:, i] = volts / v_per_ls[i]
+
+    return snr, luxsec
+
+
+__all__ = ["sensor_snr_luxsec"]
+

--- a/python/tests/test_sensor_snr.py
+++ b/python/tests/test_sensor_snr.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from isetcam.sensor import Sensor, sensor_set, sensor_snr, sensor_snr_luxsec
+
+
+def _expected(volts, cg, read_sd, gain_sd_percent, offset_sd):
+    gain_sd = gain_sd_percent / 100.0
+    shot_sd = np.sqrt(volts / cg)
+    prnu_sd = gain_sd * (volts / cg)
+    dsnu_sd = offset_sd / cg
+    signal_power = (volts / cg) ** 2
+    noise_power = shot_sd ** 2 + read_sd ** 2 + dsnu_sd ** 2 + prnu_sd ** 2
+    snr = 10 * np.log10(signal_power / noise_power)
+    snr_shot = 10 * np.log10(signal_power / (shot_sd ** 2))
+    snr_read = np.inf if read_sd == 0 else 10 * np.log10(signal_power / (read_sd ** 2))
+    snr_dsnu = np.inf if dsnu_sd == 0 else 10 * np.log10(signal_power / (dsnu_sd ** 2))
+    snr_prnu = np.inf if np.all(prnu_sd == 0) else 10 * np.log10(signal_power / (prnu_sd ** 2))
+    return snr, snr_shot, snr_read, snr_dsnu, snr_prnu
+
+
+def test_sensor_snr_basic():
+    s = Sensor(volts=np.zeros((1,)), wave=np.array([550]), exposure_time=0.01)
+    sensor_set(s, "conversion_gain", 2.0)
+    sensor_set(s, "read_noise_electrons", 1.0)
+    sensor_set(s, "gain_sd", 10.0)
+    sensor_set(s, "offset_sd", 0.5)
+    sensor_set(s, "voltage_swing", 1.0)
+
+    volts = np.array([0.1, 0.5])
+    snr, v, snr_shot, snr_read, snr_dsnu, snr_prnu = sensor_snr(s, volts)
+
+    exp_snr, exp_shot, exp_read, exp_dsnu, exp_prnu = _expected(
+        volts, 2.0, 1.0, 10.0, 0.5
+    )
+
+    assert np.allclose(v, volts)
+    assert np.allclose(snr, exp_snr)
+    assert np.allclose(snr_shot, exp_shot)
+    assert np.allclose(snr_read, exp_read)
+    assert np.allclose(snr_dsnu, exp_dsnu)
+    assert np.allclose(snr_prnu, exp_prnu)
+
+
+def test_sensor_snr_luxsec():
+    volts = np.zeros((1, 1, 2))
+    s = Sensor(volts=volts, wave=np.array([550]), exposure_time=0.01)
+    s.volts_per_lux_sec = [1.0, 2.0]
+
+    snr, luxsec = sensor_snr_luxsec(s)
+    snr_expected, volts = sensor_snr(s)[:2]
+
+    lux_expected = np.column_stack((volts, volts / 2.0))
+
+    assert np.allclose(snr, snr_expected)
+    assert np.allclose(luxsec, lux_expected)


### PR DESCRIPTION
## Summary
- implement `sensor_snr` and `sensor_snr_luxsec` in Python
- support new noise parameters in `sensor_get`/`sensor_set`
- export the new utilities from `isetcam.sensor`
- test SNR calculations against reference values

## Testing
- `PYTHONPATH=python pytest -q`