### PR TITLE
Add sensor_crop for CFA-aligned cropping

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -14,6 +14,7 @@ from .sensor_to_file import sensor_to_file
 from .sensor_create import sensor_create
 from .sensor_snr import sensor_snr
 from .sensor_snr_luxsec import sensor_snr_luxsec
+from .sensor_crop import sensor_crop
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -55,6 +56,7 @@ __all__ = [
     "sensor_photon_noise",
     "sensor_to_file",
     "sensor_create",
+    "sensor_crop",
     "sensor_snr",
     "sensor_snr_luxsec",
 ]

--- a/python/isetcam/sensor/sensor_crop.py
+++ b/python/isetcam/sensor/sensor_crop.py
@@ -1,0 +1,47 @@
+"""Crop volts from a :class:`Sensor` while preserving CFA alignment."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .sensor_class import Sensor
+
+
+def sensor_crop(sensor: Sensor, rect: Sequence[int]) -> Sensor:
+    """Return a new sensor cropped to ``rect``.
+
+    The crop rectangle is given as ``(x, y, width, height)`` using 0-based
+    indexing. To preserve the 2x2 CFA pattern alignment the ``x`` and ``y``
+    coordinates as well as ``width`` and ``height`` must be even numbers.
+    ``ValueError`` is raised if the rectangle lies outside the sensor bounds
+    or violates the CFA alignment.
+    """
+
+    if len(rect) != 4:
+        raise ValueError("rect must have four elements (x, y, width, height)")
+
+    x, y, w, h = [int(v) for v in rect]
+    if w <= 0 or h <= 0:
+        raise ValueError("width and height must be positive")
+
+    volts = np.asarray(sensor.volts)
+    s_height, s_width = volts.shape[:2]
+
+    if x < 0 or y < 0 or x + w > s_width or y + h > s_height:
+        raise ValueError("rect is outside the sensor bounds")
+
+    if (x % 2) or (y % 2) or (w % 2) or (h % 2):
+        raise ValueError("rect must align with the 2x2 CFA pattern")
+
+    cropped = volts[y : y + h, x : x + w, ...].copy()
+    out = Sensor(
+        volts=cropped,
+        wave=sensor.wave,
+        exposure_time=sensor.exposure_time,
+        name=sensor.name,
+    )
+    out.crop_rect = (x, y, w, h)
+    out.full_size = (s_height, s_width)
+    return out

--- a/python/tests/test_sensor_crop.py
+++ b/python/tests/test_sensor_crop.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+from isetcam.sensor import Sensor, sensor_crop
+
+
+def _simple_sensor(width: int = 4, height: int = 4) -> Sensor:
+    # create a simple repeating 2x2 CFA pattern
+    pattern = np.fromfunction(lambda y, x: (y % 2) * 2 + (x % 2), (height, width), dtype=int)
+    return Sensor(volts=pattern.astype(float), wave=np.array([500]), exposure_time=0.01)
+
+
+def test_sensor_crop_basic():
+    s = _simple_sensor(4, 4)
+    out = sensor_crop(s, (0, 0, 2, 2))
+    expected = s.volts[0:2, 0:2]
+    assert np.array_equal(out.volts, expected)
+    assert np.array_equal(out.wave, s.wave)
+    assert out.crop_rect == (0, 0, 2, 2)
+    assert out.full_size == (4, 4)
+
+
+def test_sensor_crop_alignment_error():
+    s = _simple_sensor(4, 4)
+    with pytest.raises(ValueError):
+        sensor_crop(s, (1, 0, 2, 2))
+    with pytest.raises(ValueError):
+        sensor_crop(s, (0, 0, 3, 2))
+


### PR DESCRIPTION
## Summary
- implement `sensor_crop` to crop sensor data while keeping CFA alignment
- expose `sensor_crop` in the sensor API
- add regression tests for the new cropping behaviour

## Testing
- `PYTHONPATH=python pytest -q`