### PR TITLE
Add camera_compute_sequence and tests

### DIFF
--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -11,6 +11,7 @@ from .camera_mtf import camera_mtf
 from .camera_vsnr import camera_vsnr
 from .camera_acutance import camera_acutance
 from .camera_color_accuracy import camera_color_accuracy
+from .camera_compute_sequence import camera_compute_sequence
 
 __all__ = [
     "Camera",
@@ -24,4 +25,5 @@ __all__ = [
     "camera_vsnr",
     "camera_acutance",
     "camera_color_accuracy",
+    "camera_compute_sequence",
 ]

--- a/python/isetcam/camera/camera_compute_sequence.py
+++ b/python/isetcam/camera/camera_compute_sequence.py
@@ -1,0 +1,83 @@
+"""Compute a sequence of images using a camera model."""
+
+from __future__ import annotations
+
+from typing import Sequence, Tuple, List
+
+import numpy as np
+
+from .camera_class import Camera
+from .camera_compute import camera_compute
+from ..scene import Scene
+
+
+def _ensure_sequence(val, n: int | None) -> list:
+    """Return ``val`` as a list of length ``n``.
+
+    If ``val`` is already a sequence, it is returned as a list. When ``val``
+    is a scalar and ``n`` is provided, ``val`` is replicated ``n`` times.
+    """
+    if isinstance(val, (list, tuple)):
+        return list(val)
+    if n is None:
+        return [val]
+    return [val for _ in range(n)]
+
+
+def camera_compute_sequence(
+    camera: Camera,
+    *,
+    scenes: Sequence[Scene] | Scene,
+    exposure_times: Sequence[float] | float = 1.0,
+    n_frames: int | None = None,
+) -> Tuple[Camera, List[np.ndarray]]:
+    """Render ``camera`` for a sequence of scenes and exposure times.
+
+    Parameters
+    ----------
+    camera:
+        Camera object to update.
+    scenes:
+        One or more :class:`Scene` instances to render.
+    exposure_times:
+        Exposure time(s) corresponding to each frame.
+    n_frames:
+        Optional number of frames. When specified, a single ``scene`` or
+        ``exposure_time`` will be replicated to match ``n_frames``.
+
+    Returns
+    -------
+    camera : Camera
+        Updated camera after processing the sequence.
+    images : list of np.ndarray
+        List of sensor ``volts`` arrays for each frame.
+    """
+
+    # Convert inputs to lists
+    scenes_list = _ensure_sequence(scenes, n_frames)
+    exp_list = _ensure_sequence(exposure_times, n_frames)
+
+    if n_frames is None:
+        n_frames = max(len(scenes_list), len(exp_list))
+
+    if len(scenes_list) not in {1, n_frames}:
+        raise ValueError("Number of scenes must be 1 or n_frames")
+    if len(exp_list) not in {1, n_frames}:
+        raise ValueError("Number of exposure_times must be 1 or n_frames")
+
+    if len(scenes_list) == 1:
+        scenes_list *= n_frames
+    if len(exp_list) == 1:
+        exp_list *= n_frames
+
+    images: List[np.ndarray] = []
+
+    for sc, et in zip(scenes_list, exp_list):
+        camera.sensor.exposure_time = float(et)
+        camera = camera_compute(camera, sc)
+        images.append(camera.sensor.volts.copy())
+
+    return camera, images
+
+
+__all__ = ["camera_compute_sequence"]

--- a/python/tests/test_camera_compute_sequence.py
+++ b/python/tests/test_camera_compute_sequence.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+from isetcam.camera import camera_create, camera_compute_sequence
+from isetcam.scene import Scene
+
+
+def _simple_scene(w: int = 2, h: int = 2, n_wave: int = 3) -> Scene:
+    wave = np.arange(500, 500 + 10 * n_wave, 10)
+    photons = np.arange(w * h * n_wave, dtype=float).reshape((h, w, n_wave))
+    return Scene(photons=photons, wave=wave)
+
+
+def test_camera_compute_sequence_single():
+    cam = camera_create()
+    sc = _simple_scene()
+    cam, imgs = camera_compute_sequence(cam, scenes=sc, exposure_times=2.0)
+    expected = sc.photons.sum(axis=2) * 2.0
+    assert len(imgs) == 1
+    assert np.allclose(imgs[0], expected)
+    assert np.allclose(cam.sensor.volts, expected)
+
+
+def test_camera_compute_sequence_multiple():
+    cam = camera_create()
+    sc1 = _simple_scene()
+    sc2 = _simple_scene()
+    cam, imgs = camera_compute_sequence(
+        cam, scenes=[sc1, sc2], exposure_times=[1.0, 0.5]
+    )
+    exp1 = sc1.photons.sum(axis=2) * 1.0
+    exp2 = sc2.photons.sum(axis=2) * 0.5
+    assert len(imgs) == 2
+    assert np.allclose(imgs[0], exp1)
+    assert np.allclose(imgs[1], exp2)
+    assert np.allclose(cam.sensor.volts, exp2)
+
+
+def test_camera_compute_sequence_repeat_exposure():
+    cam = camera_create()
+    sc1 = _simple_scene()
+    sc2 = _simple_scene()
+    cam, imgs = camera_compute_sequence(
+        cam, scenes=[sc1, sc2], exposure_times=1.5, n_frames=2
+    )
+    expected = sc1.photons.sum(axis=2) * 1.5
+    assert len(imgs) == 2
+    assert np.allclose(imgs[0], expected)
+    assert np.allclose(imgs[1], expected)
+
+
+def test_camera_compute_sequence_mismatch_error():
+    cam = camera_create()
+    sc1 = _simple_scene()
+    sc2 = _simple_scene()
+    with pytest.raises(ValueError):
+        camera_compute_sequence(cam, scenes=[sc1, sc2], exposure_times=[1.0])
+


### PR DESCRIPTION
## Summary
- add `camera_compute_sequence` translating MATLAB `cameraComputeSequence`
- export `camera_compute_sequence` in camera package
- test multi-frame camera sequence rendering

## Testing
- `pytest -q` *(fails: 121 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683a3ab5ce7883238a0705b39c114b94