### PR TITLE
Add illuminant MAT-file I/O helpers

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -453,6 +453,21 @@ illum = illuminant_create("D65")
 bb_spd = illuminant_blackbody(6500, illum.wave)
 ```
 
+Use `illuminant_to_file` and `illuminant_from_file` to write or read an
+`Illuminant` from a simple MAT-file:
+
+```python
+from isetcam.illuminant import (
+    Illuminant,
+    illuminant_to_file,
+    illuminant_from_file,
+)
+
+illum = Illuminant(spd=np.ones(4), wave=np.arange(4))
+illuminant_to_file(illum, "illum.mat")
+reloaded = illuminant_from_file("illum.mat")
+```
+
 ## Session Persistence
 
 The global session dictionary can be serialized to disk and reloaded via

--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -79,6 +79,7 @@ from .sensor import sensor_to_file
 from .display import display_to_file
 from .camera import camera_to_file, camera_from_file
 from .optics import optics_to_file, optics_from_file
+from .illuminant import illuminant_to_file, illuminant_from_file
 from .io import openexr_read, openexr_write
 
 __all__ = [
@@ -161,6 +162,8 @@ __all__ = [
     'oi_to_file',
     'sensor_to_file',
     'display_to_file',
+    'illuminant_to_file',
+    'illuminant_from_file',
     'camera_to_file',
     'camera_from_file',
     'optics_to_file',

--- a/python/isetcam/illuminant/__init__.py
+++ b/python/isetcam/illuminant/__init__.py
@@ -3,9 +3,13 @@
 from .illuminant_class import Illuminant
 from .illuminant_blackbody import illuminant_blackbody
 from .illuminant_create import illuminant_create
+from .illuminant_from_file import illuminant_from_file
+from .illuminant_to_file import illuminant_to_file
 
 __all__ = [
     "Illuminant",
     "illuminant_blackbody",
     "illuminant_create",
+    "illuminant_from_file",
+    "illuminant_to_file",
 ]

--- a/python/isetcam/illuminant/illuminant_from_file.py
+++ b/python/isetcam/illuminant/illuminant_from_file.py
@@ -1,0 +1,31 @@
+"""Load an :class:`Illuminant` from a MATLAB ``.mat`` file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from scipy.io import loadmat
+
+from .illuminant_class import Illuminant
+
+
+def illuminant_from_file(path: str | Path) -> Illuminant:
+    """Load ``path`` and return an :class:`Illuminant`.
+
+    Parameters
+    ----------
+    path : str or Path
+        MAT-file containing ``spd`` and ``wavelength`` variables.
+    """
+    mat = loadmat(str(Path(path)), squeeze_me=True, struct_as_record=False)
+    if "spd" not in mat or "wavelength" not in mat:
+        raise KeyError("File must contain 'spd' and 'wavelength'")
+
+    spd = np.asarray(mat["spd"], dtype=float).reshape(-1)
+    wave = np.asarray(mat["wavelength"], dtype=float).reshape(-1)
+    name = mat.get("name")
+    if isinstance(name, np.ndarray):
+        name = str(name.squeeze())
+
+    return Illuminant(spd=spd, wave=wave, name=name)

--- a/python/isetcam/illuminant/illuminant_to_file.py
+++ b/python/isetcam/illuminant/illuminant_to_file.py
@@ -1,0 +1,24 @@
+"""Utilities for saving :class:`Illuminant` objects to disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scipy.io import savemat
+
+from .illuminant_class import Illuminant
+
+
+def illuminant_to_file(illuminant: Illuminant, path: str | Path) -> None:
+    """Save ``illuminant`` to ``path`` as a MATLAB ``.mat`` file.
+
+    The spectral distribution is stored using the variables ``spd`` and
+    ``wavelength``.  When present, the ``name`` field is also saved.
+    """
+    data = {
+        "spd": illuminant.spd,
+        "wavelength": illuminant.wave,
+    }
+    if illuminant.name is not None:
+        data["name"] = illuminant.name
+    savemat(str(Path(path)), data)

--- a/python/tests/test_illuminant_file_io.py
+++ b/python/tests/test_illuminant_file_io.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from isetcam.illuminant import Illuminant, illuminant_from_file, illuminant_to_file
+
+
+def test_illuminant_file_roundtrip(tmp_path):
+    illum = Illuminant(spd=np.array([1.0, 0.5]), wave=np.array([500, 600]), name="demo")
+    path = tmp_path / "illum.mat"
+    illuminant_to_file(illum, path)
+
+    loaded = illuminant_from_file(path)
+    assert isinstance(loaded, Illuminant)
+    assert np.allclose(loaded.spd, illum.spd)
+    assert np.array_equal(loaded.wave, illum.wave)
+    assert loaded.name == illum.name


### PR DESCRIPTION
## Summary
- support reading/writing Illuminant data to MAT-files
- export the new helpers
- test the Illuminant I/O round‑trip
- document the new functions

## Testing
- `pytest -q`