### PR TITLE
Implement vc object management helpers

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -29,6 +29,9 @@ from .ie_session_set import ie_session_set
 from .ie_save_session import ie_save_session
 from .ie_load_session import ie_load_session
 from .vc_add_and_select_object import vc_add_and_select_object
+from .vc_get_object import vc_get_object
+from .vc_replace_object import vc_replace_object
+from .vc_replace_and_select_object import vc_replace_and_select_object
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 from .xyz_to_lab import xyz_to_lab
@@ -171,4 +174,7 @@ __all__ = [
     'openexr_read',
     'openexr_write',
     'vc_add_and_select_object',
+    'vc_get_object',
+    'vc_replace_object',
+    'vc_replace_and_select_object',
 ]

--- a/python/isetcam/vc_get_object.py
+++ b/python/isetcam/vc_get_object.py
@@ -1,0 +1,33 @@
+"""Retrieve objects from ``vcSESSION`` by type and index."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_get_object(obj_type: str, index: Optional[int] = None) -> Any:
+    """Return an object stored in ``vcSESSION``.
+
+    Parameters
+    ----------
+    obj_type : str
+        The type of object (e.g. ``'scene'`` or ``'sensor'``).
+    index : int, optional
+        1-based index of the object.  When omitted the currently selected
+        object is returned.
+    """
+    field = _norm_objtype(obj_type)
+
+    if index is None:
+        index = vcSESSION.get("SELECTED", {}).get(field)
+        if index is None:
+            return None
+
+    lst = vcSESSION.get(field)
+    if not lst or index >= len(lst) or index < 0:
+        return None
+
+    return lst[index]

--- a/python/isetcam/vc_replace_and_select_object.py
+++ b/python/isetcam/vc_replace_and_select_object.py
@@ -1,0 +1,35 @@
+"""Replace an object and explicitly set it as selected."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .ie_init_session import vcSESSION
+from .vc_replace_object import vc_replace_object
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_replace_and_select_object(
+    obj_type: str, obj: Any, index: Optional[int] = None
+) -> int:
+    """Replace ``obj`` and select it in ``vcSESSION``.
+
+    Parameters
+    ----------
+    obj_type : str
+        Type of the object.
+    obj : Any
+        The new object instance.
+    index : int, optional
+        1-based index to replace.  Uses the currently selected index when not
+        provided.
+
+    Returns
+    -------
+    int
+        The index that was replaced and selected.
+    """
+    idx = vc_replace_object(obj_type, obj, index)
+    field = _norm_objtype(obj_type)
+    vcSESSION.setdefault("SELECTED", {})[field] = idx
+    return idx

--- a/python/isetcam/vc_replace_object.py
+++ b/python/isetcam/vc_replace_object.py
@@ -1,0 +1,43 @@
+"""Replace an existing object in ``vcSESSION`` and mark it selected."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_replace_object(obj_type: str, obj: Any, index: Optional[int] = None) -> int:
+    """Replace an object stored in ``vcSESSION``.
+
+    Parameters
+    ----------
+    obj_type : str
+        Object type to replace.
+    obj : Any
+        Replacement object instance.
+    index : int, optional
+        1-based index of the object to replace.  When omitted the currently
+        selected index is used and if none exists ``1`` is assumed.
+
+    Returns
+    -------
+    int
+        The index of the replaced object.
+    """
+    field = _norm_objtype(obj_type)
+
+    if index is None:
+        index = vcSESSION.get("SELECTED", {}).get(field)
+        if index is None:
+            index = 1
+
+    lst = vcSESSION.setdefault(field, [None])
+    while len(lst) <= index:
+        lst.append(None)
+    lst[index] = obj
+    vcSESSION[field] = lst
+
+    vcSESSION.setdefault("SELECTED", {})[field] = index
+    return index

--- a/python/tests/test_vc_object_management.py
+++ b/python/tests/test_vc_object_management.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from isetcam import (
+    ie_init,
+    vc_add_and_select_object,
+    vc_get_object,
+    vc_replace_object,
+    vc_replace_and_select_object,
+)
+from isetcam.scene import Scene
+from isetcam.ie_init_session import vcSESSION
+
+
+def test_vc_get_object():
+    ie_init()
+    sc = Scene(photons=np.zeros((1, 1, 1)))
+    idx = vc_add_and_select_object("scene", sc)
+    assert vc_get_object("scene", idx) is sc
+    assert vc_get_object("scene") is sc
+
+
+def test_vc_replace_object():
+    ie_init()
+    sc1 = Scene(photons=np.zeros((1, 1, 1)))
+    idx = vc_add_and_select_object("scene", sc1)
+
+    sc2 = Scene(photons=np.ones((1, 1, 1)))
+    out = vc_replace_object("scene", sc2, idx)
+    assert out == idx
+    assert vc_get_object("scene", idx) is sc2
+    assert vcSESSION["SELECTED"]["SCENE"] == idx
+
+
+def test_vc_replace_and_select_object():
+    ie_init()
+    sc1 = Scene(photons=np.zeros((1, 1, 1)))
+    idx = vc_add_and_select_object("scene", sc1)
+
+    sc2 = Scene(photons=np.ones((1, 1, 1)))
+    out = vc_replace_and_select_object("scene", sc2)
+    assert out == idx
+    assert vc_get_object("scene", idx) is sc2
+    assert vcSESSION["SELECTED"]["SCENE"] == idx
+


### PR DESCRIPTION
## Summary
- add `vc_get_object` for retrieving vcSESSION objects
- implement object replacement helpers
- export new utilities
- test vc object management

## Testing
- `pytest -q python/tests/test_vc_object_management.py`
- `pytest -q`