### PR TITLE
Add scene_adjust_pixel_size

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -735,6 +735,15 @@ oi2 = oi_spatial_resample(oi, 1e-3)
 
 Run `pytest -q` after editing the spatial routines.
 
+`scene_adjust_pixel_size` sets the scene distance so its sample spacing
+matches a desired sensor pixel size and updates the field of view.
+
+```python
+from isetcam.scene import scene_adjust_pixel_size
+
+sc, new_d = scene_adjust_pixel_size(sc, oi, 2e-6)
+```
+
 ## Scene Frequency Support
 
 `scene_frequency_support` returns the spatial frequency grid for a scene.

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -23,6 +23,7 @@ from .scene_to_file import scene_to_file
 from .scene_extract_waveband import scene_extract_waveband
 from .scene_add_grid import scene_add_grid
 from .scene_combine import scene_combine
+from .scene_adjust_pixel_size import scene_adjust_pixel_size
 
 __all__ = [
     "Scene",
@@ -50,4 +51,5 @@ __all__ = [
     "scene_extract_waveband",
     "scene_add_grid",
     "scene_combine",
+    "scene_adjust_pixel_size",
 ]

--- a/python/isetcam/scene/scene_adjust_pixel_size.py
+++ b/python/isetcam/scene/scene_adjust_pixel_size.py
@@ -1,0 +1,42 @@
+"""Match scene sampling to a target pixel size."""
+
+from __future__ import annotations
+
+import math
+
+from .scene_class import Scene
+from ..opticalimage.oi_class import OpticalImage
+
+
+def scene_adjust_pixel_size(scene: Scene, oi: OpticalImage, pixel_size: float) -> tuple[Scene, float]:
+    """Adjust scene distance so sample spacing equals ``pixel_size``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene whose distance and field of view will be updated.
+    oi : OpticalImage
+        Optical image used with ``scene``. Currently unused but kept for
+        compatibility with the MATLAB function.
+    pixel_size : float
+        Desired pixel size in meters.
+
+    Returns
+    -------
+    Scene
+        Scene with updated ``distance`` and ``fov`` attributes.
+    float
+        The new scene distance in meters.
+    """
+    current_distance = getattr(scene, "distance", 1.0)
+    sample_spacing = getattr(scene, "sample_spacing", 1.0)
+
+    new_distance = current_distance * (pixel_size / sample_spacing)
+    scene.distance = new_distance
+
+    width_pixels = scene.photons.shape[1]
+    sensor_width = pixel_size * width_pixels
+    scene.fov = 2 * math.degrees(math.atan(sensor_width / (2 * new_distance)))
+
+    return scene, new_distance
+

--- a/python/isetcam/scene/scene_class.py
+++ b/python/isetcam/scene/scene_class.py
@@ -16,6 +16,8 @@ class Scene:
     photons: np.ndarray
     wave: np.ndarray | None = None
     name: str | None = None
+    distance: float | None = None
+    fov: float | None = None
 
     def __post_init__(self) -> None:
         if self.wave is None:

--- a/python/tests/test_scene_adjust_pixel_size.py
+++ b/python/tests/test_scene_adjust_pixel_size.py
@@ -1,0 +1,43 @@
+import math
+import numpy as np
+
+from isetcam.scene import Scene, scene_adjust_pixel_size
+from isetcam.opticalimage import OpticalImage
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([550])
+    photons = np.ones((2, 4, 1))
+    sc = Scene(photons=photons, wave=wave)
+    sc.sample_spacing = 1e-3
+    sc.distance = 1.0
+    return sc
+
+
+def _simple_oi() -> OpticalImage:
+    wave = np.array([550])
+    photons = np.ones((2, 4, 1))
+    return OpticalImage(photons=photons, wave=wave)
+
+
+def test_scene_adjust_pixel_size_smaller():
+    sc = _simple_scene()
+    oi = _simple_oi()
+    pixel = 0.5e-3
+    out, new_d = scene_adjust_pixel_size(sc, oi, pixel)
+    assert math.isclose(new_d, 0.5)
+    assert math.isclose(out.distance, new_d)
+    expected_fov = 2 * math.degrees(math.atan(pixel * 4 / (2 * new_d)))
+    assert math.isclose(out.fov, expected_fov)
+
+
+def test_scene_adjust_pixel_size_larger():
+    sc = _simple_scene()
+    oi = _simple_oi()
+    pixel = 2e-3
+    out, new_d = scene_adjust_pixel_size(sc, oi, pixel)
+    assert math.isclose(new_d, 2.0)
+    expected_fov = 2 * math.degrees(math.atan(pixel * 4 / (2 * new_d)))
+    assert math.isclose(out.fov, expected_fov)
+
+


### PR DESCRIPTION
## Summary
- add `scene_adjust_pixel_size` to match scene sample spacing to sensor pixel size
- expose the function in the scene package
- store `distance` and `fov` on `Scene`
- test FOV adjustment for simple scenes
- document pixel size helper in the migration guide

## Testing
- `pytest -q` *(fails: 101 errors during collection)*