### PR TITLE
Add human optical density, OTF, and LSF in Python

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -73,7 +73,13 @@ from .metrics.scielab import scielab, sc_params, SCIELABParams
 from .metrics.xyz_to_vsnr import xyz_to_vsnr
 from .metrics.ssim_metric import ssim_metric
 from .metrics.exposure_value import exposure_value
-from .human import human_pupil_size, human_macular_transmittance
+from .human import (
+    human_pupil_size,
+    human_macular_transmittance,
+    human_optical_density,
+    human_otf,
+    human_lsf,
+)
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
@@ -153,6 +159,9 @@ __all__ = [
     'exposure_value',
     'human_pupil_size',
     'human_macular_transmittance',
+    'human_optical_density',
+    'human_otf',
+    'human_lsf',
     'iset_root_path',
     'ie_init',
     'ie_init_session',

--- a/python/isetcam/human/__init__.py
+++ b/python/isetcam/human/__init__.py
@@ -2,8 +2,14 @@
 
 from .human_pupil_size import human_pupil_size
 from .human_macular_transmittance import human_macular_transmittance
+from .human_optical_density import human_optical_density
+from .human_otf import human_otf
+from .human_lsf import human_lsf
 
 __all__ = [
     'human_pupil_size',
     'human_macular_transmittance',
+    'human_optical_density',
+    'human_otf',
+    'human_lsf',
 ]

--- a/python/isetcam/human/human_lsf.py
+++ b/python/isetcam/human/human_lsf.py
@@ -1,0 +1,51 @@
+"""Human line spread function."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.fft import fftshift, ifft
+
+from .human_otf import human_otf, _unit_frequency_list
+
+_DEF_WAVE = np.arange(400, 701)
+
+
+def human_lsf(
+    pupil_radius: float = 0.0015,
+    dioptric_power: float = 59.9404,
+    unit: str = "mm",
+    wave: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return human line spread function."""
+    if wave is None:
+        wave = _DEF_WAVE.copy()
+    else:
+        wave = np.asarray(wave, dtype=float)
+
+    otf2d, f_support, wave = human_otf(pupil_radius, dioptric_power, None, wave)
+
+    n_wave = wave.size
+    n_samples = otf2d.shape[0]
+    line_spread = np.zeros((n_wave, n_samples))
+
+    for ii in range(n_wave):
+        tmp = otf2d[:, :, ii]
+        center = tmp[:, 0]
+        this_lsf = fftshift(np.abs(ifft(center)))
+        line_spread[ii, :] = this_lsf
+
+    delta_space = 1 / (2 * np.max(f_support))
+    spatial_extent_deg = delta_space * n_samples
+    f_list = _unit_frequency_list(n_samples)
+    x_dim = f_list * spatial_extent_deg
+
+    mm_per_deg = 0.330
+    unit_l = unit.lower()
+    if unit_l in {"mm", "default"}:
+        x_dim = x_dim * mm_per_deg
+    elif unit_l == "um":
+        x_dim = x_dim * mm_per_deg * 1e3
+    else:
+        raise ValueError(f"Unknown unit {unit}")
+
+    return line_spread, x_dim, wave

--- a/python/isetcam/human/human_optical_density.py
+++ b/python/isetcam/human/human_optical_density.py
@@ -1,0 +1,106 @@
+"""Default human optical density parameters."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+_DEF_WAVE = np.arange(390, 731)
+
+
+def human_optical_density(
+    visual_field: str = "fovea", wave: np.ndarray | None = None
+) -> dict:
+    """Return default human optical density parameters."""
+    if wave is None:
+        wave = _DEF_WAVE.copy()
+    else:
+        wave = np.asarray(wave, dtype=float)
+
+    visual_field = visual_field.lower()
+    params: dict[str, float | str | np.ndarray] = {
+        "visfield": visual_field,
+        "wave": wave,
+    }
+
+    if visual_field in {"f", "fov", "fovea", "stf", "stockmanfovea"}:
+        params.update(
+            {
+                "lens": 1.0,
+                "macular": 0.28,
+                "LPOD": 0.5,
+                "MPOD": 0.5,
+                "SPOD": 0.4,
+                "melPOD": 0.5,
+            }
+        )
+    elif visual_field in {
+        "p",
+        "peri",
+        "periphery",
+        "stp",
+        "stockmanperi",
+        "stockmanperiphery",
+    }:
+        params.update(
+            {
+                "lens": 1.0,
+                "macular": 0.0,
+                "LPOD": 0.38,
+                "MPOD": 0.38,
+                "SPOD": 0.3,
+                "melPOD": 0.5,
+            }
+        )
+    elif visual_field == "s1f":
+        params.update(
+            {
+                "lens": 0.7467,
+                "macular": 0.6910,
+                "LPOD": 0.4964,
+                "MPOD": 0.2250,
+                "SPOD": 0.1480,
+                "melPOD": 0.3239,
+                "visfield": "f",
+            }
+        )
+    elif visual_field == "s1p":
+        params.update(
+            {
+                "lens": 0.7467,
+                "macular": 0.0,
+                "LPOD": 0.4964 / 0.5 * 0.38,
+                "MPOD": 0.2250 / 0.5 * 0.38,
+                "SPOD": 0.1480 / 0.4 * 0.3,
+                "melPOD": 0.3239,
+                "visfield": "p",
+            }
+        )
+    elif visual_field == "s2f":
+        params.update(
+            {
+                "lens": 0.7637,
+                "macular": 0.5216,
+                "LPOD": 0.4841,
+                "MPOD": 0.2796,
+                "SPOD": 0.2072,
+                "melPOD": 0.3549,
+                "visfield": "f",
+            }
+        )
+    elif visual_field == "s2p":
+        params.update(
+            {
+                "lens": 0.7637,
+                "macular": 0.0,
+                "LPOD": 0.4841 / 0.5 * 0.38,
+                "MPOD": 0.2796 / 0.5 * 0.38,
+                "SPOD": 0.2072 / 0.4 * 0.3,
+                "melPOD": 0.3549,
+                "visfield": "p",
+            }
+        )
+    else:
+        raise ValueError(f"Unknown visual field '{visual_field}'")
+
+    return params

--- a/python/isetcam/human/human_otf.py
+++ b/python/isetcam/human/human_otf.py
@@ -1,0 +1,136 @@
+"""Human optical transfer function."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.interpolate import interp1d
+
+from scipy.special import jn
+
+
+_DEF_WAVE = np.arange(400, 701)
+
+
+def _unit_frequency_list(n: int) -> np.ndarray:
+    idx = np.arange(1, n + 1)
+    mid = (n + 1) // 2 if n % 2 else n // 2 + 1
+    c = idx - mid
+    if c.max() == 0:
+        return c.astype(float)
+    return c / np.max(np.abs(c))
+
+
+def _human_wave_defocus(wave: np.ndarray) -> np.ndarray:
+    q1 = 1.7312
+    q2 = 0.63346
+    q3 = 0.21410
+    return q1 - (q2 / (wave * 1e-3 - q3))
+
+
+def _human_achromatic_otf(sample_sf: np.ndarray, model: str = "exp", pupil_d: float | None = None) -> np.ndarray:
+    model = model.lower()
+    if model in {"exp", "exponential"}:
+        a = 0.1212
+        w1 = 0.3481
+        w2 = 0.6519
+        return w1 * np.ones_like(sample_sf) + w2 * np.exp(-a * sample_sf)
+    if model in {"dl", "diffractionlimited"}:
+        if pupil_d is None:
+            raise ValueError("pupil diameter required")
+        lam = 555.0
+        u0 = pupil_d * np.pi * 1e6 / lam / 180.0
+        u_hat = sample_sf / u0
+        mtf = 2 / np.pi * (np.arccos(u_hat) - u_hat * np.sqrt(1 - u_hat ** 2))
+        mtf[u_hat >= 1] = 0.0
+        return mtf
+    if model == "watson":
+        if pupil_d is None:
+            raise ValueError("pupil diameter required")
+        u1 = 21.95 - 5.512 * pupil_d + 0.3922 * pupil_d ** 2
+        mtf_dl = _human_achromatic_otf(sample_sf, "dl", pupil_d)
+        return (1 + (sample_sf / u1) ** 2) ** (-0.62) * np.sqrt(mtf_dl)
+    raise ValueError(f"Unknown model '{model}'")
+
+
+def _optics_defocused_mtf(s: np.ndarray, alpha: np.ndarray) -> np.ndarray:
+    nf = np.abs(s) / 2.0
+    beta = np.sqrt(1.0 - nf ** 2)
+    otf = np.zeros_like(nf)
+    ii = alpha == 0
+    if np.any(ii):
+        otf[ii] = (2 / np.pi) * (np.arccos(nf[ii]) - nf[ii] * beta[ii])
+    jj = ~ii
+    if np.any(jj):
+        H1 = (
+            beta[jj] * jn(1, alpha[jj])
+            + 0.5 * np.sin(2 * beta[jj]) * (jn(1, alpha[jj]) - jn(3, alpha[jj]))
+            - 0.25 * np.sin(4 * beta[jj]) * (jn(3, alpha[jj]) - jn(5, alpha[jj]))
+        )
+        H2 = (
+            np.sin(beta[jj]) * (jn(0, alpha[jj]) - jn(2, alpha[jj]))
+            + (1 / 3) * np.sin(3 * beta[jj]) * (jn(2, alpha[jj]) - jn(4, alpha[jj]))
+            - (1 / 5) * np.sin(5 * beta[jj]) * (jn(4, alpha[jj]) - jn(6, alpha[jj]))
+        )
+        otf[jj] = (
+            (4 / (np.pi * alpha[jj])) * np.cos(alpha[jj] * nf[jj]) * H1
+            - (4 / (np.pi * alpha[jj])) * np.sin(alpha[jj] * nf[jj]) * H2
+        )
+    if otf[0] != 0:
+        otf = otf / otf[0]
+    return otf
+
+
+def _human_core(wave: np.ndarray, sample_sf: np.ndarray, p: float, d0: float) -> np.ndarray:
+    D = _human_wave_defocus(wave)
+    w20 = p ** 2 / 2 * (d0 * D) / (d0 + D)
+    c = 1 / (np.tan(np.deg2rad(1)) * (1 / d0))
+    ach_otf = _human_achromatic_otf(sample_sf)
+    s = np.zeros((wave.size, sample_sf.size))
+    alpha = np.zeros_like(s)
+    otf = np.zeros_like(s)
+    lam = wave * 1e-9
+    for ii in range(wave.size):
+        s[ii, :] = (c * lam[ii] / (d0 * p)) * sample_sf
+        alpha[ii, :] = ((4 * np.pi) / lam[ii]) * w20[ii] * s[ii, :]
+        otf[ii, :] = _optics_defocused_mtf(s[ii, :], np.abs(alpha[ii, :]))
+        otf[ii, :] *= ach_otf
+    return otf
+
+
+def human_otf(
+    p_radius: float = 0.0015,
+    d0: float = 59.9404,
+    f_support: np.ndarray | None = None,
+    wave: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return human optical transfer function."""
+    if wave is None:
+        wave = _DEF_WAVE.copy()
+    else:
+        wave = np.asarray(wave, dtype=float)
+
+    if f_support is None:
+        max_f = 60
+        f_list = _unit_frequency_list(max_f) * max_f
+        X, Y = np.meshgrid(f_list, f_list)
+        f_support = np.stack((X, Y), axis=2)
+
+    dist = np.sqrt(f_support[:, :, 0] ** 2 + f_support[:, :, 1] ** 2)
+    max_f1 = np.max(f_support[:, :, 0])
+    max_f2 = np.max(f_support[:, :, 1])
+    max_f = min(max_f1, max_f2)
+    sample_sf = np.linspace(0, max_f, 40)
+
+    otf = _human_core(wave, sample_sf, p_radius, d0)
+
+    r, c = f_support.shape[:2]
+    otf2d = np.zeros((r, c, wave.size))
+    mask = dist > max_f
+
+    for ii in range(wave.size):
+        f = interp1d(sample_sf, otf[ii, :], kind="cubic", fill_value="extrapolate")
+        tmp = np.abs(f(dist))
+        tmp[mask] = 0.0
+        otf2d[:, :, ii] = tmp
+
+    return otf2d, f_support, wave

--- a/python/tests/test_human_lsf.py
+++ b/python/tests/test_human_lsf.py
@@ -1,0 +1,11 @@
+import numpy as np
+from isetcam.human import human_lsf
+
+
+def test_human_lsf_units():
+    lsf_mm, x_mm, wave = human_lsf(wave=np.array([550]), unit="mm")
+    lsf_um, x_um, _ = human_lsf(wave=np.array([550]), unit="um")
+    assert lsf_mm.shape == lsf_um.shape
+    assert np.allclose(x_um, x_mm * 1e3)
+    center_idx = x_mm.size // 2
+    assert lsf_mm[0, center_idx] == lsf_mm[0].max()

--- a/python/tests/test_human_optical_density.py
+++ b/python/tests/test_human_optical_density.py
@@ -1,0 +1,14 @@
+import numpy as np
+from isetcam.human import human_optical_density
+
+
+def test_human_optical_density_defaults():
+    params = human_optical_density()
+    assert params["visfield"] == "fovea"
+    assert np.isclose(params["lens"], 1.0)
+    assert np.isclose(params["macular"], 0.28)
+    assert np.isclose(params["LPOD"], 0.5)
+    assert np.isclose(params["MPOD"], 0.5)
+    assert np.isclose(params["SPOD"], 0.4)
+    assert np.isclose(params["melPOD"], 0.5)
+    assert np.array_equal(params["wave"], np.arange(390, 731))

--- a/python/tests/test_human_otf.py
+++ b/python/tests/test_human_otf.py
@@ -1,0 +1,11 @@
+import numpy as np
+from isetcam.human import human_otf
+
+
+def test_human_otf_center():
+    otf, fs, wave = human_otf(wave=np.array([550]))
+    r, c = fs.shape[:2]
+    center = otf[r // 2, c // 2, 0]
+    assert np.isclose(center, 1.0)
+    assert otf.shape[2] == 1
+    assert fs.shape[0] == fs.shape[1]


### PR DESCRIPTION
## Summary
- port `humanOpticalDensity`, `humanOTF`, and `humanLSF` from MATLAB
- expose them in `isetcam.human` and the main package
- add basic unit tests for the new functions

## Testing
- `pytest -q`