### PR TITLE
Add optical image irradiance calculation

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -1029,6 +1029,22 @@ scaled = oi_adjust_illuminance(oi, 100.0)
 
 Remember to run `pytest -q` after editing the illuminance utilities.
 
+## Calculate Optical Image Irradiance
+
+Use `oi_calculate_irradiance` to integrate the spectral photon data of an
+optical image and return an irradiance map.
+
+```python
+from isetcam.opticalimage import OpticalImage, oi_calculate_irradiance,
+oi_calculate_illuminance
+
+oi = OpticalImage(photons=data, wave=wave)
+irr = oi_calculate_irradiance(oi)
+lux = oi_calculate_illuminance(oi)
+```
+
+Run `pytest -q` after updating the irradiance helpers.
+
 ## Bayer Indices
 
 `bayer_indices` returns the column and row positions of each color in a

--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -18,6 +18,8 @@ from .oi_frequency_support import oi_frequency_support
 from .oi_frequency_resample import oi_frequency_resample
 from .oi_adjust_illuminance import oi_adjust_illuminance
 from .oi_extract_waveband import oi_extract_waveband
+from .oi_calculate_irradiance import oi_calculate_irradiance
+from .oi_calculate_illuminance import oi_calculate_illuminance
 
 __all__ = [
     "OpticalImage",
@@ -40,4 +42,6 @@ __all__ = [
     "oi_to_file",
     "oi_adjust_illuminance",
     "oi_extract_waveband",
+    "oi_calculate_irradiance",
+    "oi_calculate_illuminance",
 ]

--- a/python/isetcam/opticalimage/oi_calculate_illuminance.py
+++ b/python/isetcam/opticalimage/oi_calculate_illuminance.py
@@ -1,0 +1,37 @@
+"""Calculate optical image illuminance from photon data."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+from ..luminance_from_photons import luminance_from_photons
+
+
+def oi_calculate_illuminance(
+    oi: OpticalImage, binwidth: float | None = None
+) -> np.ndarray:
+    """Return illuminance in lux for each pixel of ``oi``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Optical image providing photon data.
+    binwidth : float, optional
+        Spectral bin width in nanometers. When not provided it is
+        derived from ``oi.wave`` if possible, otherwise defaults to
+        10 nm.
+
+    Returns
+    -------
+    np.ndarray
+        Illuminance values in lux with the same spatial dimensions as
+        ``oi.photons``.
+    """
+    photons = np.asarray(oi.photons, dtype=float)
+    wave = np.asarray(oi.wave, dtype=float).reshape(-1)
+
+    if photons.shape[-1] != wave.size:
+        raise ValueError("oi.photons last dimension must match oi.wave length")
+
+    return luminance_from_photons(photons, wave, binwidth)

--- a/python/isetcam/opticalimage/oi_calculate_irradiance.py
+++ b/python/isetcam/opticalimage/oi_calculate_irradiance.py
@@ -1,0 +1,46 @@
+"""Calculate integrated irradiance from an OpticalImage."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+_DEF_BINWIDTH = 10.0
+
+
+def oi_calculate_irradiance(
+    oi: OpticalImage, binwidth: float | None = None
+) -> np.ndarray:
+    """Return photon irradiance integrated across wavelength.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image providing photon data.
+    binwidth : float, optional
+        Spectral bin width in nanometers. When not provided it is
+        derived from ``oi.wave`` if possible, otherwise defaults to
+        10 nm.
+
+    Returns
+    -------
+    np.ndarray
+        Irradiance in photons/(s m^2) with the same spatial dimensions
+        as ``oi.photons``.
+    """
+    photons = np.asarray(oi.photons, dtype=float)
+    wave = np.asarray(oi.wave, dtype=float).reshape(-1)
+
+    if photons.shape[-1] != wave.size:
+        raise ValueError("oi.photons last dimension must match oi.wave length")
+
+    if binwidth is None:
+        if wave.size > 1:
+            binwidth = float(wave[1] - wave[0])
+        else:
+            binwidth = _DEF_BINWIDTH
+
+    irr = photons.sum(axis=2) * binwidth
+    return irr

--- a/python/tests/test_oi_calculate.py
+++ b/python/tests/test_oi_calculate.py
@@ -1,0 +1,45 @@
+import numpy as np
+from scipy.io import loadmat
+
+from isetcam.opticalimage import (
+    OpticalImage,
+    oi_calculate_irradiance,
+    oi_calculate_illuminance,
+)
+from isetcam import quanta_to_energy, iset_root_path
+
+
+def _expected_irradiance(wave, photons):
+    bw = wave[1] - wave[0] if len(wave) > 1 else 10
+    return photons.sum(axis=2) * bw
+
+
+def _expected_illuminance(wave, photons):
+    energy = quanta_to_energy(wave, photons)
+    root = iset_root_path()
+    mat = loadmat(root / "data" / "human" / "luminosity.mat")
+    V = np.interp(wave, mat["wavelength"].ravel(), mat["data"].ravel(), left=0.0, right=0.0)
+    bw = wave[1] - wave[0] if len(wave) > 1 else 10
+    xw = energy.reshape(-1, len(wave))
+    lum = 683 * xw.dot(V) * bw
+    return lum.reshape(photons.shape[:2])
+
+
+def _simple_oi(scale: float = 1.0) -> OpticalImage:
+    wave = np.array([500, 510, 520], dtype=float)
+    photons = np.ones((2, 2, 3), dtype=float) * scale
+    return OpticalImage(photons=photons, wave=wave)
+
+
+def test_oi_calculate_irradiance():
+    oi = _simple_oi(2.0)
+    irr = oi_calculate_irradiance(oi)
+    expected = _expected_irradiance(oi.wave, oi.photons)
+    assert np.allclose(irr, expected)
+
+
+def test_oi_calculate_illuminance():
+    oi = _simple_oi(0.5)
+    illum = oi_calculate_illuminance(oi)
+    expected = _expected_illuminance(oi.wave, oi.photons)
+    assert np.allclose(illum, expected)


### PR DESCRIPTION
## Summary
- compute irradiance and illuminance for optical images
- export helpers via `opticalimage` package
- validate irradiance helpers with unit tests
- document the new helpers in the migration guide

## Testing
- `pytest -q`