### PR TITLE
Implement scene_combine utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -22,6 +22,7 @@ from .scene_frequency_resample import scene_frequency_resample
 from .scene_to_file import scene_to_file
 from .scene_extract_waveband import scene_extract_waveband
 from .scene_add_grid import scene_add_grid
+from .scene_combine import scene_combine
 
 __all__ = [
     "Scene",
@@ -48,4 +49,5 @@ __all__ = [
     "scene_to_file",
     "scene_extract_waveband",
     "scene_add_grid",
+    "scene_combine",
 ]

--- a/python/isetcam/scene/scene_combine.py
+++ b/python/isetcam/scene/scene_combine.py
@@ -1,0 +1,70 @@
+"""Combine two scenes horizontally, vertically, or in a grid."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+_VALID_DIRS = {"horizontal", "vertical", "both", "centered"}
+
+
+def scene_combine(scene1: Scene, scene2: Scene, direction: str = "horizontal") -> Scene:
+    """Combine two scenes using the specified orientation.
+
+    Parameters
+    ----------
+    scene1 : Scene
+        First scene to combine.
+    scene2 : Scene
+        Second scene to combine. Must have the same wavelength sampling as
+        ``scene1``.
+    direction : {"horizontal", "vertical", "both", "centered"}, optional
+        Orientation of the combination. Defaults to ``"horizontal"``.
+
+    Returns
+    -------
+    Scene
+        New scene containing the combined photon data with the same wavelength
+        samples.
+    """
+
+    if direction is None:
+        direction = "horizontal"
+    direction = str(direction).lower()
+    if direction not in _VALID_DIRS:
+        raise ValueError("direction must be 'horizontal', 'vertical', 'both', or 'centered'")
+
+    if not np.array_equal(scene1.wave, scene2.wave):
+        raise ValueError("Scenes must have matching wavelength samples")
+
+    p1 = scene1.photons
+    p2 = scene2.photons
+    r1, c1 = p1.shape[:2]
+    r2, c2 = p2.shape[:2]
+
+    if direction == "horizontal":
+        if r1 != r2:
+            raise ValueError("Scenes must have the same number of rows for horizontal combination")
+        photons = np.concatenate((p1, p2), axis=1)
+        return Scene(photons=photons, wave=scene1.wave, name=scene1.name)
+
+    if direction == "vertical":
+        if c1 != c2:
+            raise ValueError("Scenes must have the same number of columns for vertical combination")
+        photons = np.concatenate((p1, p2), axis=0)
+        return Scene(photons=photons, wave=scene1.wave, name=scene1.name)
+
+    if direction == "both":
+        tmp = scene_combine(scene1, scene2, "horizontal")
+        return scene_combine(tmp, tmp, "vertical")
+
+    # centered
+    mid = scene_combine(scene1, scene2, "horizontal")
+    mid = scene_combine(scene2, mid, "horizontal")
+    edge = scene_combine(scene2, scene2, "horizontal")
+    edge = scene_combine(edge, scene2, "horizontal")
+    tmp = scene_combine(edge, mid, "vertical")
+    return scene_combine(tmp, edge, "vertical")
+

--- a/python/tests/test_scene_combine.py
+++ b/python/tests/test_scene_combine.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytest
+
+from isetcam.scene import Scene, scene_combine
+
+
+def _scene(width: int, height: int, value: float) -> Scene:
+    wave = np.array([500, 510])
+    photons = np.full((height, width, wave.size), value, dtype=float)
+    return Scene(photons=photons, wave=wave)
+
+
+def test_scene_combine_horizontal():
+    s1 = _scene(2, 2, 1.0)
+    s2 = _scene(3, 2, 2.0)
+    out = scene_combine(s1, s2, "horizontal")
+    assert out.photons.shape == (2, 5, 2)
+    assert np.all(out.photons[:, :2, :] == 1.0)
+    assert np.all(out.photons[:, 2:, :] == 2.0)
+
+
+def test_scene_combine_vertical():
+    s1 = _scene(2, 2, 1.0)
+    s2 = _scene(2, 1, 2.0)
+    out = scene_combine(s1, s2, "vertical")
+    assert out.photons.shape == (3, 2, 2)
+    assert np.all(out.photons[:2, :, :] == 1.0)
+    assert np.all(out.photons[2:, :, :] == 2.0)
+
+
+def test_scene_combine_both():
+    s1 = _scene(1, 1, 1.0)
+    s2 = _scene(1, 1, 2.0)
+    out = scene_combine(s1, s2, "both")
+    expected = np.array(
+        [[[1.0, 1.0], [2.0, 2.0]], [[1.0, 1.0], [2.0, 2.0]]]
+    )
+    assert np.array_equal(out.photons, expected)
+
+
+def test_scene_combine_centered():
+    s1 = _scene(1, 1, 1.0)
+    s2 = _scene(1, 1, 2.0)
+    out = scene_combine(s1, s2, "centered")
+    expected = np.array(
+        [
+            [[2.0, 2.0], [2.0, 2.0], [2.0, 2.0]],
+            [[2.0, 2.0], [1.0, 1.0], [2.0, 2.0]],
+            [[2.0, 2.0], [2.0, 2.0], [2.0, 2.0]],
+        ]
+    )
+    assert np.array_equal(out.photons, expected)
+
+
+def test_scene_combine_wave_mismatch():
+    s1 = _scene(1, 1, 1.0)
+    s2 = Scene(photons=s1.photons, wave=np.array([500, 520]))
+    with pytest.raises(ValueError):
+        scene_combine(s1, s2, "horizontal")
+
+
+def test_scene_combine_size_mismatch():
+    s1 = _scene(2, 2, 1.0)
+    s2 = _scene(3, 3, 2.0)
+    with pytest.raises(ValueError):
+        scene_combine(s1, s2, "horizontal")
+


### PR DESCRIPTION
## Summary
- add `scene_combine` for combining two scenes with several layouts
- export the function from the scene package
- test new functionality for all directions and error cases

## Testing
- `PYTHONPATH=python pytest -q`