### PR TITLE
Add Portable FloatMap I/O utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -84,7 +84,7 @@ from .display import display_to_file
 from .camera import camera_to_file, camera_from_file
 from .optics import optics_to_file, optics_from_file
 from .illuminant import illuminant_to_file, illuminant_from_file
-from .io import openexr_read, openexr_write
+from .io import openexr_read, openexr_write, pfm_read, pfm_write
 
 __all__ = [
     'vc_constants',
@@ -178,6 +178,8 @@ __all__ = [
     'optics_from_file',
     'openexr_read',
     'openexr_write',
+    'pfm_read',
+    'pfm_write',
     'vc_add_and_select_object',
     'vc_get_object',
     'vc_replace_object',

--- a/python/isetcam/io/__init__.py
+++ b/python/isetcam/io/__init__.py
@@ -2,5 +2,7 @@
 
 from .openexr_read import openexr_read
 from .openexr_write import openexr_write
+from .pfm_read import pfm_read
+from .pfm_write import pfm_write
 
-__all__ = ["openexr_read", "openexr_write"]
+__all__ = ["openexr_read", "openexr_write", "pfm_read", "pfm_write"]

--- a/python/isetcam/io/pfm_read.py
+++ b/python/isetcam/io/pfm_read.py
@@ -1,0 +1,51 @@
+"""Read images in Portable FloatMap (PFM) format."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+
+def pfm_read(path: str | Path) -> np.ndarray:
+    """Load ``path`` and return a ``float32`` array.
+
+    Parameters
+    ----------
+    path:
+        Location of the PFM file to read.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``(H, W)`` array for grayscale images or ``(H, W, 3)`` array for color
+        images.  Values are returned as ``float32``.
+    """
+
+    p = Path(path)
+    with p.open("rb") as f:
+        header = f.readline().decode("ascii").rstrip()
+        if header == "PF":
+            n_chan = 3
+        elif header == "Pf":
+            n_chan = 1
+        else:
+            raise ValueError("Not a PFM file")
+
+        dims = f.readline().decode("ascii").strip()
+        while dims.startswith("#"):
+            dims = f.readline().decode("ascii").strip()
+        width, height = map(int, dims.split())
+
+        scale = float(f.readline().decode("ascii").strip())
+        endian = "<" if scale < 0 else ">"
+        scale = abs(scale)
+
+        data = np.fromfile(f, endian + "f", width * height * n_chan)
+        data = data.reshape((height, width, n_chan))
+        data = np.flipud(data) * scale
+
+    if n_chan == 1:
+        return data[:, :, 0]
+    return data
+

--- a/python/isetcam/io/pfm_write.py
+++ b/python/isetcam/io/pfm_write.py
@@ -1,0 +1,38 @@
+"""Write images to Portable FloatMap (PFM) files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+
+def pfm_write(path: str | Path, data: np.ndarray) -> None:
+    """Save ``data`` to ``path`` in PFM format.
+
+    Parameters
+    ----------
+    path:
+        Destination file.
+    data:
+        ``(H, W)`` or ``(H, W, 3)`` array of ``float32`` values.
+    """
+
+    arr = np.asarray(data, dtype=np.float32)
+    if arr.ndim == 2:
+        header = "Pf"
+    elif arr.ndim == 3 and arr.shape[2] == 3:
+        header = "PF"
+    else:
+        raise ValueError("data must have shape (H, W) or (H, W, 3)")
+
+    height, width = arr.shape[:2]
+
+    p = Path(path)
+    with p.open("wb") as f:
+        f.write(f"{header}\n".encode("ascii"))
+        f.write(f"{width} {height}\n".encode("ascii"))
+        f.write(b"-1.0\n")  # little-endian with scale 1.0
+        flipped = np.flipud(arr)
+        flipped.tofile(f)
+

--- a/python/tests/test_pfm_io.py
+++ b/python/tests/test_pfm_io.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from isetcam.io import pfm_read, pfm_write
+
+
+def test_pfm_roundtrip_rgb(tmp_path):
+    arr = np.random.rand(3, 4, 3).astype(np.float32)
+    path = tmp_path / "rgb.pfm"
+    pfm_write(path, arr)
+    loaded = pfm_read(path)
+    assert loaded.shape == arr.shape
+    assert np.allclose(loaded, arr)
+
+
+def test_pfm_roundtrip_single(tmp_path):
+    arr = np.random.rand(2, 5).astype(np.float32)
+    path = tmp_path / "gray.pfm"
+    pfm_write(path, arr)
+    loaded = pfm_read(path)
+    assert loaded.shape == arr.shape
+    assert np.allclose(loaded, arr)
+


### PR DESCRIPTION
## Summary
- support PFM files for image I/O
- export PFM helpers in package initializers
- test PFM round-trip saves and loads

## Testing
- `pytest -q python/tests/test_pfm_io.py`
- `pytest -q`