### PR TITLE
Add color transform matrix creation

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -17,6 +17,7 @@ from .ie_xyz_from_energy import ie_xyz_from_energy
 from .ie_xyz_from_photons import ie_xyz_from_photons
 from .ie_color_transform import ie_color_transform
 from .color_transform_matrix import color_transform_matrix
+from .color_transform_matrix_create import color_transform_matrix_create
 from .color_block_matrix import color_block_matrix
 from .chromaticity import chromaticity
 from .chromaticity_plot import chromaticity_plot
@@ -111,6 +112,7 @@ __all__ = [
     'ie_xyz_from_photons',
     'ie_color_transform',
     'color_transform_matrix',
+    'color_transform_matrix_create',
     'color_block_matrix',
     'chromaticity',
     'chromaticity_plot',

--- a/python/isetcam/color_transform_matrix_create.py
+++ b/python/isetcam/color_transform_matrix_create.py
@@ -1,0 +1,50 @@
+"""Create color transformation matrix from spectral data."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+from .ie_read_spectra import ie_read_spectra
+
+
+def _load_data(src: str | Path | np.ndarray, wave: Iterable[float] | None) -> np.ndarray:
+    if isinstance(src, (str, Path)):
+        data, _, _, _ = ie_read_spectra(src, wave)
+    else:
+        data = np.asarray(src, dtype=float)
+        if wave is not None and data.shape[0] != len(list(wave)):
+            raise ValueError("Data length must match wavelength vector")
+    return data
+
+
+def color_transform_matrix_create(
+    src: str | Path | np.ndarray,
+    dst: str | Path | np.ndarray,
+    wave: Iterable[float] | None = None,
+) -> np.ndarray:
+    """Compute a least-squares transform between spectral datasets.
+
+    Parameters
+    ----------
+    src, dst : str or Path or array-like
+        Source and target spectral data or filenames understood by
+        :func:`~isetcam.ie_read_spectra`.
+    wave : array-like, optional
+        Wavelength sampling used when loading spectra from files.
+
+    Returns
+    -------
+    np.ndarray
+        Matrix ``T`` such that ``src @ T`` approximates ``dst``.
+    """
+    src_data = _load_data(src, wave)
+    dst_data = _load_data(dst, wave)
+
+    if src_data.shape[0] != dst_data.shape[0]:
+        raise ValueError("src and dst must have the same number of rows")
+
+    T, _, _, _ = np.linalg.lstsq(src_data, dst_data, rcond=None)
+    return T

--- a/python/tests/test_color_transform_matrix_create.py
+++ b/python/tests/test_color_transform_matrix_create.py
@@ -1,0 +1,25 @@
+import numpy as np
+from isetcam import (
+    color_transform_matrix_create,
+    color_transform_matrix,
+    iset_root_path,
+)
+
+
+def test_color_transform_matrix_create_arrays():
+    src = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    true_T = np.array([[1.0, 2.0], [-1.0, 0.5]])
+    dst = src @ true_T
+    T = color_transform_matrix_create(src, dst)
+    assert np.allclose(T, true_T)
+
+
+def test_color_transform_matrix_create_files():
+    root = iset_root_path()
+    xyz_file = root / "data" / "human" / "XYZ.mat"
+    stock_file = root / "data" / "human" / "stockman.mat"
+    wave = np.arange(400, 701, 5)
+    T = color_transform_matrix_create(xyz_file, stock_file, wave)
+    expected = color_transform_matrix("xyz2sto")
+    assert T.shape == (3, 3)
+    assert np.allclose(T, expected, rtol=5e-4, atol=5e-05)


### PR DESCRIPTION
## Summary
- implement `color_transform_matrix_create` for creating color transforms from spectra
- expose in `isetcam` package
- add tests for matrix creation

## Testing
- `pytest -q python/tests/test_color_transform_matrix_create.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a354e266883239eabeb5407446575