### PR TITLE
Add illuminant spatial pattern utilities

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -22,6 +22,8 @@ from .oi_calculate_irradiance import oi_calculate_irradiance
 from .oi_calculate_illuminance import oi_calculate_illuminance
 from .oi_show_image import oi_show_image
 from .oi_save_image import oi_save_image
+from .oi_illuminant_pattern import oi_illuminant_pattern
+from .oi_illuminant_ss import oi_illuminant_ss
 
 __all__ = [
     "OpticalImage",
@@ -48,4 +50,6 @@ __all__ = [
     "oi_calculate_illuminance",
     "oi_show_image",
     "oi_save_image",
+    "oi_illuminant_pattern",
+    "oi_illuminant_ss",
 ]

--- a/python/isetcam/opticalimage/oi_illuminant_pattern.py
+++ b/python/isetcam/opticalimage/oi_illuminant_pattern.py
@@ -1,0 +1,58 @@
+"""Apply a spatial pattern to the optical image illuminant and photons."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import zoom as nd_zoom
+
+from .oi_class import OpticalImage
+
+
+def oi_illuminant_pattern(oi: OpticalImage, pattern: np.ndarray) -> OpticalImage:
+    """Multiply ``oi`` photons and illuminant by ``pattern``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image containing an ``illuminant`` attribute.
+    pattern : array-like
+        2-D spatial pattern used to modulate the photons and illuminant.
+
+    Returns
+    -------
+    OpticalImage
+        New optical image with scaled photons and illuminant.
+    """
+
+    pat = np.asarray(pattern, dtype=float)
+    if pat.ndim != 2:
+        raise ValueError("pattern must be 2-D")
+
+    photons = np.asarray(oi.photons, dtype=float)
+    rows, cols = photons.shape[:2]
+    if pat.shape != (rows, cols):
+        zoom_factors = (rows / pat.shape[0], cols / pat.shape[1])
+        pat = nd_zoom(pat, zoom_factors, order=1)
+
+    scaled_photons = photons * pat[:, :, np.newaxis]
+    out = OpticalImage(photons=scaled_photons, wave=oi.wave, name=oi.name)
+
+    illum = getattr(oi, "illuminant", None)
+    if illum is not None:
+        ill = np.asarray(illum, dtype=float)
+        if ill.ndim == 1:
+            if ill.size != photons.shape[2]:
+                raise ValueError("Illuminant vector length must match oi wave")
+            ill = np.tile(ill.reshape(1, 1, -1), (rows, cols, 1))
+        elif ill.ndim == 3:
+            if ill.shape != photons.shape:
+                raise ValueError("Illuminant cube must match oi photon shape")
+        else:
+            raise ValueError("Illuminant must be 1-D or 3-D")
+        ill = ill * pat[:, :, np.newaxis]
+        if np.allclose(ill, ill[0, 0, :]):
+            out.illuminant = ill[0, 0, :]
+        else:
+            out.illuminant = ill
+
+    return out

--- a/python/isetcam/opticalimage/oi_illuminant_ss.py
+++ b/python/isetcam/opticalimage/oi_illuminant_ss.py
@@ -1,0 +1,52 @@
+"""Convert an optical image illuminant to spatial-spectral format."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+from .oi_illuminant_pattern import oi_illuminant_pattern
+
+
+def oi_illuminant_ss(oi: OpticalImage, pattern: np.ndarray | None = None) -> OpticalImage:
+    """Ensure the optical image illuminant is spatial-spectral.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image with an ``illuminant`` attribute.
+    pattern : array-like, optional
+        Spatial pattern applied after conversion.
+
+    Returns
+    -------
+    OpticalImage
+        Optical image with spatial-spectral illuminant, optionally scaled by ``pattern``.
+    """
+
+    photons = np.asarray(oi.photons, dtype=float)
+    rows, cols, n_wave = photons.shape
+
+    illum = getattr(oi, "illuminant", None)
+    if illum is None:
+        raise AttributeError("oi has no illuminant attribute")
+    ill = np.asarray(illum, dtype=float)
+
+    if ill.ndim == 1:
+        if ill.size != n_wave:
+            raise ValueError("Illuminant vector length must match oi wave")
+        ill_cube = np.tile(ill.reshape(1, 1, -1), (rows, cols, 1))
+    elif ill.ndim == 3:
+        if ill.shape != photons.shape:
+            raise ValueError("Illuminant cube must match oi photon shape")
+        ill_cube = ill
+    else:
+        raise ValueError("Illuminant must be 1-D or 3-D")
+
+    out = OpticalImage(photons=photons, wave=oi.wave, name=oi.name)
+    out.illuminant = ill_cube
+
+    if pattern is not None:
+        out = oi_illuminant_pattern(out, pattern)
+
+    return out

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -27,6 +27,8 @@ from .scene_combine import scene_combine
 from .scene_adjust_pixel_size import scene_adjust_pixel_size
 from .scene_show_image import scene_show_image
 from .scene_save_image import scene_save_image
+from .scene_illuminant_pattern import scene_illuminant_pattern
+from .scene_illuminant_ss import scene_illuminant_ss
 
 __all__ = [
     "Scene",
@@ -58,4 +60,6 @@ __all__ = [
     "scene_adjust_pixel_size",
     "scene_show_image",
     "scene_save_image",
+    "scene_illuminant_pattern",
+    "scene_illuminant_ss",
 ]

--- a/python/isetcam/scene/scene_illuminant_pattern.py
+++ b/python/isetcam/scene/scene_illuminant_pattern.py
@@ -1,0 +1,58 @@
+"""Apply a spatial pattern to the scene illuminant and photons."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import zoom as nd_zoom
+
+from .scene_class import Scene
+
+
+def scene_illuminant_pattern(scene: Scene, pattern: np.ndarray) -> Scene:
+    """Multiply ``scene`` photons and illuminant by ``pattern``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene containing an ``illuminant`` attribute.
+    pattern : array-like
+        2-D spatial pattern used to modulate the photons and illuminant.
+
+    Returns
+    -------
+    Scene
+        New scene with scaled photons and illuminant.
+    """
+
+    pat = np.asarray(pattern, dtype=float)
+    if pat.ndim != 2:
+        raise ValueError("pattern must be 2-D")
+
+    photons = np.asarray(scene.photons, dtype=float)
+    rows, cols = photons.shape[:2]
+    if pat.shape != (rows, cols):
+        zoom_factors = (rows / pat.shape[0], cols / pat.shape[1])
+        pat = nd_zoom(pat, zoom_factors, order=1)
+
+    scaled_photons = photons * pat[:, :, np.newaxis]
+    out = Scene(photons=scaled_photons, wave=scene.wave, name=scene.name)
+
+    illum = getattr(scene, "illuminant", None)
+    if illum is not None:
+        ill = np.asarray(illum, dtype=float)
+        if ill.ndim == 1:
+            if ill.size != photons.shape[2]:
+                raise ValueError("Illuminant vector length must match scene wave")
+            ill = np.tile(ill.reshape(1, 1, -1), (rows, cols, 1))
+        elif ill.ndim == 3:
+            if ill.shape != photons.shape:
+                raise ValueError("Illuminant cube must match scene photon shape")
+        else:
+            raise ValueError("Illuminant must be 1-D or 3-D")
+        ill = ill * pat[:, :, np.newaxis]
+        if np.allclose(ill, ill[0, 0, :]):
+            out.illuminant = ill[0, 0, :]
+        else:
+            out.illuminant = ill
+
+    return out

--- a/python/isetcam/scene/scene_illuminant_ss.py
+++ b/python/isetcam/scene/scene_illuminant_ss.py
@@ -1,0 +1,52 @@
+"""Convert a scene illuminant to spatial-spectral format."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+from .scene_illuminant_pattern import scene_illuminant_pattern
+
+
+def scene_illuminant_ss(scene: Scene, pattern: np.ndarray | None = None) -> Scene:
+    """Ensure the scene illuminant is spatial-spectral.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene with an ``illuminant`` attribute.
+    pattern : array-like, optional
+        Spatial pattern applied after conversion.
+
+    Returns
+    -------
+    Scene
+        Scene with spatial-spectral illuminant, optionally scaled by ``pattern``.
+    """
+
+    photons = np.asarray(scene.photons, dtype=float)
+    rows, cols, n_wave = photons.shape
+
+    illum = getattr(scene, "illuminant", None)
+    if illum is None:
+        raise AttributeError("scene has no illuminant attribute")
+    ill = np.asarray(illum, dtype=float)
+
+    if ill.ndim == 1:
+        if ill.size != n_wave:
+            raise ValueError("Illuminant vector length must match scene wave")
+        ill_cube = np.tile(ill.reshape(1, 1, -1), (rows, cols, 1))
+    elif ill.ndim == 3:
+        if ill.shape != photons.shape:
+            raise ValueError("Illuminant cube must match scene photon shape")
+        ill_cube = ill
+    else:
+        raise ValueError("Illuminant must be 1-D or 3-D")
+
+    out = Scene(photons=photons, wave=scene.wave, name=scene.name)
+    out.illuminant = ill_cube
+
+    if pattern is not None:
+        out = scene_illuminant_pattern(out, pattern)
+
+    return out

--- a/python/tests/test_illuminant_pattern.py
+++ b/python/tests/test_illuminant_pattern.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_illuminant_pattern, scene_illuminant_ss
+from isetcam.opticalimage import OpticalImage, oi_illuminant_pattern, oi_illuminant_ss
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([500, 510])
+    photons = np.ones((2, 3, 2), dtype=float)
+    sc = Scene(photons=photons, wave=wave)
+    sc.illuminant = np.array([1.0, 2.0])
+    return sc
+
+
+def _simple_oi() -> OpticalImage:
+    wave = np.array([500, 510])
+    photons = np.ones((2, 3, 2), dtype=float)
+    oi = OpticalImage(photons=photons, wave=wave)
+    oi.illuminant = np.array([1.0, 2.0])
+    return oi
+
+
+def test_scene_illuminant_ss():
+    sc = _simple_scene()
+    out = scene_illuminant_ss(sc)
+    expected = np.tile(sc.illuminant.reshape(1, 1, -1), (2, 3, 1))
+    assert np.allclose(out.illuminant, expected)
+
+
+def test_scene_illuminant_pattern():
+    sc = scene_illuminant_ss(_simple_scene())
+    pattern = np.array([[1.0, 2.0, 3.0], [0.5, 0.5, 0.5]])
+    out = scene_illuminant_pattern(sc, pattern)
+    assert np.allclose(out.photons, sc.photons * pattern[:, :, None])
+    assert np.allclose(out.illuminant, sc.illuminant * pattern[:, :, None])
+
+
+def test_oi_illuminant_ss():
+    oi = _simple_oi()
+    out = oi_illuminant_ss(oi)
+    expected = np.tile(oi.illuminant.reshape(1, 1, -1), (2, 3, 1))
+    assert np.allclose(out.illuminant, expected)
+
+
+def test_oi_illuminant_pattern():
+    oi = oi_illuminant_ss(_simple_oi())
+    pattern = np.array([[2.0, 2.0, 1.0], [1.0, 0.5, 0.5]])
+    out = oi_illuminant_pattern(oi, pattern)
+    assert np.allclose(out.photons, oi.photons * pattern[:, :, None])
+    assert np.allclose(out.illuminant, oi.illuminant * pattern[:, :, None])


### PR DESCRIPTION
## Summary
- implement `scene_illuminant_pattern` and `oi_illuminant_pattern`
- add `scene_illuminant_ss` and `oi_illuminant_ss`
- expose the new utilities in package `__init__` files
- test illuminant pattern functions

## Testing
- `pytest python/tests/test_illuminant_pattern.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683a51d3dcd48323974b7d02c991752d