### PR TITLE
Add scene_add_grid utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -21,6 +21,7 @@ from .scene_frequency_support import scene_frequency_support
 from .scene_frequency_resample import scene_frequency_resample
 from .scene_to_file import scene_to_file
 from .scene_extract_waveband import scene_extract_waveband
+from .scene_add_grid import scene_add_grid
 
 __all__ = [
     "Scene",
@@ -46,4 +47,5 @@ __all__ = [
     "scene_photon_noise",
     "scene_to_file",
     "scene_extract_waveband",
+    "scene_add_grid",
 ]

--- a/python/isetcam/scene/scene_add_grid.py
+++ b/python/isetcam/scene/scene_add_grid.py
@@ -1,0 +1,65 @@
+"""Add black grid lines to a Scene."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def scene_add_grid(scene: Scene, p_size: int | Sequence[int], g_width: int = 1) -> Scene:
+    """Overlay black grid lines on ``scene`` photon data.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene whose photons will be modified.
+    p_size : int or sequence of int
+        Grid spacing in pixels specified as ``(row_spacing, col_spacing)``.
+        A single integer uses the same spacing in both dimensions.
+    g_width : int, optional
+        Width of the grid lines in pixels. Defaults to ``1``.
+
+    Returns
+    -------
+    Scene
+        New scene with grid lines added. Wavelength information is
+        preserved and the scene name is appended with "with grid".
+    """
+
+    if isinstance(p_size, Sequence):
+        spacing = list(p_size)
+        if len(spacing) == 1:
+            spacing = [int(spacing[0]), int(spacing[0])]
+        elif len(spacing) >= 2:
+            spacing = [int(spacing[0]), int(spacing[1])]
+        else:
+            raise ValueError("p_size must be an int or sequence of one or two ints")
+    else:
+        spacing = [int(p_size), int(p_size)]
+
+    g_width = int(g_width)
+    if g_width < 1:
+        raise ValueError("g_width must be >= 1")
+
+    photons = scene.photons.copy()
+    rows, cols = photons.shape[:2]
+    r_space, c_space = spacing
+
+    # Row lines including edges
+    photons[:g_width, :, :] = 0
+    for r in range(r_space, rows - 1, r_space):
+        photons[r : r + g_width, :, :] = 0
+    photons[rows - g_width : rows, :, :] = 0
+
+    # Column lines including edges
+    photons[:, :g_width, :] = 0
+    for c in range(c_space, cols - 1, c_space):
+        photons[:, c : c + g_width, :] = 0
+    photons[:, cols - g_width : cols, :] = 0
+
+    name = f"{scene.name} with grid" if scene.name else "with grid"
+
+    return Scene(photons=photons, wave=scene.wave, name=name)

--- a/python/tests/test_scene_add_grid.py
+++ b/python/tests/test_scene_add_grid.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_add_grid
+
+
+def _simple_scene(width: int = 6, height: int = 5, n_wave: int = 1) -> Scene:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    return Scene(photons=photons, wave=wave, name="base")
+
+
+def _expected_grid(data: np.ndarray, p_size, g_width):
+    out = data.copy()
+    rows, cols = data.shape[:2]
+    r_space, c_space = p_size
+    out[:g_width, :, :] = 0
+    for r in range(r_space, rows - 1, r_space):
+        out[r:r+g_width, :, :] = 0
+    out[rows-g_width:rows, :, :] = 0
+    out[:, :g_width, :] = 0
+    for c in range(c_space, cols - 1, c_space):
+        out[:, c:c+g_width, :] = 0
+    out[:, cols-g_width:cols, :] = 0
+    return out
+
+
+def test_scene_add_grid_basic():
+    sc = _simple_scene(6, 5, 1)
+    out = scene_add_grid(sc, (2, 3), g_width=1)
+    expected = _expected_grid(sc.photons, (2, 3), 1)
+    assert np.array_equal(out.photons, expected)
+    assert np.array_equal(out.wave, sc.wave)
+
+
+def test_scene_add_grid_single_spacing_width():
+    sc = _simple_scene(7, 7, 1)
+    out = scene_add_grid(sc, 3, g_width=2)
+    expected = _expected_grid(sc.photons, (3, 3), 2)
+    assert np.array_equal(out.photons, expected)
+
+
+def test_scene_add_grid_name():
+    sc = _simple_scene(4, 4, 1)
+    out = scene_add_grid(sc, 2, g_width=1)
+    assert out.name != sc.name
+    assert "grid" in out.name


### PR DESCRIPTION
## Summary
- add `scene_add_grid` function to overlay grid lines on a Scene
- export function in `isetcam.scene` package
- add tests for `scene_add_grid`

## Testing
- `pytest -q`
