### PR TITLE
Add human cone contrast utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -84,6 +84,8 @@ from .human import (
     human_optical_density,
     human_otf,
     human_lsf,
+    human_cone_contrast,
+    human_cone_isolating,
 )
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
@@ -173,6 +175,8 @@ __all__ = [
     'human_optical_density',
     'human_otf',
     'human_lsf',
+    'human_cone_contrast',
+    'human_cone_isolating',
     'iset_root_path',
     'ie_init',
     'ie_init_session',

--- a/python/isetcam/human/__init__.py
+++ b/python/isetcam/human/__init__.py
@@ -5,6 +5,8 @@ from .human_macular_transmittance import human_macular_transmittance
 from .human_optical_density import human_optical_density
 from .human_otf import human_otf
 from .human_lsf import human_lsf
+from .human_cone_contrast import human_cone_contrast
+from .human_cone_isolating import human_cone_isolating
 
 __all__ = [
     'human_pupil_size',
@@ -12,4 +14,6 @@ __all__ = [
     'human_optical_density',
     'human_otf',
     'human_lsf',
+    'human_cone_contrast',
+    'human_cone_isolating',
 ]

--- a/python/isetcam/human/human_cone_contrast.py
+++ b/python/isetcam/human/human_cone_contrast.py
@@ -1,0 +1,56 @@
+"""Cone contrast for a signal relative to a background."""
+
+from __future__ import annotations
+
+import numpy as np
+from ..ie_read_spectra import ie_read_spectra
+from ..iset_root_path import iset_root_path
+from ..quanta2energy import quanta_to_energy
+
+Units = "energy", "photons", "quanta"
+
+def human_cone_contrast(
+    spd_signal: np.ndarray,
+    spd_background: np.ndarray,
+    wave: np.ndarray,
+    units: str = "energy",
+) -> np.ndarray:
+    """Return L, M, S cone contrast of ``spd_signal`` on ``spd_background``.
+
+    Parameters
+    ----------
+    spd_signal : np.ndarray
+        Signal spectral power distribution. Columns represent different
+        signals and the length of the first dimension must match ``wave``.
+    spd_background : np.ndarray
+        Background spectral power distribution with length ``wave``.
+    wave : np.ndarray
+        Wavelength samples in nanometers.
+    units : {'energy', 'photons', 'quanta'}, optional
+        Units of the input spectra. Defaults to ``'energy'``.
+
+    Returns
+    -------
+    np.ndarray
+        Cone contrast matrix with shape ``(3, n)`` where ``n`` is the number
+        of signal spectra.
+    """
+    spd_signal = np.asarray(spd_signal, dtype=float)
+    spd_background = np.asarray(spd_background, dtype=float).reshape(-1)
+    wave = np.asarray(wave, dtype=float).reshape(-1)
+
+    if spd_signal.shape[0] != wave.size or spd_background.size != wave.size:
+        raise ValueError("wave length must match spd dimensions")
+
+    if units.lower() in {"photons", "quanta"}:
+        spd_signal = quanta_to_energy(wave, spd_signal)
+        spd_background = quanta_to_energy(wave, spd_background)
+
+    root = iset_root_path()
+    cone_file = root / "data" / "human" / "stockman.mat"
+    cones, _, _, _ = ie_read_spectra(cone_file, wave)
+
+    back_cones = cones.T @ spd_background
+    sig_cones = cones.T @ spd_signal
+
+    return np.diag(1.0 / back_cones) @ sig_cones

--- a/python/isetcam/human/human_cone_isolating.py
+++ b/python/isetcam/human/human_cone_isolating.py
@@ -1,0 +1,43 @@
+"""RGB directions that approximately isolate the cones of a display."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..display import Display
+from ..ie_read_spectra import ie_read_spectra
+from ..iset_root_path import iset_root_path
+
+
+def human_cone_isolating(display: Display) -> tuple[np.ndarray, np.ndarray]:
+    """Return RGB vectors that isolate L, M and S cones.
+
+    Parameters
+    ----------
+    display : :class:`~isetcam.display.Display`
+        Display model providing spectral power distributions of its
+        primaries.
+
+    Returns
+    -------
+    cone_isolating : np.ndarray
+        ``(3, 3)`` matrix whose columns are linear RGB directions scaled so
+        that ``max(abs(col)) == 0.5``.
+    spd : np.ndarray
+        Spectral power distributions of the three directions with shape
+        ``(len(display.wave), 3)``.
+    """
+    wave = np.asarray(display.wave, dtype=float)
+    spd = np.asarray(display.spd, dtype=float)
+
+    root = iset_root_path()
+    cone_file = root / "data" / "human" / "stockman.mat"
+    cones, _, _, _ = ie_read_spectra(cone_file, wave)
+
+    rgb2lms = (cones.T @ spd).T
+    cone_isolating = np.linalg.inv(rgb2lms)
+    mx = np.max(np.abs(cone_isolating), axis=0)
+    cone_isolating = cone_isolating / (2 * mx)
+    spd_dirs = spd @ cone_isolating
+
+    return cone_isolating, spd_dirs

--- a/python/tests/test_human_cone_contrast.py
+++ b/python/tests/test_human_cone_contrast.py
@@ -1,0 +1,19 @@
+import numpy as np
+from isetcam.display import display_create
+from isetcam.human import human_cone_isolating, human_cone_contrast
+
+
+def test_human_cone_contrast_example():
+    dsp = display_create('LCD-Apple')
+    iso, sig_spd = human_cone_isolating(dsp)
+    bg_spd = dsp.spd @ (0.5 * np.ones(3))
+    contrast = human_cone_contrast(sig_spd, bg_spd, dsp.wave)
+
+    expected = np.array([
+        [-0.40720624, 0.59435214, 0.0252326],
+        [-0.68956722, 0.75893057, 0.06778289],
+        [0.00689323, -0.07968389, 0.91977398],
+    ])
+
+    assert contrast.shape == (3, 3)
+    assert np.allclose(contrast, expected, atol=3e-5)

--- a/python/tests/test_human_cone_isolating.py
+++ b/python/tests/test_human_cone_isolating.py
@@ -1,0 +1,28 @@
+import numpy as np
+from isetcam.display import display_create
+from isetcam.human import human_cone_isolating
+
+
+def test_human_cone_isolating_basic():
+    dsp = display_create('LCD-Apple')
+    iso, spd = human_cone_isolating(dsp)
+
+    expected_iso = np.array([
+        [0.5, -0.15395504, -0.00267701],
+        [-0.49142262, 0.5, -0.02156203],
+        [0.0343801, -0.07811632, 0.5],
+    ])
+
+    assert iso.shape == (3, 3)
+    assert spd.shape == (dsp.wave.size, 3)
+    assert np.allclose(iso, expected_iso, atol=1e-5)
+    assert np.allclose(
+        spd[0],
+        [-9.21315187e-07, 1.97421203e-06, 2.03042851e-06],
+        atol=1e-10,
+    )
+    assert np.allclose(
+        spd[-1],
+        [1.46054133e-05, 7.27774837e-06, 1.68922615e-05],
+        atol=1e-9,
+    )


### PR DESCRIPTION
## Summary
- implement `human_cone_contrast` and `human_cone_isolating`
- expose the new functions in the human package and top-level API
- test cone isolating directions for the LCD-Apple display
- test cone contrast computation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a59a3d7f08323b249669d6f03a584