### PR TITLE
Add human package with pupil size & macular transmittance

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -73,10 +73,11 @@ from .metrics.scielab import scielab, sc_params, SCIELABParams
 from .metrics.xyz_to_vsnr import xyz_to_vsnr
 from .metrics.ssim_metric import ssim_metric
 from .metrics.exposure_value import exposure_value
+from .human import human_pupil_size, human_macular_transmittance
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc, metrics, optics
+from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc, metrics, optics, human
 from .opticalimage import oi_to_file
 from .sensor import sensor_to_file
 from .display import display_to_file
@@ -150,6 +151,8 @@ __all__ = [
     'xyz_to_vsnr',
     'ssim_metric',
     'exposure_value',
+    'human_pupil_size',
+    'human_macular_transmittance',
     'iset_root_path',
     'ie_init',
     'ie_init_session',
@@ -162,6 +165,7 @@ __all__ = [
     'illuminant',
     'imgproc',
     'metrics',
+    'human',
     'oi_to_file',
     'sensor_to_file',
     'display_to_file',

--- a/python/isetcam/human/__init__.py
+++ b/python/isetcam/human/__init__.py
@@ -1,0 +1,9 @@
+"""Human physiology related functions."""
+
+from .human_pupil_size import human_pupil_size
+from .human_macular_transmittance import human_macular_transmittance
+
+__all__ = [
+    'human_pupil_size',
+    'human_macular_transmittance',
+]

--- a/python/isetcam/human/human_macular_transmittance.py
+++ b/python/isetcam/human/human_macular_transmittance.py
@@ -1,0 +1,35 @@
+"""Apply macular pigment transmittance to an optical image."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from scipy.io import loadmat
+
+from ..iset_root_path import iset_root_path
+from ..opticalimage import OpticalImage
+
+
+def _macular_transmittance(density: float, wave: np.ndarray) -> np.ndarray:
+    """Return macular pigment transmittance for ``wave``."""
+    root = iset_root_path()
+    mat = loadmat(root / 'data' / 'human' / 'macularPigment.mat')
+    src_wave = mat['wavelength'].ravel()
+    data = mat['data'].ravel()
+    unit = np.interp(wave, src_wave, data, left=0.0, right=0.0) / 0.3521
+    dens = unit * float(density)
+    return 10.0 ** (-dens)
+
+
+def human_macular_transmittance(
+    oi: OpticalImage, density: float = 0.35
+) -> OpticalImage:
+    """Multiply ``oi`` photon data by macular pigment transmittance."""
+    wave = np.asarray(oi.wave, dtype=float)
+    trans = _macular_transmittance(density, wave)
+    photons = np.asarray(oi.photons, dtype=float)
+    shape = [1] * photons.ndim
+    shape[-1] = trans.size
+    out_photons = photons * trans.reshape(shape)
+    return OpticalImage(photons=out_photons, wave=wave, name=oi.name)

--- a/python/isetcam/human/human_pupil_size.py
+++ b/python/isetcam/human/human_pupil_size.py
@@ -1,0 +1,59 @@
+"""Estimate human pupil diameter and area."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def human_pupil_size(lum: float | np.ndarray = 100, model: str = 'wy', **kwargs):
+    """Return pupil diameter and area in mm and mm^2.
+
+    Parameters
+    ----------
+    lum : float or array-like, optional
+        Mean luminance in cd/m^2. Defaults to 100.
+    model : {'ms', 'dg', 'sd', 'wy'}, optional
+        Model used for the calculation. Defaults to ``'wy'`` (Watson and
+        Yellott, 2012).
+    **kwargs :
+        Additional parameters required by some models:
+
+        ``area`` : field area in deg^2 used by the ``'sd'`` and ``'wy'`` models.
+        ``age`` : observer age in years for the ``'wy'`` model (default 28).
+        ``eye_num`` : number of eyes (1 or 2) for the ``'wy'`` model
+            (default 1).
+
+    Returns
+    -------
+    diam : np.ndarray
+        Pupil diameter in millimeters.
+    area : np.ndarray
+        Pupil area in square millimeters.
+    """
+
+    lum_arr = np.asarray(lum, dtype=float)
+    flag = model.lower()
+
+    if flag == 'ms':
+        diam = 4.9 - 3 * np.tanh(0.4 * np.log10(lum_arr) + 1)
+    elif flag == 'dg':
+        diam = 10 ** (0.8558 - 0.000401 * (np.log10(lum_arr) + 8.6) ** 3)
+    elif flag == 'sd':
+        area = kwargs.get('area')
+        if area is None:
+            raise ValueError("'area' is required for sd model")
+        F = lum_arr * float(area)
+        diam = 7.75 - 5.75 * (F / 846) ** 0.41 / ((F / 846) ** 0.41 + 2)
+    elif flag == 'wy':
+        age = kwargs.get('age', 28)
+        area = kwargs.get('area', 4)
+        eye_num = kwargs.get('eye_num', 1)
+        me = 0.1 if eye_num == 1 else 1.0
+        F = lum_arr * float(area) * me
+        Dsd, _ = human_pupil_size(F, 'sd', area=1)
+        diam = Dsd + (float(age) - 28.58) * (0.02132 - 0.009562 * Dsd)
+    else:
+        raise ValueError(f"Unknown model '{model}'")
+
+    area_out = np.pi * (diam / 2) ** 2
+    return diam, area_out

--- a/python/tests/test_human_macular.py
+++ b/python/tests/test_human_macular.py
@@ -1,0 +1,25 @@
+import numpy as np
+from scipy.io import loadmat
+
+from isetcam import iset_root_path
+from isetcam.opticalimage import OpticalImage
+from isetcam.human import human_macular_transmittance
+
+
+def test_human_macular_transmittance_basic():
+    wave = np.arange(400, 701, 10)
+    photons = np.ones((1, 1, len(wave)))
+    oi = OpticalImage(photons=photons, wave=wave)
+
+    out = human_macular_transmittance(oi, density=0.35)
+
+    root = iset_root_path()
+    mat = loadmat(root / 'data' / 'human' / 'macularPigment.mat')
+    src_wave = mat['wavelength'].ravel()
+    data = mat['data'].ravel()
+    unit = np.interp(wave, src_wave, data, left=0.0, right=0.0) / 0.3521
+    trans = 10 ** (-unit * 0.35)
+    expected = photons * trans.reshape(1, 1, len(wave))
+
+    assert np.allclose(out.photons, expected)
+    assert np.array_equal(out.wave, wave)

--- a/python/tests/test_human_pupil_size.py
+++ b/python/tests/test_human_pupil_size.py
@@ -1,0 +1,30 @@
+import numpy as np
+from isetcam.human import human_pupil_size
+
+
+def test_human_pupil_size_ms():
+    diam, area = human_pupil_size(100, 'ms')
+    expected = 4.9 - 3 * np.tanh(0.4 * np.log10(100) + 1)
+    assert np.isclose(diam, expected)
+    assert np.isclose(area, np.pi * (expected / 2) ** 2)
+
+
+def test_human_pupil_size_dg():
+    diam, _ = human_pupil_size(50, 'dg')
+    expected = 10 ** (0.8558 - 0.000401 * (np.log10(50) + 8.6) ** 3)
+    assert np.isclose(diam, expected)
+
+
+def test_human_pupil_size_sd():
+    diam, _ = human_pupil_size(20, 'sd', area=1)
+    F = 20 * 1
+    expected = 7.75 - 5.75 * (F / 846) ** 0.41 / ((F / 846) ** 0.41 + 2)
+    assert np.isclose(diam, expected)
+
+
+def test_human_pupil_size_wy():
+    diam, _ = human_pupil_size(100, 'wy', age=30, area=4, eye_num=1)
+    F = 100 * 4 * 0.1
+    Dsd = 7.75 - 5.75 * (F / 846) ** 0.41 / ((F / 846) ** 0.41 + 2)
+    expected = Dsd + (30 - 28.58) * (0.02132 - 0.009562 * Dsd)
+    assert np.isclose(diam, expected)


### PR DESCRIPTION
## Summary
- implement human physiology utilities in new subpackage `human`
- expose `human_pupil_size` and `human_macular_transmittance`
- add unit tests for both functions

## Testing
- `PYTHONPATH=python pytest -q`