### PR TITLE
Implement camera MTF

### DIFF
--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -7,6 +7,7 @@ from .camera_to_file import camera_to_file
 from .camera_from_file import camera_from_file
 from .camera_create import camera_create
 from .camera_compute import camera_compute
+from .camera_mtf import camera_mtf
 
 __all__ = [
     "Camera",
@@ -16,4 +17,5 @@ __all__ = [
     "camera_from_file",
     "camera_create",
     "camera_compute",
+    "camera_mtf",
 ]

--- a/python/isetcam/camera/camera_mtf.py
+++ b/python/isetcam/camera/camera_mtf.py
@@ -1,0 +1,84 @@
+"""Compute camera MTF from sensor and optics models."""
+
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import numpy as np
+
+from .camera_class import Camera
+
+
+_DEF_PIXEL_SIZE = 2.8e-6  # meters, matches sensor_create default
+_DEF_WAVELENGTH = 550e-9  # meters
+
+
+def _pixel_mtf(freq: np.ndarray, pixel_size: float) -> np.ndarray:
+    """Return MTF of a square pixel aperture.
+
+    Parameters
+    ----------
+    freq : np.ndarray
+        Spatial frequencies in cycles/mm.
+    pixel_size : float
+        Pixel width in meters.
+    """
+    pixel_mm = pixel_size * 1e3
+    return np.abs(np.sinc(freq * pixel_mm))
+
+
+def _diffraction_mtf(freq: np.ndarray, f_number: float, wavelength: float) -> np.ndarray:
+    """Diffraction limited optics MTF for a circular aperture."""
+    # cutoff frequency in cycles/mm
+    f_cutoff = 1.0 / (wavelength * f_number) / 1e3
+    norm_freq = np.asarray(freq, dtype=float) / float(f_cutoff)
+    mtf = np.zeros_like(norm_freq)
+    inside = norm_freq <= 1.0
+    f = norm_freq[inside]
+    mtf[inside] = (2 / np.pi) * (np.arccos(f) - f * np.sqrt(1.0 - f**2))
+    return mtf
+
+
+def camera_mtf(camera: Camera,
+               freqs: Sequence[float] | None = None,
+               method: str = "product") -> Tuple[np.ndarray, np.ndarray]:
+    """Return the modulation transfer function of ``camera``.
+
+    Parameters
+    ----------
+    camera : Camera
+        Camera instance containing ``sensor`` and ``optics`` models.
+    freqs : sequence of float, optional
+        Spatial frequencies in cycles/mm. When ``None`` a range from 0 to
+        the optics diffraction limit is used.
+    method : str, optional
+        Combination method. Only ``"product"`` (pixel MTF times optics MTF)
+        is implemented.
+
+    Returns
+    -------
+    freqs : np.ndarray
+        Frequency samples used for the calculation (cycles/mm).
+    mtf : np.ndarray
+        MTF values corresponding to ``freqs``.
+    """
+    pixel_size = getattr(camera.sensor, "pixel_size", _DEF_PIXEL_SIZE)
+    f_number = getattr(camera.optics, "f_number", 4.0)
+    wavelength = float(np.mean(camera.sensor.wave)) * 1e-9 if getattr(camera.sensor, "wave", None) is not None else _DEF_WAVELENGTH
+    # diffraction cutoff frequency in cycles/mm
+    f_cutoff = 1.0 / (wavelength * f_number) / 1e3
+    if freqs is None:
+        freqs = np.linspace(0, f_cutoff, 100)
+    else:
+        freqs = np.asarray(freqs, dtype=float)
+
+    if method != "product":
+        raise ValueError(f"Unknown method '{method}'")
+
+    mtf_pixel = _pixel_mtf(freqs, pixel_size)
+    mtf_optics = _diffraction_mtf(freqs, f_number, wavelength)
+    mtf = mtf_pixel * mtf_optics
+    return freqs, mtf
+
+
+__all__ = ["camera_mtf"]

--- a/python/tests/test_camera_mtf.py
+++ b/python/tests/test_camera_mtf.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+from isetcam.camera import camera_create, camera_mtf
+
+
+def _expected(freqs, camera):
+    pixel = getattr(camera.sensor, "pixel_size", 2.8e-6)
+    f_number = getattr(camera.optics, "f_number", 4.0)
+    wave = np.mean(camera.sensor.wave) * 1e-9
+    f_cutoff = 1.0 / (wave * f_number) / 1e3
+    pixel_mtf = np.abs(np.sinc(freqs * pixel * 1e3))
+    nf = freqs / f_cutoff
+    optics_mtf = np.zeros_like(freqs)
+    inside = nf <= 1.0
+    f = nf[inside]
+    optics_mtf[inside] = (2 / np.pi) * (np.arccos(f) - f * np.sqrt(1 - f ** 2))
+    return pixel_mtf * optics_mtf
+
+
+def test_camera_mtf_default():
+    cam = camera_create()
+    freqs, mtf = camera_mtf(cam)
+    expected = _expected(freqs, cam)
+    assert np.allclose(mtf, expected)
+    assert freqs[0] == pytest.approx(0.0)
+    assert mtf[0] == pytest.approx(1.0)
+    assert mtf[-1] <= 1.0
+
+
+def test_camera_mtf_custom_freq_and_error():
+    cam = camera_create()
+    f = np.linspace(0, 50, 10)
+    freqs, mtf = camera_mtf(cam, f)
+    expected = _expected(f, cam)
+    assert np.allclose(freqs, f)
+    assert np.allclose(mtf, expected)
+    with pytest.raises(ValueError):
+        camera_mtf(cam, f, method="unknown")


### PR DESCRIPTION
## Summary
- add `camera_mtf` for computing camera MTF from sensor/optics models
- export `camera_mtf` from the camera package
- test camera MTF on synthetic data

## Testing
- `pytest python/tests/test_camera_mtf.py -q`
- `pytest -q`