### PR TITLE
Implement oi_compute

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -6,6 +6,7 @@ from .oi_add import oi_add
 from .oi_get import oi_get
 from .oi_set import oi_set
 from .oi_from_file import oi_from_file
+from .oi_compute import oi_compute
 from .oi_photon_noise import oi_photon_noise
 from .oi_to_file import oi_to_file
 from .oi_crop import oi_crop
@@ -27,6 +28,7 @@ __all__ = [
     "oi_get",
     "oi_set",
     "oi_from_file",
+    "oi_compute",
     "oi_crop",
     "oi_pad",
     "oi_rotate",

--- a/python/isetcam/opticalimage/oi_compute.py
+++ b/python/isetcam/opticalimage/oi_compute.py
@@ -1,0 +1,45 @@
+"""Compute an optical image from a scene and optics."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..scene import Scene
+from ..optics import Optics
+from .oi_class import OpticalImage
+
+
+def oi_compute(scene: Scene, optics: Optics) -> OpticalImage:
+    """Return the irradiance image formed by ``optics`` on ``scene``.
+
+    This simplified model interpolates the scene radiance to the
+    optics wavelength sampling, applies the optics transmittance and
+    scales the result by ``(f_length / f_number)**2``.
+    """
+
+    sc_wave = np.asarray(scene.wave, dtype=float).reshape(-1)
+    oi_wave = np.asarray(optics.wave, dtype=float).reshape(-1)
+
+    photons = np.asarray(scene.photons, dtype=float)
+    if photons.shape[-1] != sc_wave.size:
+        raise ValueError("scene.wave length must match photons shape")
+
+    flat = photons.reshape(-1, sc_wave.size)
+    interp = np.empty((flat.shape[0], oi_wave.size), dtype=float)
+    for i, spec in enumerate(flat):
+        interp[i] = np.interp(oi_wave, sc_wave, spec, left=0.0, right=0.0)
+    oi_photons = interp.reshape(photons.shape[0], photons.shape[1], oi_wave.size)
+
+    trans = optics.transmittance
+    if trans is None:
+        trans = np.ones_like(oi_wave, dtype=float)
+    else:
+        trans = np.asarray(trans, dtype=float)
+        if trans.size != oi_wave.size:
+            raise ValueError("optics.transmittance length must match optics.wave")
+    oi_photons *= trans
+
+    scale = (float(optics.f_length) / float(optics.f_number)) ** 2
+    oi_photons *= scale
+
+    return OpticalImage(photons=oi_photons, wave=oi_wave, name=getattr(scene, "name", None))

--- a/python/tests/test_oi_compute.py
+++ b/python/tests/test_oi_compute.py
@@ -1,0 +1,34 @@
+import numpy as np
+from isetcam.scene import Scene
+from isetcam.optics import Optics
+from isetcam.opticalimage import oi_compute
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([500, 510, 520], dtype=float)
+    photons = np.array([[[1.0, 2.0, 3.0]]])
+    return Scene(photons=photons, wave=wave)
+
+
+def test_oi_compute_interpolation():
+    sc = _simple_scene()
+    optics_wave = np.array([500, 505, 515, 520], dtype=float)
+    optics = Optics(f_number=2.0, f_length=2.0, wave=optics_wave)
+    oi = oi_compute(sc, optics)
+    expected = np.array([np.interp(optics_wave, sc.wave, sc.photons[0, 0])])
+    expected = expected.reshape(1, 1, optics_wave.size)
+    assert np.allclose(oi.photons, expected)
+    assert np.array_equal(oi.wave, optics_wave)
+
+
+def test_oi_compute_transmittance_and_scale():
+    sc = _simple_scene()
+    trans = np.array([0.5, 2.0, 1.0], dtype=float)
+    optics = Optics(f_number=1.0, f_length=2.0, wave=sc.wave, transmittance=trans)
+    oi = oi_compute(sc, optics)
+    scale = (optics.f_length / optics.f_number) ** 2
+    expected = sc.photons * trans * scale
+    assert np.allclose(oi.photons, expected)
+    assert np.array_equal(oi.wave, sc.wave)
+
+


### PR DESCRIPTION
## Summary
- add `oi_compute` for simple scene to optical image conversion
- export `oi_compute` in opticalimage module
- test interpolation and scaling behavior of `oi_compute`

## Testing
- `pytest -q python/tests/test_oi_compute.py`
- `pytest -q`