### PR TITLE
Add thumbnail utilities

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -22,6 +22,7 @@ from .oi_calculate_irradiance import oi_calculate_irradiance
 from .oi_calculate_illuminance import oi_calculate_illuminance
 from .oi_show_image import oi_show_image
 from .oi_save_image import oi_save_image
+from .oi_thumbnail import oi_thumbnail
 from .oi_illuminant_pattern import oi_illuminant_pattern
 from .oi_illuminant_ss import oi_illuminant_ss
 
@@ -50,6 +51,7 @@ __all__ = [
     "oi_calculate_illuminance",
     "oi_show_image",
     "oi_save_image",
+    "oi_thumbnail",
     "oi_illuminant_pattern",
     "oi_illuminant_ss",
 ]

--- a/python/isetcam/opticalimage/oi_thumbnail.py
+++ b/python/isetcam/opticalimage/oi_thumbnail.py
@@ -1,0 +1,20 @@
+"""Create a thumbnail RGB image for an :class:`OpticalImage`."""
+
+from __future__ import annotations
+
+import numpy as np
+from skimage.transform import resize
+
+from .oi_class import OpticalImage
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def oi_thumbnail(oi: OpticalImage, size: tuple[int, int] = (128, 128)) -> np.ndarray:
+    """Return a downscaled sRGB rendering of ``oi``."""
+    xyz = ie_xyz_from_photons(oi.photons, oi.wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    img = np.clip(srgb, 0.0, 1.0)
+    rows, cols = int(size[0]), int(size[1])
+    thumb = resize(img, (rows, cols, 3), order=1, mode="reflect", anti_aliasing=True, preserve_range=True)
+    return thumb.astype(float)

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -27,6 +27,7 @@ from .scene_combine import scene_combine
 from .scene_adjust_pixel_size import scene_adjust_pixel_size
 from .scene_show_image import scene_show_image
 from .scene_save_image import scene_save_image
+from .scene_thumbnail import scene_thumbnail
 from .scene_illuminant_pattern import scene_illuminant_pattern
 from .scene_illuminant_ss import scene_illuminant_ss
 
@@ -60,6 +61,7 @@ __all__ = [
     "scene_adjust_pixel_size",
     "scene_show_image",
     "scene_save_image",
+    "scene_thumbnail",
     "scene_illuminant_pattern",
     "scene_illuminant_ss",
 ]

--- a/python/isetcam/scene/scene_thumbnail.py
+++ b/python/isetcam/scene/scene_thumbnail.py
@@ -1,0 +1,33 @@
+"""Create a thumbnail RGB image for a :class:`Scene`."""
+
+from __future__ import annotations
+
+import numpy as np
+from skimage.transform import resize
+
+from .scene_class import Scene
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def scene_thumbnail(scene: Scene, size: tuple[int, int] = (128, 128)) -> np.ndarray:
+    """Return a downscaled sRGB rendering of ``scene``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Scene to render.
+    size : tuple[int, int], optional
+        Desired ``(rows, cols)`` for the output thumbnail. Defaults to ``(128, 128)``.
+
+    Returns
+    -------
+    np.ndarray
+        sRGB image of shape ``(rows, cols, 3)`` with values in ``[0, 1]``.
+    """
+    xyz = ie_xyz_from_photons(scene.photons, scene.wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    img = np.clip(srgb, 0.0, 1.0)
+    rows, cols = int(size[0]), int(size[1])
+    thumb = resize(img, (rows, cols, 3), order=1, mode="reflect", anti_aliasing=True, preserve_range=True)
+    return thumb.astype(float)

--- a/python/tests/test_thumbnails.py
+++ b/python/tests/test_thumbnails.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_thumbnail
+from isetcam.opticalimage import OpticalImage, oi_thumbnail
+
+
+def test_scene_thumbnail_size():
+    wave = np.array([500, 600, 700])
+    photons = np.ones((32, 16, 3))
+    sc = Scene(photons=photons, wave=wave)
+    thumb = scene_thumbnail(sc, size=(8, 4))
+    assert thumb.shape == (8, 4, 3)
+    assert thumb.min() >= 0 and thumb.max() <= 1
+
+
+def test_oi_thumbnail_size():
+    wave = np.array([500, 600, 700])
+    photons = np.ones((16, 16, 3))
+    oi = OpticalImage(photons=photons, wave=wave)
+    thumb = oi_thumbnail(oi, size=(4, 4))
+    assert thumb.shape == (4, 4, 3)
+    assert thumb.min() >= 0 and thumb.max() <= 1


### PR DESCRIPTION
## Summary
- implement `scene_thumbnail` for simple RGB preview of scenes
- implement `oi_thumbnail` for optical images
- expose new helpers through packages
- add tests

## Testing
- `pytest python/tests/test_thumbnails.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a544074788323b5e98bee60b61221