### PR TITLE
Add scene_show_image and scene_save_image utilities

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -25,6 +25,8 @@ from .scene_extract_waveband import scene_extract_waveband
 from .scene_add_grid import scene_add_grid
 from .scene_combine import scene_combine
 from .scene_adjust_pixel_size import scene_adjust_pixel_size
+from .scene_show_image import scene_show_image
+from .scene_save_image import scene_save_image
 
 __all__ = [
     "Scene",
@@ -54,4 +56,6 @@ __all__ = [
     "scene_add_grid",
     "scene_combine",
     "scene_adjust_pixel_size",
+    "scene_show_image",
+    "scene_save_image",
 ]

--- a/python/isetcam/scene/scene_save_image.py
+++ b/python/isetcam/scene/scene_save_image.py
@@ -1,0 +1,30 @@
+"""Save a rendered RGB version of a Scene."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import imageio.v2 as imageio
+
+from .scene_class import Scene
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def scene_save_image(scene: Scene, path: str | Path) -> None:
+    """Save an sRGB rendering of ``scene`` to ``path``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Scene to save.
+    path : str or Path
+        Destination image file path.
+    """
+    xyz = ie_xyz_from_photons(scene.photons, scene.wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    img = np.clip(srgb, 0.0, 1.0)
+
+    arr = (img * 255).round().astype(np.uint8)
+    imageio.imwrite(str(Path(path)), arr)

--- a/python/isetcam/scene/scene_show_image.py
+++ b/python/isetcam/scene/scene_show_image.py
@@ -1,0 +1,41 @@
+"""Display a Scene as an RGB image using Matplotlib."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - matplotlib might not be installed
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+from .scene_class import Scene
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def scene_show_image(scene: Scene):
+    """Render ``scene`` to sRGB and display with matplotlib.
+
+    Parameters
+    ----------
+    scene : Scene
+        Scene to visualise.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        Axis containing the displayed image.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for scene_show_image")
+
+    xyz = ie_xyz_from_photons(scene.photons, scene.wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    img = np.clip(srgb, 0.0, 1.0)
+
+    fig, ax = plt.subplots()
+    ax.imshow(img)
+    ax.axis("off")
+    fig.tight_layout()
+    return ax

--- a/python/tests/test_scene_show_save.py
+++ b/python/tests/test_scene_show_save.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.scene import Scene, scene_show_image, scene_save_image
+
+
+def _matplotlib_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_scene_show_image_runs():
+    sc = Scene(photons=np.ones((1, 1, 3)), wave=np.array([500, 600, 700]))
+    ax = scene_show_image(sc)
+    assert ax is not None
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_scene_save_image(tmp_path):
+    sc = Scene(photons=np.ones((1, 1, 3)), wave=np.array([500, 600, 700]))
+    path = tmp_path / "out.png"
+    scene_save_image(sc, path)
+    import imageio.v2 as imageio
+
+    img = imageio.imread(path)
+    assert img.shape == (1, 1, 3)


### PR DESCRIPTION
## Summary
- add `scene_show_image` and `scene_save_image` helpers
- expose them from `scene` package
- test showing and saving scenes

## Testing
- `PYTHONPATH=$PWD/python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a4ce45b6483239099e336c178b771