### PR TITLE
Add camera VSNR helper and tests

### DIFF
--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -8,6 +8,7 @@ from .camera_from_file import camera_from_file
 from .camera_create import camera_create
 from .camera_compute import camera_compute
 from .camera_mtf import camera_mtf
+from .camera_vsnr import camera_vsnr
 
 __all__ = [
     "Camera",
@@ -18,4 +19,5 @@ __all__ = [
     "camera_create",
     "camera_compute",
     "camera_mtf",
+    "camera_vsnr",
 ]

--- a/python/isetcam/camera/camera_vsnr.py
+++ b/python/isetcam/camera/camera_vsnr.py
@@ -1,0 +1,46 @@
+"""Compute visible SNR for a camera scene pair."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .camera_class import Camera
+from ..scene import Scene
+from ..opticalimage import OpticalImage
+from ..sensor import sensor_compute
+from ..quanta2energy import quanta_to_energy
+from ..ie_xyz_from_energy import ie_xyz_from_energy
+from ..metrics import xyz_to_vsnr
+
+
+def camera_vsnr(camera: Camera, scene: Scene) -> float:
+    """Return the VSNR value for ``camera`` imaging ``scene``.
+
+    The scene is converted to an optical image which is passed through the
+    sensor model using :func:`~isetcam.sensor.sensor_compute`. The scene
+    spectral energy is converted to CIE XYZ by
+    :func:`~isetcam.ie_xyz_from_energy` and the S-CIELAB domain variance is
+    summarized with :func:`~isetcam.metrics.xyz_to_vsnr`.
+    """
+
+    # Create a trivial optical image from the scene
+    oi = OpticalImage(photons=scene.photons, wave=scene.wave, name=scene.name)
+
+    # Ensure sensor wavelengths match the scene
+    if camera.sensor.wave is None or not np.array_equal(camera.sensor.wave, scene.wave):
+        camera.sensor.wave = scene.wave.copy()
+        if hasattr(camera.sensor, "qe"):
+            camera.sensor.qe = np.ones_like(camera.sensor.wave, dtype=float)
+
+    # Update the sensor response
+    sensor_compute(camera.sensor, oi)
+
+    # Convert scene photon data to energy and then to XYZ
+    energy = quanta_to_energy(scene.wave, scene.photons)
+    xyz = ie_xyz_from_energy(energy, scene.wave)
+
+    white = np.array([1.0, 1.0, 1.0], dtype=float)
+    return float(xyz_to_vsnr(xyz, white))
+
+
+__all__ = ["camera_vsnr"]

--- a/python/tests/test_camera_vsnr.py
+++ b/python/tests/test_camera_vsnr.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from isetcam.camera import camera_create, camera_vsnr
+from isetcam.scene import Scene
+from isetcam.quanta2energy import quanta_to_energy
+from isetcam.ie_xyz_from_energy import ie_xyz_from_energy
+from isetcam.metrics import xyz_to_vsnr
+
+
+def _simple_scene(w=2, h=2, n_wave=3) -> Scene:
+    wave = np.arange(500, 500 + 10 * n_wave, 10)
+    photons = np.arange(w * h * n_wave, dtype=float).reshape((h, w, n_wave))
+    return Scene(photons=photons, wave=wave)
+
+
+def test_camera_vsnr_matches_manual():
+    cam = camera_create()
+    sc = _simple_scene()
+    val = camera_vsnr(cam, sc)
+
+    energy = quanta_to_energy(sc.wave, sc.photons)
+    xyz = ie_xyz_from_energy(energy, sc.wave)
+    expected = xyz_to_vsnr(xyz, np.array([1.0, 1.0, 1.0]))
+    assert np.isclose(val, expected)
+
+
+def test_camera_vsnr_uniform_scene():
+    cam = camera_create()
+    wave = np.arange(500, 530, 10)
+    photons = np.ones((4, 4, wave.size), dtype=float)
+    sc = Scene(photons=photons, wave=wave)
+    val = camera_vsnr(cam, sc)
+    assert np.isfinite(val)
+    assert val > 0


### PR DESCRIPTION
## Summary
- implement `camera_vsnr` for VSNR calculation of a scene
- export through the `camera` package
- test VSNR computation on synthetic scenes

## Testing
- `pytest -q python/tests/test_camera_vsnr.py`
- `pytest -q`