### PR TITLE
Add display_show_image test

### DIFF
--- a/python/tests/test_display_show_image.py
+++ b/python/tests/test_display_show_image.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.display import Display, display_show_image
+
+
+def _matplotlib_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_display_show_image_runs():
+    img = np.array([[[0.2, 0.4, 0.6]]], dtype=float)
+    disp = Display(spd=np.ones((1, 3)), wave=np.array([500]), gamma=None)
+    ax = display_show_image(img, disp)
+    assert ax is not None


### PR DESCRIPTION
## Summary
- add test_display_show_image to ensure matplotlib axis returned
- skip the test when matplotlib isn't installed

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_display_show_image.py`
- `PYTHONPATH=python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6838192535d4832381b2d0510ea5b2b2