### PR TITLE
Add sRGB <-> linear RGB conversion helpers

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -46,6 +46,8 @@ from .lms_to_xyz import lms_to_xyz
 from .xyz_to_lms import xyz_to_lms
 from .lms_to_srgb import lms_to_srgb
 from .srgb_to_lms import srgb_to_lms
+from .srgb_to_lrgb import srgb_to_lrgb
+from .lrgb_to_srgb import lrgb_to_srgb
 from .srgb_xyz import (
     srgb_to_linear,
     linear_to_srgb,
@@ -134,6 +136,8 @@ __all__ = [
     'xyz_to_lms',
     'lms_to_srgb',
     'srgb_to_lms',
+    'srgb_to_lrgb',
+    'lrgb_to_srgb',
     'srgb_to_linear',
     'linear_to_srgb',
     'srgb_to_xyz',

--- a/python/isetcam/lrgb_to_srgb.py
+++ b/python/isetcam/lrgb_to_srgb.py
@@ -1,0 +1,47 @@
+"""Convert linear RGB values to nonlinear sRGB."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .srgb_xyz import linear_to_srgb
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+__all__ = ["lrgb_to_srgb"]
+
+
+def lrgb_to_srgb(lrgb: np.ndarray) -> np.ndarray:
+    """Convert linear RGB values to sRGB.
+
+    Parameters
+    ----------
+    lrgb : np.ndarray
+        Linear RGB values in either ``(n, 3)`` XW format or ``(rows, cols, 3)``
+        RGB format. Values should be in ``[0, 1]``.
+
+    Returns
+    -------
+    np.ndarray
+        sRGB values in the same spatial format as ``lrgb``.
+    """
+    lrgb = np.asarray(lrgb, dtype=float)
+
+    if lrgb.max() > 1 or lrgb.min() < 0:
+        raise ValueError("lrgb values must be between 0 and 1")
+
+    if lrgb.ndim == 3:
+        xw, r, c = rgb_to_xw_format(lrgb)
+        reshape = True
+    elif lrgb.ndim == 2 and lrgb.shape[1] == 3:
+        xw = lrgb
+        reshape = False
+    else:
+        raise ValueError("lrgb must be (rows, cols, 3) or (n, 3)")
+
+    srgb = linear_to_srgb(xw)
+
+    if reshape:
+        srgb = xw_to_rgb_format(srgb, r, c)
+
+    return srgb

--- a/python/isetcam/srgb_to_lrgb.py
+++ b/python/isetcam/srgb_to_lrgb.py
@@ -1,0 +1,44 @@
+"""Convert nonlinear sRGB values to linear RGB."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .srgb_xyz import srgb_to_linear
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+__all__ = ["srgb_to_lrgb"]
+
+
+def srgb_to_lrgb(srgb: np.ndarray) -> np.ndarray:
+    """Convert sRGB values to linear RGB.
+
+    Parameters
+    ----------
+    srgb : np.ndarray
+        sRGB values in either ``(n, 3)`` XW format or ``(rows, cols, 3)``
+        RGB format.
+
+    Returns
+    -------
+    np.ndarray
+        Linear RGB values in the same spatial format as ``srgb``.
+    """
+    srgb = np.asarray(srgb, dtype=float)
+
+    if srgb.ndim == 3:
+        xw, r, c = rgb_to_xw_format(srgb)
+        reshape = True
+    elif srgb.ndim == 2 and srgb.shape[1] == 3:
+        xw = srgb
+        reshape = False
+    else:
+        raise ValueError("srgb must be (rows, cols, 3) or (n, 3)")
+
+    lrgb = srgb_to_linear(xw)
+
+    if reshape:
+        lrgb = xw_to_rgb_format(lrgb, r, c)
+
+    return lrgb

--- a/python/tests/test_srgb_lrgb.py
+++ b/python/tests/test_srgb_lrgb.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from isetcam import srgb_to_lrgb, lrgb_to_srgb
+
+
+def test_srgb_lrgb_round_trip_xw():
+    srgb = np.random.rand(10, 3)
+    lrgb = srgb_to_lrgb(srgb)
+    srgb2 = lrgb_to_srgb(lrgb)
+    assert np.allclose(srgb2, srgb, atol=1e-6)
+
+
+def test_srgb_lrgb_round_trip_rgb():
+    srgb = np.random.rand(4, 5, 3)
+    lrgb = srgb_to_lrgb(srgb)
+    srgb2 = lrgb_to_srgb(lrgb)
+    assert np.allclose(srgb2, srgb, atol=1e-6)


### PR DESCRIPTION
## Summary
- convert sRGB images to linear RGB and back
- export the new helpers in the public API
- test round‑tripping between formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a33ada62c83238a4c445ba6f58882