### PR TITLE
Add camera acutance and color accuracy

### DIFF
--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -9,6 +9,8 @@ from .camera_create import camera_create
 from .camera_compute import camera_compute
 from .camera_mtf import camera_mtf
 from .camera_vsnr import camera_vsnr
+from .camera_acutance import camera_acutance
+from .camera_color_accuracy import camera_color_accuracy
 
 __all__ = [
     "Camera",
@@ -20,4 +22,6 @@ __all__ = [
     "camera_compute",
     "camera_mtf",
     "camera_vsnr",
+    "camera_acutance",
+    "camera_color_accuracy",
 ]

--- a/python/isetcam/camera/camera_acutance.py
+++ b/python/isetcam/camera/camera_acutance.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .camera_class import Camera
+from .camera_mtf import camera_mtf
+from ..metrics import iso_acutance
+
+
+_DEF_F_LENGTH = 0.004  # meters
+
+
+def _freq_to_cpd(freq: np.ndarray, f_length: float) -> np.ndarray:
+    deg_per_mm = (1e-3 / f_length) * 180.0 / np.pi
+    return freq / deg_per_mm
+
+
+def camera_acutance(camera: Camera) -> float:
+    """Return the ISO acutance of ``camera``."""
+    freqs, mtf = camera_mtf(camera)
+    f_length = getattr(camera.optics, "f_length", _DEF_F_LENGTH)
+    cpd = _freq_to_cpd(freqs, f_length)
+    return iso_acutance(cpd, mtf)
+
+
+__all__ = ["camera_acutance"]

--- a/python/isetcam/camera/camera_color_accuracy.py
+++ b/python/isetcam/camera/camera_color_accuracy.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .camera_class import Camera
+from .camera_compute import camera_compute
+from ..scene import scene_create, scene_adjust_luminance
+from ..luminance_from_photons import luminance_from_photons
+
+
+_DEF_LUMINANCE = 100.0
+
+
+def _patch_means(img: np.ndarray, patch_size: int) -> np.ndarray:
+    means = []
+    for r in range(4):
+        for c in range(6):
+            patch = img[r*patch_size:(r+1)*patch_size, c*patch_size:(c+1)*patch_size]
+            means.append(np.mean(patch))
+    return np.array(means, dtype=float)
+
+
+def camera_color_accuracy(camera: Camera, lum: float = _DEF_LUMINANCE,
+                          patch_size: int = 16) -> tuple[dict[str, np.ndarray], Camera]:
+    """Compute a simple color accuracy metric for ``camera``."""
+    sc = scene_create("macbeth d65", patch_size=patch_size)
+    sc = scene_adjust_luminance(sc, "mean", lum)
+    camera_compute(camera, sc)
+
+    sensor_means = _patch_means(camera.sensor.volts, patch_size)
+    ref_lum = luminance_from_photons(sc.photons, sc.wave)
+    ref_means = _patch_means(ref_lum, patch_size)
+
+    scale = ref_means[3] / sensor_means[3]
+    scaled = sensor_means * scale
+    delta_e = np.abs(scaled - ref_means)
+
+    result = {
+        "deltaE": delta_e,
+        "sensor_means": sensor_means,
+        "reference_means": ref_means,
+    }
+    return result, camera
+
+
+__all__ = ["camera_color_accuracy"]

--- a/python/isetcam/metrics/__init__.py
+++ b/python/isetcam/metrics/__init__.py
@@ -9,6 +9,7 @@ from .delta_e_uv import delta_e_uv
 from .xyz_to_vsnr import xyz_to_vsnr
 from .ssim_metric import ssim_metric
 from .exposure_value import exposure_value
+from .iso_acutance import iso_acutance
 
 __all__ = [
     "ie_psnr",
@@ -22,4 +23,5 @@ __all__ = [
     "xyz_to_vsnr",
     "ssim_metric",
     "exposure_value",
+    "iso_acutance",
 ]

--- a/python/isetcam/metrics/iso_acutance.py
+++ b/python/isetcam/metrics/iso_acutance.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def _cpiq_csf(v: np.ndarray) -> np.ndarray:
+    a = 75.0
+    b = 0.2
+    c = 0.8
+    K = 34.05
+    csf = a * (v ** c) * np.exp(-b * v) / K
+    if csf.size:
+        csf = csf / csf.max()
+    return csf
+
+
+def iso_acutance(cpd: np.ndarray, lum_mtf: np.ndarray) -> float:
+    cpd = np.asarray(cpd, dtype=float)
+    lum_mtf = np.asarray(lum_mtf, dtype=float)
+    if cpd.shape != lum_mtf.shape:
+        raise ValueError("cpd and lum_mtf must have the same shape")
+    if cpd.size < 2:
+        return float(np.sum(lum_mtf))
+    cpiq = _cpiq_csf(cpd)
+    dv = float(cpd[1] - cpd[0])
+    A = np.sum(lum_mtf * cpiq) * dv
+    Ar = np.sum(cpiq) * dv
+    return float(A / Ar)
+
+
+__all__ = ["iso_acutance"]

--- a/python/tests/test_camera_acutance.py
+++ b/python/tests/test_camera_acutance.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from isetcam.camera import camera_create, camera_mtf, camera_acutance
+from isetcam.camera.camera_acutance import _freq_to_cpd
+from isetcam.metrics import iso_acutance
+
+
+def test_camera_acutance_matches_manual():
+    cam = camera_create()
+    freqs, mtf = camera_mtf(cam)
+    cpd = _freq_to_cpd(freqs, cam.optics.f_length)
+    expected = iso_acutance(cpd, mtf)
+    val = camera_acutance(cam)
+    assert np.isclose(val, expected)

--- a/python/tests/test_camera_color_accuracy.py
+++ b/python/tests/test_camera_color_accuracy.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from isetcam.camera import camera_create, camera_color_accuracy
+
+
+def test_camera_color_accuracy_basic():
+    cam = camera_create()
+    res, returned = camera_color_accuracy(cam, lum=50, patch_size=4)
+    assert returned is cam
+    assert res["deltaE"].shape == (24,)
+    assert np.isclose(res["deltaE"][3], 0.0)
+    assert np.all(np.isfinite(res["deltaE"]))


### PR DESCRIPTION
## Summary
- port ISO acutance metric and provide `camera_acutance`
- implement a simple `camera_color_accuracy` metric
- expose new functions from package `__init__` modules
- add unit tests for the new camera utilities

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_camera_acutance.py python/tests/test_camera_color_accuracy.py`
- `PYTHONPATH=python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a37bfbabc83239221d7a13d801174