### PR TITLE
Implement display rendering utilities

### DIFF
--- a/python/isetcam/display/__init__.py
+++ b/python/isetcam/display/__init__.py
@@ -10,6 +10,8 @@ from .display_create import display_create
 from .display_get import display_get
 from .display_set import display_set
 from .display_apply_gamma import display_apply_gamma
+from .display_render import display_render
+from .display_show_image import display_show_image
 from .display_from_file import display_from_file
 from .display_to_file import display_to_file
 
@@ -19,6 +21,8 @@ __all__ = [
     "display_get",
     "display_set",
     "display_apply_gamma",
+    "display_render",
+    "display_show_image",
     "display_from_file",
     "display_to_file",
 ]

--- a/python/isetcam/display/display_render.py
+++ b/python/isetcam/display/display_render.py
@@ -1,0 +1,57 @@
+"""Render display spectral output from digital RGB values."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .display_class import Display
+from .display_apply_gamma import display_apply_gamma
+from ..rgb_to_xw_format import rgb_to_xw_format
+from ..xw_to_rgb_format import xw_to_rgb_format
+
+
+def display_render(image: np.ndarray, display: Display, apply_gamma: bool = True) -> np.ndarray:
+    """Return spectral radiance for ``image`` on ``display``.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Digital RGB image values in ``(R, C, 3)`` or ``(N, 3)`` format.
+    display : Display
+        Display providing spectral primaries and optional gamma table.
+    apply_gamma : bool, optional
+        When ``True`` apply ``display``'s gamma table to ``image`` before
+        computing the spectral radiance.
+
+    Returns
+    -------
+    np.ndarray
+        Spectral radiance image with one band per display wavelength.
+        The output has the same spatial organisation as ``image``.
+    """
+    img = np.asarray(image, dtype=float)
+
+    if img.ndim == 3:
+        reshape = True
+        xw, rows, cols = rgb_to_xw_format(img)
+    elif img.ndim == 2 and img.shape[1] == 3:
+        reshape = False
+        xw = img
+    else:
+        raise ValueError("image must be (rows, cols, 3) or (n, 3)")
+
+    if apply_gamma and display.gamma is not None:
+        xw = display_apply_gamma(xw, display)
+
+    spd = np.asarray(display.spd, dtype=float)
+    if spd.shape[1] != 3:
+        raise ValueError("display.spd must have shape (n_wave, 3)")
+
+    out_xw = xw @ spd.T
+
+    if reshape:
+        out = xw_to_rgb_format(out_xw, rows, cols)
+    else:
+        out = out_xw
+
+    return out

--- a/python/isetcam/display/display_show_image.py
+++ b/python/isetcam/display/display_show_image.py
@@ -1,0 +1,46 @@
+"""Display an RGB image using a ``Display`` definition."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+from .display_class import Display
+from .display_apply_gamma import display_apply_gamma
+
+
+def display_show_image(image: np.ndarray, display: Display):
+    """Render ``image`` for ``display`` and show with matplotlib.
+
+    The input image is assumed to contain digital RGB drive values in
+    ``[0, 1]``.  The display's gamma table is applied before showing the
+    image.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        RGB image in ``(R, C, 3)`` format.
+    display : Display
+        Display definition providing the gamma table.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The axis containing the displayed image.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for display_show_image")
+
+    img = np.asarray(image, dtype=float)
+    if display.gamma is not None:
+        img = display_apply_gamma(img, display)
+
+    fig, ax = plt.subplots()
+    ax.imshow(np.clip(img, 0.0, 1.0))
+    ax.axis("off")
+    fig.tight_layout()
+    return ax

--- a/python/tests/test_display_render.py
+++ b/python/tests/test_display_render.py
@@ -1,0 +1,51 @@
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.display import Display, display_apply_gamma, display_render
+from isetcam.rgb_to_xw_format import rgb_to_xw_format
+from isetcam.xw_to_rgb_format import xw_to_rgb_format
+
+
+def _make_display(n_levels: int = 4) -> Display:
+    wave = np.array([500, 510])
+    spd = np.array([[1.0, 0.5, 0.2], [0.8, 0.3, 0.1]])
+    gamma_vals = np.linspace(0, 1, n_levels) ** 2
+    gamma = gamma_vals.reshape(n_levels, 1).repeat(3, axis=1)
+    return Display(spd=spd, wave=wave, gamma=gamma)
+
+
+def test_display_render_apply_gamma_xw():
+    disp = _make_display()
+    img = np.array(
+        [
+            [0.0, 0.5, 1.0],
+            [0.25, 0.75, 0.1],
+        ]
+    )
+    lin = display_apply_gamma(img, disp)
+    expected = lin @ disp.spd.T
+    out = display_render(img, disp, apply_gamma=True)
+    assert np.allclose(out, expected)
+
+
+def test_display_render_no_gamma_rgb():
+    disp = _make_display()
+    img = np.random.rand(2, 3, 3)
+    expected_xw, rows, cols = rgb_to_xw_format(img)
+    expected = expected_xw @ disp.spd.T
+    expected = xw_to_rgb_format(expected, rows, cols)
+    out = display_render(img, disp, apply_gamma=False)
+    assert np.allclose(out, expected)
+
+
+def test_display_render_apply_gamma_rgb():
+    disp = _make_display()
+    img = np.random.rand(3, 2, 3)
+    lin = display_apply_gamma(img, disp)
+    xw, rows, cols = rgb_to_xw_format(lin)
+    expected = xw @ disp.spd.T
+    expected = xw_to_rgb_format(expected, rows, cols)
+    out = display_render(img, disp, apply_gamma=True)
+    assert np.allclose(out, expected)


### PR DESCRIPTION
## Summary
- add `display_render` to compute display spectral output
- add `display_show_image` helper using matplotlib
- export new helpers from `isetcam.display`
- test gamma handling in `display_render`

## Testing
- `PYTHONPATH=python pytest -q`
