### PR TITLE
Add basic IP pipeline

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -77,7 +77,7 @@ from .human import human_pupil_size, human_macular_transmittance
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc, metrics, optics, human
+from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc, metrics, optics, human, ip
 from .opticalimage import oi_to_file
 from .sensor import sensor_to_file
 from .display import display_to_file
@@ -166,6 +166,7 @@ __all__ = [
     'imgproc',
     'metrics',
     'human',
+    'ip',
     'oi_to_file',
     'sensor_to_file',
     'display_to_file',

--- a/python/isetcam/ip/__init__.py
+++ b/python/isetcam/ip/__init__.py
@@ -1,0 +1,15 @@
+"""Simple sensor to display image processing pipeline."""
+
+from .vcimage_class import VCImage
+from .ip_create import ip_create
+from .ip_compute import ip_compute
+from .ip_get import ip_get
+from .ip_set import ip_set
+
+__all__ = [
+    "VCImage",
+    "ip_create",
+    "ip_compute",
+    "ip_get",
+    "ip_set",
+]

--- a/python/isetcam/ip/ip_compute.py
+++ b/python/isetcam/ip/ip_compute.py
@@ -1,0 +1,20 @@
+"""Render a sensor image to display RGB."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..sensor import Sensor
+from ..display import Display, display_apply_gamma
+from .vcimage_class import VCImage
+from .ip_create import ip_create
+
+
+def ip_compute(sensor: Sensor, display: Display) -> VCImage:
+    """Return ``VCImage`` rendered from ``sensor`` for ``display``."""
+    ip = ip_create(sensor, display)
+    rgb = np.repeat(sensor.volts[:, :, None], 3, axis=2)
+    if display.gamma is not None:
+        rgb = display_apply_gamma(rgb, display, inverse=True)
+    ip.rgb = rgb
+    return ip

--- a/python/isetcam/ip/ip_create.py
+++ b/python/isetcam/ip/ip_create.py
@@ -1,0 +1,31 @@
+"""Create a :class:`VCImage` from a sensor and display."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..sensor import Sensor
+from ..display import Display
+from .vcimage_class import VCImage
+
+
+def ip_create(sensor: Sensor, display: Display) -> VCImage:
+    """Initialise a VCImage compatible with ``sensor`` and ``display``."""
+    wave = sensor.wave if sensor.wave is not None else display.wave
+    if wave is None:
+        raise ValueError("Sensor or Display must define wavelength samples")
+
+    if display.wave is not None and not np.array_equal(wave, display.wave):
+        if len(wave) != len(display.wave):
+            raise ValueError("Sensor and Display must have matching wavelengths")
+        # adopt sensor.wave; assume display.spd is compatible
+
+    rgb_shape = sensor.volts.shape + (3,)
+    rgb = np.zeros(rgb_shape, dtype=float)
+    name_parts = []
+    if getattr(sensor, "name", None):
+        name_parts.append(sensor.name)
+    if getattr(display, "name", None):
+        name_parts.append(display.name)
+    name = "-".join(name_parts) if name_parts else None
+    return VCImage(rgb=rgb, wave=wave, name=name)

--- a/python/isetcam/ip/ip_get.py
+++ b/python/isetcam/ip/ip_get.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .vcimage_class import VCImage
+from ..ie_param_format import ie_param_format
+
+
+def ip_get(ip: VCImage, param: str) -> Any:
+    """Return a parameter value from ``ip``."""
+    key = ie_param_format(param)
+    if key == "rgb":
+        return ip.rgb
+    if key == "wave":
+        return ip.wave
+    if key in {"nwave", "n_wave"}:
+        return len(ip.wave)
+    if key == "name":
+        return getattr(ip, "name", None)
+    raise KeyError(f"Unknown VCImage parameter '{param}'")
+

--- a/python/isetcam/ip/ip_set.py
+++ b/python/isetcam/ip/ip_set.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .vcimage_class import VCImage
+from ..ie_param_format import ie_param_format
+
+
+def ip_set(ip: VCImage, param: str, val: Any) -> None:
+    """Set a parameter value on ``ip``."""
+    key = ie_param_format(param)
+    if key == "rgb":
+        ip.rgb = np.asarray(val)
+        return
+    if key == "wave":
+        ip.wave = np.asarray(val)
+        return
+    if key == "name":
+        ip.name = None if val is None else str(val)
+        return
+    raise KeyError(f"Unknown or read-only VCImage parameter '{param}'")
+

--- a/python/isetcam/ip/vcimage_class.py
+++ b/python/isetcam/ip/vcimage_class.py
@@ -1,0 +1,16 @@
+"""Basic :class:`VCImage` dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class VCImage:
+    """Minimal view controller image container."""
+
+    rgb: np.ndarray
+    wave: np.ndarray
+    name: str | None = None

--- a/python/tests/test_ip_pipeline.py
+++ b/python/tests/test_ip_pipeline.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from isetcam.sensor import Sensor
+from isetcam.display import Display
+from isetcam.ip import VCImage, ip_create, ip_compute
+
+
+def _simple_sensor() -> Sensor:
+    wave = np.array([500, 510])
+    volts = np.full((2, 2), 0.5)
+    return Sensor(volts=volts, wave=wave, exposure_time=1.0)
+
+
+def _simple_display(n_levels: int = 4) -> Display:
+    wave = np.array([500, 510])
+    spd = np.ones((2, 3))
+    gamma = np.linspace(0, 1, n_levels).reshape(n_levels, 1).repeat(3, axis=1)
+    return Display(spd=spd, wave=wave, gamma=gamma)
+
+
+def test_ip_create():
+    sensor = _simple_sensor()
+    disp = _simple_display()
+    ip = ip_create(sensor, disp)
+    assert isinstance(ip, VCImage)
+    assert ip.rgb.shape == (2, 2, 3)
+    assert np.array_equal(ip.wave, sensor.wave)
+
+
+def test_ip_compute():
+    sensor = _simple_sensor()
+    disp = _simple_display()
+    ip = ip_compute(sensor, disp)
+    expected = np.full((2, 2, 3), 0.5)
+    assert np.allclose(ip.rgb, expected)


### PR DESCRIPTION
## Summary
- implement simple `ip` package with VCImage dataclass and helpers
- support creation and compute of a basic sensor-to-display pipeline
- export `ip` from the top-level package
- add tests for VCImage creation and compute

## Testing
- `pytest -q`