### PR TITLE
Add VC object management utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -29,6 +29,9 @@ from .ie_session_set import ie_session_set
 from .ie_save_session import ie_save_session
 from .ie_load_session import ie_load_session
 from .vc_add_and_select_object import vc_add_and_select_object
+from .vc_get_object import vc_get_object
+from .vc_replace_object import vc_replace_object
+from .vc_replace_and_select_object import vc_replace_and_select_object
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 from .xyz_to_lab import xyz_to_lab
@@ -171,4 +174,7 @@ __all__ = [
     'openexr_read',
     'openexr_write',
     'vc_add_and_select_object',
+    'vc_get_object',
+    'vc_replace_object',
+    'vc_replace_and_select_object',
 ]

--- a/python/isetcam/vc_get_object.py
+++ b/python/isetcam/vc_get_object.py
@@ -1,0 +1,36 @@
+"""Retrieve an object from ``vcSESSION``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_get_object(obj_type: str, index: int | None = None) -> Any:
+    """Return an object stored in ``vcSESSION``.
+
+    Parameters
+    ----------
+    obj_type : str
+        Object type name.
+    index : int, optional
+        Index of the desired object. When omitted the currently selected
+        object of ``obj_type`` is returned.
+
+    Returns
+    -------
+    Any
+        The requested object or ``None`` if not found.
+    """
+    field = _norm_objtype(obj_type)
+
+    if index is None:
+        index = vcSESSION.get("SELECTED", {}).get(field)
+
+    lst = vcSESSION.get(field)
+    if index is None or lst is None or index <= 0 or index >= len(lst):
+        return None
+
+    return lst[index]

--- a/python/isetcam/vc_replace_and_select_object.py
+++ b/python/isetcam/vc_replace_and_select_object.py
@@ -1,0 +1,19 @@
+"""Replace an object in ``vcSESSION`` and set it as selected."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .ie_init_session import vcSESSION
+from .vc_replace_object import vc_replace_object
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_replace_and_select_object(
+    obj_type: str, obj: Any, index: int | None = None
+) -> int:
+    """Replace an object and select it."""
+    field = _norm_objtype(obj_type)
+    idx = vc_replace_object(obj_type, obj, index)
+    vcSESSION.setdefault("SELECTED", {})[field] = idx
+    return idx

--- a/python/isetcam/vc_replace_object.py
+++ b/python/isetcam/vc_replace_object.py
@@ -1,0 +1,43 @@
+"""Replace an existing object in ``vcSESSION``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_replace_object(obj_type: str, obj: Any, index: int | None = None) -> int:
+    """Replace an object stored in ``vcSESSION``.
+
+    Parameters
+    ----------
+    obj_type : str
+        Type of the object to replace.
+    obj : Any
+        Object instance that will overwrite the stored entry.
+    index : int, optional
+        Index to replace. Defaults to the currently selected object of
+        ``obj_type`` or ``1`` if none is selected.
+
+    Returns
+    -------
+    int
+        The index of the replaced object.
+    """
+    field = _norm_objtype(obj_type)
+
+    if index is None:
+        index = vcSESSION.get("SELECTED", {}).get(field, 1)
+    if index is None or index < 1:
+        index = 1
+
+    lst = vcSESSION.setdefault(field, [None])
+    while len(lst) <= index:
+        lst.append(None)
+    lst[index] = obj
+    vcSESSION[field] = lst
+
+    vcSESSION.setdefault("SELECTED", {})[field] = index
+    return index

--- a/python/tests/test_vc_object_management.py
+++ b/python/tests/test_vc_object_management.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from isetcam import (
+    ie_init,
+    vc_add_and_select_object,
+    vc_get_object,
+    vc_replace_object,
+    vc_replace_and_select_object,
+)
+from isetcam.scene import Scene
+from isetcam.ie_init_session import vcSESSION
+
+
+def test_vc_get_object():
+    ie_init()
+    s1 = Scene(photons=np.zeros((1, 1, 1)))
+    s2 = Scene(photons=np.ones((1, 1, 1)))
+    idx1 = vc_add_and_select_object("scene", s1)
+    idx2 = vc_add_and_select_object("scene", s2)
+
+    assert vc_get_object("scene", idx1) is s1
+    assert vc_get_object("scene") is s2
+    assert vcSESSION["SELECTED"]["SCENE"] == idx2
+
+
+def test_vc_replace_object():
+    ie_init()
+    s1 = Scene(photons=np.zeros((1, 1, 1)))
+    vc_add_and_select_object("scene", s1)
+
+    s2 = Scene(photons=np.ones((1, 1, 1)))
+    idx = vc_replace_object("scene", s2)
+
+    assert idx == 1
+    assert vcSESSION["SCENE"][1] is s2
+    assert vcSESSION["SELECTED"]["SCENE"] == 1
+
+
+def test_vc_replace_and_select_object():
+    ie_init()
+    s1 = Scene(photons=np.zeros((1, 1, 1)))
+    idx = vc_add_and_select_object("scene", s1)
+
+    s2 = Scene(photons=np.ones((1, 1, 1)))
+    out_idx = vc_replace_and_select_object("scene", s2, idx)
+
+    assert out_idx == idx
+    assert vcSESSION["SCENE"][idx] is s2
+    assert vcSESSION["SELECTED"]["SCENE"] == idx


### PR DESCRIPTION
## Summary
- add `vc_get_object`, `vc_replace_object` and `vc_replace_and_select_object`
- expose new utilities via package `__init__`
- test retrieving, replacing and selecting VC objects

## Testing
- `PYTHONPATH=python pytest -q`