### PR TITLE
Add display plot and list utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -93,7 +93,12 @@ from .human import (
 from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc, metrics, optics, human, ip
 from .opticalimage import oi_to_file
 from .sensor import sensor_to_file
-from .display import display_to_file
+from .display import (
+    display_to_file,
+    display_list,
+    display_max_contrast,
+    display_plot,
+)
 from .camera import camera_to_file, camera_from_file
 from .optics import optics_to_file, optics_from_file
 from .illuminant import illuminant_to_file, illuminant_from_file
@@ -194,6 +199,9 @@ __all__ = [
     'oi_to_file',
     'sensor_to_file',
     'display_to_file',
+    'display_list',
+    'display_max_contrast',
+    'display_plot',
     'illuminant_to_file',
     'illuminant_from_file',
     'camera_to_file',

--- a/python/isetcam/display/__init__.py
+++ b/python/isetcam/display/__init__.py
@@ -14,6 +14,9 @@ from .display_render import display_render
 from .display_show_image import display_show_image
 from .display_from_file import display_from_file
 from .display_to_file import display_to_file
+from .display_list import display_list
+from .display_max_contrast import display_max_contrast
+from .display_plot import display_plot
 
 __all__ = [
     "Display",
@@ -25,4 +28,7 @@ __all__ = [
     "display_show_image",
     "display_from_file",
     "display_to_file",
+    "display_list",
+    "display_max_contrast",
+    "display_plot",
 ]

--- a/python/isetcam/display/display_list.py
+++ b/python/isetcam/display/display_list.py
@@ -1,0 +1,29 @@
+"""List available display calibration files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..iset_root_path import iset_root_path
+
+
+_DEF_DIR = "data"
+
+
+def display_list() -> list[str]:
+    """Return available display calibration names.
+
+    The names correspond to ``.mat`` files under ``data/displays`` in the
+    ISETCam repository.  The returned list is sorted alphabetically and the
+    ``.mat`` extension is stripped.
+    """
+    root = iset_root_path()
+    disp_dir = root / _DEF_DIR / "displays"
+    names: list[str] = []
+    if disp_dir.exists():
+        for f in disp_dir.glob("*.mat"):
+            names.append(Path(f).stem)
+    return sorted(names)
+
+
+__all__ = ["display_list"]

--- a/python/isetcam/display/display_max_contrast.py
+++ b/python/isetcam/display/display_max_contrast.py
@@ -1,0 +1,28 @@
+"""Compute the Michelson contrast between two signals."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+
+def display_max_contrast(signal_dir: np.ndarray, back_dir: np.ndarray) -> float:
+    """Return the maximum Michelson contrast of ``signal_dir`` vs ``back_dir``.
+
+    ``signal_dir`` and ``back_dir`` should be arrays of the same shape.
+    The function computes ``(max(signal) - min(background)) / (max(signal) + min(background))``.
+    When either input contains only zeros the contrast is zero.
+    """
+    sig = np.asarray(signal_dir, dtype=float)
+    back = np.asarray(back_dir, dtype=float)
+    if sig.shape != back.shape:
+        raise ValueError("signal_dir and back_dir must have the same shape")
+    s_max = sig.max()
+    b_min = back.min()
+    denom = s_max + b_min
+    if denom == 0:
+        return 0.0
+    return float((s_max - b_min) / denom)
+
+
+__all__ = ["display_max_contrast"]

--- a/python/isetcam/display/display_plot.py
+++ b/python/isetcam/display/display_plot.py
@@ -1,0 +1,88 @@
+"""Visualize different properties of a Display."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+from .display_class import Display
+from ..ie_xyz_from_energy import ie_xyz_from_energy
+from ..chromaticity import chromaticity
+
+
+_DEF_COLORS = ["r", "g", "b"]
+
+
+def display_plot(display: Display, kind: str = "spd", ax: "plt.Axes | None" = None) -> "plt.Axes":
+    """Plot information about ``display``.
+
+    Parameters
+    ----------
+    display : Display
+        Display definition.
+    kind : str, optional
+        One of ``'spd'``, ``'gamma'`` or ``'gamut'``.  ``'spd'`` plots the
+        spectral power distribution of the primaries versus wavelength.
+        ``'gamma'`` plots the gamma curves if available. ``'gamut'`` plots the
+        chromaticity coordinates of the primaries.
+    ax : matplotlib.axes.Axes, optional
+        Axis to plot into. When ``None`` a new figure and axis are created.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        Axis containing the plot.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for display_plot")
+
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = ax.figure
+
+    kind = kind.lower()
+    if kind == "spd":
+        wave = np.asarray(display.wave, dtype=float)
+        spd = np.asarray(display.spd, dtype=float)
+        if spd.shape[0] != wave.shape[0]:
+            raise ValueError("display.spd and display.wave size mismatch")
+        for i in range(min(spd.shape[1], 3)):
+            ax.plot(wave, spd[:, i], color=_DEF_COLORS[i])
+        ax.set_xlabel("Wavelength (nm)")
+        ax.set_ylabel("Spectral power")
+    elif kind == "gamma":
+        if display.gamma is None:
+            raise ValueError("display has no gamma table")
+        gamma = np.asarray(display.gamma, dtype=float)
+        x = np.linspace(0, 1, gamma.shape[0])
+        for i in range(min(gamma.shape[1], 3)):
+            ax.plot(x, gamma[:, i], color=_DEF_COLORS[i])
+        ax.set_xlabel("Input level")
+        ax.set_ylabel("Output level")
+    elif kind == "gamut":
+        wave = np.asarray(display.wave, dtype=float)
+        spd = np.asarray(display.spd, dtype=float)
+        xyz = ie_xyz_from_energy(spd.T, wave)
+        xy = chromaticity(xyz)
+        for i in range(min(xy.shape[0], 3)):
+            ax.plot(xy[i, 0], xy[i, 1], "o", color=_DEF_COLORS[i])
+        # draw triangle
+        order = list(range(min(xy.shape[0], 3))) + [0]
+        ax.plot(xy[order, 0], xy[order, 1], "k-")
+        ax.set_xlabel("CIE x")
+        ax.set_ylabel("CIE y")
+        ax.set_xlim(0.0, 0.8)
+        ax.set_ylim(0.0, 0.9)
+    else:
+        raise ValueError("Unknown kind '%s'" % kind)
+
+    fig.tight_layout()
+    return ax
+
+
+__all__ = ["display_plot"]

--- a/python/tests/test_display_list_plot.py
+++ b/python/tests/test_display_list_plot.py
@@ -1,0 +1,34 @@
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.display import (
+    display_create,
+    display_list,
+    display_plot,
+)
+
+
+def _matplotlib_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def test_display_list_contains_default():
+    names = display_list()
+    assert "LCD-Apple" in names
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_display_plot_variants():
+    disp = display_create()
+    ax1 = display_plot(disp, kind="spd")
+    assert ax1 is not None
+    ax2 = display_plot(disp, kind="gamma")
+    assert ax2 is not None
+    ax3 = display_plot(disp, kind="gamut")
+    assert ax3 is not None


### PR DESCRIPTION
## Summary
- add helper to enumerate available displays
- compute simple Michelson contrast
- plot display SPDs, gamma curves and gamuts via matplotlib
- export new functions through public APIs
- test display_list and display_plot

## Testing
- `pytest -q python/tests/test_display_list_plot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a5d2c547c832384d82f27eee8a742