### PR TITLE
Add scotopic luminance from photons

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -11,6 +11,7 @@ from .ie_init_session import ie_init_session
 from .luminance_from_energy import luminance_from_energy
 from .luminance_from_photons import luminance_from_photons
 from .scotopic_luminance_from_energy import scotopic_luminance_from_energy
+from .scotopic_luminance_from_photons import scotopic_luminance_from_photons
 from .ie_luminance_to_radiance import ie_luminance_to_radiance
 from .ie_xyz_from_energy import ie_xyz_from_energy
 from .ie_xyz_from_photons import ie_xyz_from_photons
@@ -102,6 +103,7 @@ __all__ = [
     'luminance_from_energy',
     'luminance_from_photons',
     'scotopic_luminance_from_energy',
+    'scotopic_luminance_from_photons',
     'ie_luminance_to_radiance',
     'ie_xyz_from_energy',
     'ie_xyz_from_photons',

--- a/python/isetcam/scotopic_luminance_from_photons.py
+++ b/python/isetcam/scotopic_luminance_from_photons.py
@@ -1,0 +1,16 @@
+"""Calculate scotopic luminance from photon counts."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .quanta2energy import quanta_to_energy
+from .scotopic_luminance_from_energy import scotopic_luminance_from_energy
+
+
+def scotopic_luminance_from_photons(
+    photons: np.ndarray, wavelength: np.ndarray, binwidth: float | None = None
+) -> np.ndarray:
+    """Compute scotopic luminance (cd/m^2) from spectral photon data."""
+    energy = quanta_to_energy(wavelength, photons)
+    return scotopic_luminance_from_energy(energy, wavelength, binwidth)

--- a/python/tests/test_scotopic_luminance_photons.py
+++ b/python/tests/test_scotopic_luminance_photons.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from isetcam import (
+    scotopic_luminance_from_energy,
+    scotopic_luminance_from_photons,
+    energy_to_quanta,
+)
+
+
+def test_scotopic_luminance_from_photons():
+    wave = np.arange(400, 701, 10)
+    energy = np.ones((1, len(wave)))
+    # energy_to_quanta expects wavelength along rows
+    photons = energy_to_quanta(wave, energy.T).T
+    lum = scotopic_luminance_from_photons(photons, wave)
+    expected = scotopic_luminance_from_energy(energy, wave)
+    assert np.allclose(lum, expected)


### PR DESCRIPTION
## Summary
- support computing scotopic luminance from photons
- expose scotopic_luminance_from_photons in package
- test scotopic luminance calculation from photon data

## Testing
- `pytest -q`
