### PR TITLE
Add RGB↔YCbCr utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -51,6 +51,7 @@ from .srgb_xyz import (
     srgb_to_xyz,
     xyz_to_srgb,
 )
+from .rgb_ycbcr import rgb_to_ycbcr, ycbcr_to_rgb
 from .srgb_to_cct import srgb_to_cct
 from .spd_to_cct import spd_to_cct
 from .srgb_parameters import srgb_parameters
@@ -135,6 +136,8 @@ __all__ = [
     'linear_to_srgb',
     'srgb_to_xyz',
     'xyz_to_srgb',
+    'rgb_to_ycbcr',
+    'ycbcr_to_rgb',
     'srgb_to_cct',
     'spd_to_cct',
     'srgb_parameters',

--- a/python/isetcam/rgb_ycbcr.py
+++ b/python/isetcam/rgb_ycbcr.py
@@ -1,0 +1,77 @@
+"""Conversions between RGB and YCbCr color spaces."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .color_transform_matrix import color_transform_matrix
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+
+def rgb_to_ycbcr(rgb: np.ndarray) -> np.ndarray:
+    """Convert RGB values to YCbCr.
+
+    Parameters
+    ----------
+    rgb : np.ndarray
+        RGB values in either ``(n, 3)`` XW format or ``(rows, cols, 3)`` RGB
+        format.
+
+    Returns
+    -------
+    np.ndarray
+        YCbCr values in the same spatial format as ``rgb``.
+    """
+    rgb = np.asarray(rgb, dtype=float)
+
+    if rgb.ndim == 3:
+        xw, r, c = rgb_to_xw_format(rgb)
+        reshape = True
+    elif rgb.ndim == 2 and rgb.shape[1] == 3:
+        xw = rgb
+        reshape = False
+    else:
+        raise ValueError("rgb must be (rows, cols, 3) or (n, 3)")
+
+    T = color_transform_matrix('rgb2yuv')
+    ycbcr = xw @ T
+
+    if reshape:
+        ycbcr = xw_to_rgb_format(ycbcr, r, c)
+
+    return ycbcr
+
+
+def ycbcr_to_rgb(ycbcr: np.ndarray) -> np.ndarray:
+    """Convert YCbCr values to RGB.
+
+    Parameters
+    ----------
+    ycbcr : np.ndarray
+        YCbCr values in either ``(n, 3)`` XW format or ``(rows, cols, 3)`` RGB
+        format.
+
+    Returns
+    -------
+    np.ndarray
+        RGB values in the same spatial format as ``ycbcr``.
+    """
+    ycbcr = np.asarray(ycbcr, dtype=float)
+
+    if ycbcr.ndim == 3:
+        xw, r, c = rgb_to_xw_format(ycbcr)
+        reshape = True
+    elif ycbcr.ndim == 2 and ycbcr.shape[1] == 3:
+        xw = ycbcr
+        reshape = False
+    else:
+        raise ValueError("ycbcr must be (rows, cols, 3) or (n, 3)")
+
+    T = color_transform_matrix('yuv2rgb')
+    rgb = xw @ T
+
+    if reshape:
+        rgb = xw_to_rgb_format(rgb, r, c)
+
+    return rgb

--- a/python/tests/test_rgb_ycbcr.py
+++ b/python/tests/test_rgb_ycbcr.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from isetcam import rgb_to_ycbcr, ycbcr_to_rgb
+
+
+def test_rgb_ycbcr_round_trip_xw():
+    rgb = np.random.rand(10, 3)
+    ycbcr = rgb_to_ycbcr(rgb)
+    rgb2 = ycbcr_to_rgb(ycbcr)
+    assert np.allclose(rgb2, rgb, atol=1e-6)
+
+
+def test_rgb_ycbcr_round_trip_rgb():
+    rgb = np.random.rand(4, 5, 3)
+    ycbcr = rgb_to_ycbcr(rgb)
+    rgb2 = ycbcr_to_rgb(ycbcr)
+    assert np.allclose(rgb2, rgb, atol=1e-6)


### PR DESCRIPTION
## Summary
- add `rgb_to_ycbcr` and `ycbcr_to_rgb` conversions
- expose functions from package root
- test round‑trip conversions

## Testing
- `pytest -q python/tests/test_rgb_ycbcr.py`
- `pytest -q`
