### PR TITLE
Add scene reflectance adjustment helper

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -190,6 +190,22 @@ sc3 = scene_adjust_illuminant(sc, spd)
 
 Run `pytest -q` after modifying the scene routines.
 
+## Adjusting Scene Reflectance
+
+The helper `scene_adjust_reflectance` replaces the scene reflectance
+data while leaving the illuminant untouched. The reflectance can be a
+uniform vector or a spatial-spectral cube matching the scene photon
+array:
+
+```python
+from isetcam.scene import scene_adjust_reflectance
+
+new_refl = np.linspace(0.2, 0.8, len(sc.wave))
+sc4 = scene_adjust_reflectance(sc, new_refl)
+```
+
+Run `pytest -q` after updating the reflectance routines.
+
 ## Optical Image Utilities
 
 Optical images are represented by the `OpticalImage` dataclass found in

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -8,6 +8,7 @@ from .scene_get import scene_get
 from .scene_set import scene_set
 from .scene_adjust_luminance import scene_adjust_luminance
 from .scene_adjust_illuminant import scene_adjust_illuminant
+from .scene_adjust_reflectance import scene_adjust_reflectance
 from .scene_create import scene_create
 from .scene_photon_noise import scene_photon_noise
 from .scene_crop import scene_crop
@@ -36,6 +37,7 @@ __all__ = [
     "scene_set",
     "scene_adjust_luminance",
     "scene_adjust_illuminant",
+    "scene_adjust_reflectance",
     "scene_crop",
     "scene_pad",
     "scene_insert",

--- a/python/isetcam/scene/scene_adjust_reflectance.py
+++ b/python/isetcam/scene/scene_adjust_reflectance.py
@@ -1,0 +1,94 @@
+"""Replace scene reflectance while keeping the illuminant constant."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def _broadcast_vector(vec: np.ndarray, shape: tuple[int, int, int]) -> np.ndarray:
+    """Return ``vec`` expanded to ``shape``."""
+    return np.tile(vec.reshape(1, 1, -1), (shape[0], shape[1], 1))
+
+
+def scene_adjust_reflectance(scene: Scene, new_reflectance: np.ndarray) -> Scene:
+    """Adjust the scene reflectance keeping the original illuminant.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene to adjust.
+    new_reflectance : array-like
+        New reflectance values. Can be a 1-D vector of length ``scene.wave``
+        or a 3-D array matching ``scene.photons``.
+
+    Returns
+    -------
+    Scene
+        New scene with photons recomputed from the preserved illuminant and
+        ``new_reflectance``.
+    """
+
+    photons = np.asarray(scene.photons, dtype=float)
+    wave_len = photons.shape[2]
+    shape = photons.shape
+
+    refl = np.asarray(new_reflectance, dtype=float)
+    if refl.ndim == 1:
+        if refl.size != wave_len:
+            raise ValueError("Reflectance vector length must match scene wave")
+        refl_cube = _broadcast_vector(refl, shape)
+    elif refl.ndim == 3:
+        if refl.shape != shape:
+            raise ValueError("Reflectance cube must match scene photon shape")
+        refl_cube = refl
+    else:
+        raise ValueError("new_reflectance must be 1-D or 3-D")
+
+    illum = getattr(scene, "illuminant", None)
+    if illum is not None:
+        illum = np.asarray(illum, dtype=float)
+        if illum.ndim == 1:
+            if illum.size != wave_len:
+                raise ValueError("Illuminant vector length must match scene wave")
+            illum_cube = _broadcast_vector(illum, shape)
+        elif illum.ndim == 3:
+            if illum.shape != shape:
+                raise ValueError("Illuminant cube must match scene photon shape")
+            illum_cube = illum
+        else:
+            raise ValueError("Illuminant must be 1-D or 3-D")
+    else:
+        old_refl = getattr(scene, "reflectance", None)
+        if old_refl is not None:
+            old = np.asarray(old_refl, dtype=float)
+            if old.ndim == 1:
+                if old.size != wave_len:
+                    raise ValueError("Reflectance vector length must match scene wave")
+                old_cube = _broadcast_vector(old, shape)
+            elif old.ndim == 3:
+                if old.shape != shape:
+                    raise ValueError("Reflectance cube must match scene photon shape")
+                old_cube = old
+            else:
+                raise ValueError("Reflectance must be 1-D or 3-D")
+            with np.errstate(divide="ignore", invalid="ignore"):
+                illum_cube = np.divide(photons, old_cube, out=np.zeros_like(photons), where=old_cube!=0)
+        else:
+            illum_vec = photons.mean(axis=(0, 1))
+            illum_cube = _broadcast_vector(illum_vec, shape)
+
+    new_photons = refl_cube * illum_cube
+
+    out = Scene(photons=new_photons, wave=scene.wave, name=scene.name)
+    if illum is not None:
+        out.illuminant = illum
+    else:
+        # store a vector when the illuminant is uniform across space
+        if np.allclose(illum_cube, illum_cube[0, 0, :]):
+            out.illuminant = illum_cube[0, 0, :]
+        else:
+            out.illuminant = illum_cube
+    out.reflectance = new_reflectance
+    return out

--- a/python/tests/test_scene_adjust_reflectance.py
+++ b/python/tests/test_scene_adjust_reflectance.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_adjust_reflectance
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([500, 510, 520])
+    illum = np.array([1.0, 2.0, 3.0])
+    refl = np.full(3, 0.5)
+    photons = np.tile(refl.reshape(1, 1, -1), (2, 2, 1)) * illum.reshape(1, 1, -1)
+    sc = Scene(photons=photons, wave=wave)
+    sc.illuminant = illum
+    sc.reflectance = refl
+    return sc
+
+
+def test_scene_adjust_reflectance_vector():
+    sc = _simple_scene()
+    new_r = np.array([0.2, 0.4, 0.6])
+    out = scene_adjust_reflectance(sc, new_r)
+    expected = np.tile(new_r.reshape(1, 1, -1), (2, 2, 1)) * sc.illuminant.reshape(1, 1, -1)
+    assert np.allclose(out.photons, expected)
+    assert np.allclose(out.reflectance, new_r)
+
+
+def test_scene_adjust_reflectance_cube():
+    sc = _simple_scene()
+    new_r = np.array(
+        [
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+            [[0.7, 0.8, 0.9], [0.2, 0.4, 0.6]],
+        ]
+    )
+    out = scene_adjust_reflectance(sc, new_r)
+    expected = new_r * sc.illuminant.reshape(1, 1, -1)
+    assert np.allclose(out.photons, expected)
+    assert np.allclose(out.reflectance, new_r)


### PR DESCRIPTION
## Summary
- implement `scene_adjust_reflectance`
- export from `isetcam.scene`
- test reflectance adjustment
- document new helper in migration guide

## Testing
- `pytest -q`