### PR TITLE
Add optical image show/save helpers

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -20,6 +20,8 @@ from .oi_adjust_illuminance import oi_adjust_illuminance
 from .oi_extract_waveband import oi_extract_waveband
 from .oi_calculate_irradiance import oi_calculate_irradiance
 from .oi_calculate_illuminance import oi_calculate_illuminance
+from .oi_show_image import oi_show_image
+from .oi_save_image import oi_save_image
 
 __all__ = [
     "OpticalImage",
@@ -44,4 +46,6 @@ __all__ = [
     "oi_extract_waveband",
     "oi_calculate_irradiance",
     "oi_calculate_illuminance",
+    "oi_show_image",
+    "oi_save_image",
 ]

--- a/python/isetcam/opticalimage/oi_save_image.py
+++ b/python/isetcam/opticalimage/oi_save_image.py
@@ -1,0 +1,47 @@
+"""Save a rendered RGB version of an OpticalImage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import imageio.v2 as imageio
+
+from .oi_class import OpticalImage
+from ..display import Display, display_create, display_render, display_apply_gamma
+from ..rgb_to_xw_format import rgb_to_xw_format
+from ..xw_to_rgb_format import xw_to_rgb_format
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def _photons_to_rgb(oi: OpticalImage, display: Display) -> np.ndarray:
+    photons = np.asarray(oi.photons, dtype=float)
+    if photons.ndim != 3:
+        raise ValueError("oi.photons must be a 3-D array")
+    spd = np.asarray(display.spd, dtype=float)
+    if photons.shape[2] != spd.shape[0]:
+        raise ValueError("Wavelength dimension mismatch with display")
+
+    xw, rows, cols = rgb_to_xw_format(photons)
+    rgb_lin = xw @ np.linalg.pinv(spd)
+    if display.gamma is not None:
+        rgb = display_apply_gamma(rgb_lin, display, inverse=True)
+    else:
+        rgb = rgb_lin
+    rgb = xw_to_rgb_format(rgb, rows, cols)
+    return rgb
+
+
+def oi_save_image(oi: OpticalImage, path: str | Path, display: Display | None = None) -> None:
+    """Save an sRGB rendering of ``oi`` to ``path``."""
+    if display is None:
+        display = display_create()
+
+    rgb = _photons_to_rgb(oi, display)
+    spectral = display_render(rgb, display, apply_gamma=True)
+    xyz = ie_xyz_from_photons(spectral, display.wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+
+    arr = (np.clip(srgb, 0.0, 1.0) * 255).round().astype(np.uint8)
+    imageio.imwrite(str(Path(path)), arr)

--- a/python/isetcam/opticalimage/oi_show_image.py
+++ b/python/isetcam/opticalimage/oi_show_image.py
@@ -1,0 +1,56 @@
+"""Display an OpticalImage using Matplotlib."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - matplotlib might not be installed
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+from .oi_class import OpticalImage
+from ..display import Display, display_create, display_render, display_apply_gamma
+from ..rgb_to_xw_format import rgb_to_xw_format
+from ..xw_to_rgb_format import xw_to_rgb_format
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def _photons_to_rgb(oi: OpticalImage, display: Display) -> np.ndarray:
+    """Convert optical image photons to display RGB values."""
+    photons = np.asarray(oi.photons, dtype=float)
+    if photons.ndim != 3:
+        raise ValueError("oi.photons must be a 3-D array")
+    spd = np.asarray(display.spd, dtype=float)
+    if photons.shape[2] != spd.shape[0]:
+        raise ValueError("Wavelength dimension mismatch with display")
+
+    xw, rows, cols = rgb_to_xw_format(photons)
+    rgb_lin = xw @ np.linalg.pinv(spd)
+    if display.gamma is not None:
+        rgb = display_apply_gamma(rgb_lin, display, inverse=True)
+    else:
+        rgb = rgb_lin
+    rgb = xw_to_rgb_format(rgb, rows, cols)
+    return rgb
+
+
+def oi_show_image(oi: OpticalImage, display: Display | None = None):
+    """Render ``oi`` to RGB for ``display`` and show with matplotlib."""
+    if plt is None:
+        raise ImportError("matplotlib is required for oi_show_image")
+    if display is None:
+        display = display_create()
+
+    rgb = _photons_to_rgb(oi, display)
+    # Render through the display model
+    spectral = display_render(rgb, display, apply_gamma=True)
+    xyz = ie_xyz_from_photons(spectral, display.wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+
+    fig, ax = plt.subplots()
+    ax.imshow(np.clip(srgb, 0.0, 1.0))
+    ax.axis("off")
+    fig.tight_layout()
+    return ax

--- a/python/tests/test_oi_show_save.py
+++ b/python/tests/test_oi_show_save.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.opticalimage import OpticalImage, oi_show_image, oi_save_image
+from isetcam.display import Display
+
+
+def _matplotlib_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_oi_show_image_runs():
+    wave = np.array([500, 600, 700])
+    photons = np.ones((1, 1, 3))
+    oi = OpticalImage(photons=photons, wave=wave)
+    disp = Display(spd=np.eye(3), wave=wave, gamma=None)
+    ax = oi_show_image(oi, disp)
+    assert ax is not None
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_oi_save_image(tmp_path):
+    wave = np.array([500, 600, 700])
+    photons = np.ones((1, 1, 3))
+    oi = OpticalImage(photons=photons, wave=wave)
+    disp = Display(spd=np.eye(3), wave=wave, gamma=None)
+    path = tmp_path / "oi.png"
+    oi_save_image(oi, path, disp)
+    import imageio.v2 as imageio
+
+    img = imageio.imread(path)
+    assert img.shape == (1, 1, 3)


### PR DESCRIPTION
## Summary
- add helper functions for displaying and saving optical images
- render photons through a Display to sRGB
- export helpers from `isetcam.opticalimage`
- test optical image show and save utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a4ef12d848323933f2c22d6faf978