### PR TITLE
Use importlib resources for data access

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -2,6 +2,7 @@
 
 from .vc_constants import vc_constants
 from .iset_root_path import iset_root_path
+from .data_path import data_path
 from .vc_get_image_format import vc_get_image_format
 from .quanta2energy import quanta_to_energy
 from .energy_to_quanta import energy_to_quanta
@@ -183,6 +184,7 @@ __all__ = [
     'human_cone_contrast',
     'human_cone_isolating',
     'iset_root_path',
+    'data_path',
     'ie_init',
     'ie_init_session',
     'camera',

--- a/python/isetcam/cct.py
+++ b/python/isetcam/cct.py
@@ -6,18 +6,17 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
-from .iset_root_path import iset_root_path
+from .data_path import data_path
 
 
 def _load_cct_table() -> np.ndarray:
     """Load isotemperature line data."""
-    root = iset_root_path()
     # Prefer data in human subfolder if available
-    path = root / "data" / "human" / "cct.mat"
+    path = data_path("human/cct.mat")
     if not path.exists():
-        path = root / "color" / "cct.mat"
+        path = data_path("color/cct.mat")
         if not path.exists():
-            path = root / "data" / "lights" / "cct.mat"
+            path = data_path("lights/cct.mat")
     data = loadmat(path)
     return data["table"]
 

--- a/python/isetcam/cct_to_sun.py
+++ b/python/isetcam/cct_to_sun.py
@@ -8,7 +8,7 @@ from typing import Literal
 import numpy as np
 from scipy.io import loadmat
 
-from .iset_root_path import iset_root_path
+from .data_path import data_path
 from .energy_to_quanta import energy_to_quanta
 
 
@@ -17,8 +17,7 @@ _DEF_FILE = "cieDaylightBasis.mat"
 
 def _load_daylight_basis(wave: np.ndarray) -> np.ndarray:
     """Return daylight basis functions interpolated to ``wave``."""
-    root = iset_root_path()
-    mat = loadmat(root / "data" / "lights" / _DEF_FILE)
+    mat = loadmat(data_path(f"lights/{_DEF_FILE}"))
     src_wave = mat["wavelength"].ravel()
     data = mat["data"]
     if np.array_equal(wave, src_wave):

--- a/python/isetcam/chromaticity_plot.py
+++ b/python/isetcam/chromaticity_plot.py
@@ -51,7 +51,8 @@ def chromaticity_plot(
         fig = ax.figure
 
     # Load CIE XYZ color matching functions for wavelengths 370-730 nm
-    data = loadmat(Path(__file__).resolve().parents[2] / "data" / "human" / "XYZ.mat")
+    from .data_path import data_path
+    data = loadmat(data_path("human/XYZ.mat"))
     XYZ = data["data"]
     xy = chromaticity(XYZ)
 

--- a/python/isetcam/data/__init__.py
+++ b/python/isetcam/data/__init__.py
@@ -1,0 +1,1 @@
+"""Package containing ISETCam data files."""

--- a/python/isetcam/data_path.py
+++ b/python/isetcam/data_path.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+import importlib.resources as resources
+
+from .iset_root_path import iset_root_path
+
+
+def data_path(relative: str | Path) -> Path:
+    """Return absolute path to a data file.
+
+    The function first attempts to locate the file within the installed
+    ``isetcam.data`` package. If the file is not found there, it falls back
+    to the repository ``data`` directory, allowing the code to run from the
+    source tree.
+    """
+    rel = Path(relative)
+    try:
+        base = resources.files('isetcam.data')
+        candidate = Path(base / rel)
+        if candidate.exists():
+            return candidate
+    except ModuleNotFoundError:
+        pass
+    return iset_root_path() / 'data' / rel

--- a/python/isetcam/display/display_create.py
+++ b/python/isetcam/display/display_create.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
-from ..iset_root_path import iset_root_path
+from ..data_path import data_path
 
 from .display_class import Display
 
@@ -38,8 +38,7 @@ def display_create(name: str | None = None) -> Display:
     """
     if name is None:
         name = _DEFAULT_NAME
-    root = iset_root_path()
-    path = root / _DEF_DIR / "displays" / f"{name}.mat"
+    path = data_path(f"displays/{name}.mat")
     if not path.exists():
         raise FileNotFoundError(f"Unknown display '{name}'")
     wave, spd, gamma = _load_display(path)

--- a/python/isetcam/display/display_list.py
+++ b/python/isetcam/display/display_list.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ..iset_root_path import iset_root_path
+from ..data_path import data_path
 
 
 _DEF_DIR = "data"
@@ -17,8 +17,7 @@ def display_list() -> list[str]:
     ISETCam repository.  The returned list is sorted alphabetically and the
     ``.mat`` extension is stripped.
     """
-    root = iset_root_path()
-    disp_dir = root / _DEF_DIR / "displays"
+    disp_dir = data_path("displays")
     names: list[str] = []
     if disp_dir.exists():
         for f in disp_dir.glob("*.mat"):

--- a/python/isetcam/human/human_cone_contrast.py
+++ b/python/isetcam/human/human_cone_contrast.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 from ..ie_read_spectra import ie_read_spectra
-from ..iset_root_path import iset_root_path
+from ..data_path import data_path
 from ..quanta2energy import quanta_to_energy
 
 Units = "energy", "photons", "quanta"
@@ -46,8 +46,7 @@ def human_cone_contrast(
         spd_signal = quanta_to_energy(wave, spd_signal)
         spd_background = quanta_to_energy(wave, spd_background)
 
-    root = iset_root_path()
-    cone_file = root / "data" / "human" / "stockman.mat"
+    cone_file = data_path("human/stockman.mat")
     cones, _, _, _ = ie_read_spectra(cone_file, wave)
 
     back_cones = cones.T @ spd_background

--- a/python/isetcam/human/human_cone_isolating.py
+++ b/python/isetcam/human/human_cone_isolating.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ..display import Display
 from ..ie_read_spectra import ie_read_spectra
-from ..iset_root_path import iset_root_path
+from ..data_path import data_path
 
 
 def human_cone_isolating(display: Display) -> tuple[np.ndarray, np.ndarray]:
@@ -30,8 +30,7 @@ def human_cone_isolating(display: Display) -> tuple[np.ndarray, np.ndarray]:
     wave = np.asarray(display.wave, dtype=float)
     spd = np.asarray(display.spd, dtype=float)
 
-    root = iset_root_path()
-    cone_file = root / "data" / "human" / "stockman.mat"
+    cone_file = data_path("human/stockman.mat")
     cones, _, _, _ = ie_read_spectra(cone_file, wave)
 
     rgb2lms = (cones.T @ spd).T

--- a/python/isetcam/human/human_macular_transmittance.py
+++ b/python/isetcam/human/human_macular_transmittance.py
@@ -7,14 +7,13 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
-from ..iset_root_path import iset_root_path
+from ..data_path import data_path
 from ..opticalimage import OpticalImage
 
 
 def _macular_transmittance(density: float, wave: np.ndarray) -> np.ndarray:
     """Return macular pigment transmittance for ``wave``."""
-    root = iset_root_path()
-    mat = loadmat(root / 'data' / 'human' / 'macularPigment.mat')
+    mat = loadmat(data_path('human/macularPigment.mat'))
     src_wave = mat['wavelength'].ravel()
     data = mat['data'].ravel()
     unit = np.interp(wave, src_wave, data, left=0.0, right=0.0) / 0.3521

--- a/python/isetcam/ie_color_transform.py
+++ b/python/isetcam/ie_color_transform.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
-from .iset_root_path import iset_root_path
+from .data_path import data_path
 from .illuminant import illuminant_create
 
 
@@ -25,9 +25,8 @@ def _interp_data(src_wave: np.ndarray, data: np.ndarray, wave: np.ndarray) -> np
 
 
 def _load_surfaces(name: str, wave: np.ndarray) -> np.ndarray:
-    root = iset_root_path()
     if name.lower() in {"mcc", "macbeth"}:
-        path = root / "data" / "surfaces" / "reflectances" / "macbethChart.mat"
+        path = data_path("surfaces/reflectances/macbethChart.mat")
     else:
         raise ValueError("Unknown surface set: %s" % name)
     data = loadmat(path)
@@ -37,8 +36,7 @@ def _load_surfaces(name: str, wave: np.ndarray) -> np.ndarray:
 
 
 def _load_xyz(wave: np.ndarray) -> np.ndarray:
-    root = iset_root_path()
-    data = loadmat(root / "data" / "human" / "XYZ.mat")
+    data = loadmat(data_path("human/XYZ.mat"))
     src_wave = data["wavelength"].ravel()
     xyz = data["data"]
     return _interp_data(src_wave, xyz, wave)

--- a/python/isetcam/ie_spectra_sphere.py
+++ b/python/isetcam/ie_spectra_sphere.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy.io import loadmat
 
 from .ie_xyz_from_energy import ie_xyz_from_energy, _xyz_color_matching
-from .iset_root_path import iset_root_path
+from .data_path import data_path
 
 _DEF_FILE = "cieDaylightBasis.mat"
 
@@ -17,13 +17,11 @@ def _load_basis(wave: np.ndarray, basis: np.ndarray | str | Path | None) -> np.n
     """Return spectral basis functions interpolated to ``wave``."""
     wave = np.asarray(wave, dtype=float).reshape(-1)
     if basis is None:
-        root = iset_root_path()
-        path = root / "data" / "lights" / _DEF_FILE
+        path = data_path(f"lights/{_DEF_FILE}")
     elif isinstance(basis, (str, Path)):
         p = Path(basis)
         if not p.is_absolute():
-            root = iset_root_path()
-            p2 = root / "data" / "lights" / p
+            p2 = data_path(f"lights/{p}")
             if p2.exists():
                 p = p2
         path = p

--- a/python/isetcam/ie_xyz_from_energy.py
+++ b/python/isetcam/ie_xyz_from_energy.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
-from .iset_root_path import iset_root_path
+from .data_path import data_path
 
 from .vc_get_image_format import vc_get_image_format
 from .rgb_to_xw_format import rgb_to_xw_format
@@ -15,8 +15,7 @@ from .xw_to_rgb_format import xw_to_rgb_format
 
 def _xyz_color_matching(wave: np.ndarray) -> np.ndarray:
     """Interpolate the CIE XYZ color matching functions to ``wave``."""
-    root = iset_root_path()
-    data = loadmat(root / "data" / "human" / "XYZ.mat")
+    data = loadmat(data_path("human/XYZ.mat"))
     src_wave = data["wavelength"].ravel()
     xyz = data["data"]
     cmf = np.zeros((len(wave), 3))

--- a/python/isetcam/illuminant/illuminant_create.py
+++ b/python/isetcam/illuminant/illuminant_create.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
-from ..iset_root_path import iset_root_path
+from ..data_path import data_path
 
 from .illuminant_class import Illuminant
 
@@ -24,9 +24,8 @@ def _load_spd(path: Path) -> tuple[np.ndarray, np.ndarray]:
 
 def illuminant_create(name: str, wave: np.ndarray | None = None) -> Illuminant:
     """Create an illuminant by name, optionally interpolated to ``wave``."""
-    root = iset_root_path()
     fname = name.strip().upper() + '.mat'
-    path = root / _DEF_DIR / 'lights' / fname
+    path = data_path(f'lights/{fname}')
     if not path.exists():
         raise FileNotFoundError(f"Unknown illuminant '{name}'")
     src_wave, spd = _load_spd(path)

--- a/python/isetcam/luminance_from_energy.py
+++ b/python/isetcam/luminance_from_energy.py
@@ -9,16 +9,14 @@ import numpy as np
 from scipy.io import loadmat
 
 from .vc_get_image_format import vc_get_image_format
-from .iset_root_path import iset_root_path
+from .data_path import data_path
 
 _DEF_BINWIDTH = 10
 
 
 def _photopic_luminosity(wave: np.ndarray) -> np.ndarray:
     """Return the photopic luminosity function interpolated to ``wave``."""
-    root = iset_root_path()
-    fpath = root / 'data' / 'human' / 'luminosity.mat'
-    data = loadmat(fpath)
+    data = loadmat(data_path('human/luminosity.mat'))
     src_wave = data['wavelength'].ravel()
     V = data['data'].ravel()
     return np.interp(wave, src_wave, V, left=0.0, right=0.0)

--- a/python/isetcam/scene/scene_create.py
+++ b/python/isetcam/scene/scene_create.py
@@ -10,7 +10,7 @@ from scipy.io import loadmat
 
 from .scene_class import Scene
 from ..luminance_from_photons import luminance_from_photons
-from ..iset_root_path import iset_root_path
+from ..data_path import data_path
 
 
 _DEF_DIR = "data"
@@ -18,8 +18,7 @@ _DEF_DIR = "data"
 
 def _load_macbeth_data(wave: Optional[np.ndarray]) -> tuple[np.ndarray, np.ndarray]:
     """Return reflectance data and wavelength array for the Macbeth chart."""
-    root = iset_root_path()
-    mat = loadmat(root / _DEF_DIR / "surfaces" / "reflectances" / "macbethChart.mat")
+    mat = loadmat(data_path("surfaces/reflectances/macbethChart.mat"))
     src_wave = mat["wavelength"].ravel().astype(float)
     refl = mat["data"].astype(float)
     if wave is None:
@@ -33,8 +32,7 @@ def _load_macbeth_data(wave: Optional[np.ndarray]) -> tuple[np.ndarray, np.ndarr
 
 def _load_d65(wave: np.ndarray) -> np.ndarray:
     """Return D65 spectral power distribution sampled at ``wave``."""
-    root = iset_root_path()
-    mat = loadmat(root / _DEF_DIR / "lights" / "D65.mat")
+    mat = loadmat(data_path("lights/D65.mat"))
     src_wave = mat["wavelength"].ravel().astype(float)
     spd = mat["data"].ravel().astype(float)
     return np.interp(wave, src_wave, spd, left=0.0, right=0.0)

--- a/python/isetcam/scotopic_luminance_from_energy.py
+++ b/python/isetcam/scotopic_luminance_from_energy.py
@@ -9,16 +9,14 @@ import numpy as np
 from scipy.io import loadmat
 
 from .vc_get_image_format import vc_get_image_format
-from .iset_root_path import iset_root_path
+from .data_path import data_path
 
 _DEF_BINWIDTH = 10
 
 
 def _scotopic_luminosity(wave: np.ndarray) -> np.ndarray:
     """Return the scotopic luminosity function interpolated to ``wave``."""
-    root = iset_root_path()
-    fpath = root / 'data' / 'human' / 'rods.mat'
-    data = loadmat(fpath)
+    data = loadmat(data_path('human/rods.mat'))
     src_wave = data['wavelength'].ravel()
     Vprime = data['data'].ravel()
     return np.interp(wave, src_wave, Vprime, left=0.0, right=0.0)

--- a/python/isetcam/srgb_to_cct.py
+++ b/python/isetcam/srgb_to_cct.py
@@ -8,7 +8,7 @@ from scipy.io import loadmat
 from .srgb_xyz import srgb_to_xyz
 from .rgb_to_xw_format import rgb_to_xw_format
 from .chromaticity import chromaticity
-from .iset_root_path import iset_root_path
+from .data_path import data_path
 from .illuminant import illuminant_blackbody
 
 __all__ = ["srgb_to_cct"]
@@ -18,8 +18,7 @@ def _default_table() -> np.ndarray:
     """Return lookup table of xy chromaticities for sample color temperatures."""
     wave = np.arange(400, 701, 10)
     ctemps = np.arange(2500, 10501, 500)
-    root = iset_root_path()
-    data = loadmat(root / "data" / "human" / "XYZEnergy.mat")
+    data = loadmat(data_path("human/XYZEnergy.mat"))
     src_wave = data["wavelength"].ravel()
     XYZ = np.zeros((len(wave), 3))
     for i in range(3):

--- a/python/isetcam/xyz_to_lms.py
+++ b/python/isetcam/xyz_to_lms.py
@@ -14,7 +14,7 @@ from scipy.io import loadmat
 
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
-from .iset_root_path import iset_root_path
+from .data_path import data_path
 
 # XYZ to LMS conversion matrix (Stockman fundamentals)
 _XYZ2LMS = np.array([
@@ -24,7 +24,7 @@ _XYZ2LMS = np.array([
 ])
 
 
-_def_stockman_path = iset_root_path() / "data" / "human" / "stockman.mat"
+_def_stockman_path = data_path("human/stockman.mat")
 
 
 def _stockman_values(wavelengths: list[float]) -> np.ndarray:

--- a/python/tests/test_cct_to_sun.py
+++ b/python/tests/test_cct_to_sun.py
@@ -2,15 +2,14 @@ import numpy as np
 from pathlib import Path
 from scipy.io import loadmat
 
-from isetcam import cct_to_sun, energy_to_quanta, iset_root_path
+from isetcam import cct_to_sun, energy_to_quanta, data_path
 
 
 def test_cct_to_sun_matches_d65():
     wave = np.arange(380, 781, 5)
     spd = cct_to_sun(wave, 6500)
 
-    root = iset_root_path()
-    d65 = loadmat(root / "data" / "lights" / "D65.mat")
+    d65 = loadmat(data_path("lights/D65.mat"))
     d_wave = d65["wavelength"].ravel()
     d_spd = d65["data"].ravel()
     ref = np.interp(wave, d_wave, d_spd)

--- a/python/tests/test_color_transform_matrix_create.py
+++ b/python/tests/test_color_transform_matrix_create.py
@@ -2,7 +2,7 @@ import numpy as np
 from isetcam import (
     color_transform_matrix_create,
     color_transform_matrix,
-    iset_root_path,
+    data_path,
 )
 
 
@@ -15,9 +15,8 @@ def test_color_transform_matrix_create_arrays():
 
 
 def test_color_transform_matrix_create_files():
-    root = iset_root_path()
-    xyz_file = root / "data" / "human" / "XYZ.mat"
-    stock_file = root / "data" / "human" / "stockman.mat"
+    xyz_file = data_path("human/XYZ.mat")
+    stock_file = data_path("human/stockman.mat")
     wave = np.arange(400, 701, 5)
     T = color_transform_matrix_create(xyz_file, stock_file, wave)
     expected = color_transform_matrix("xyz2sto")

--- a/python/tests/test_daylight.py
+++ b/python/tests/test_daylight.py
@@ -1,12 +1,11 @@
 import numpy as np
 from scipy.io import loadmat
 
-from isetcam import daylight, energy_to_quanta, luminance_from_energy, iset_root_path
+from isetcam import daylight, energy_to_quanta, luminance_from_energy, data_path
 
 
 def _expected_d65(wave: np.ndarray) -> np.ndarray:
-    root = iset_root_path()
-    mat = loadmat(root / "data" / "lights" / "D65.mat")
+    mat = loadmat(data_path("lights/D65.mat"))
     d_wave = mat["wavelength"].ravel()
     d_spd = np.interp(wave, d_wave, mat["data"].ravel())
     lum = luminance_from_energy(d_spd[np.newaxis, :], wave)[0]

--- a/python/tests/test_human_macular.py
+++ b/python/tests/test_human_macular.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy.io import loadmat
 
-from isetcam import iset_root_path
+from isetcam import data_path
 from isetcam.opticalimage import OpticalImage
 from isetcam.human import human_macular_transmittance
 
@@ -13,8 +13,7 @@ def test_human_macular_transmittance_basic():
 
     out = human_macular_transmittance(oi, density=0.35)
 
-    root = iset_root_path()
-    mat = loadmat(root / 'data' / 'human' / 'macularPigment.mat')
+    mat = loadmat(data_path('human/macularPigment.mat'))
     src_wave = mat['wavelength'].ravel()
     data = mat['data'].ravel()
     unit = np.interp(wave, src_wave, data, left=0.0, right=0.0) / 0.3521

--- a/python/tests/test_ie_color_transform.py
+++ b/python/tests/test_ie_color_transform.py
@@ -2,7 +2,7 @@ import numpy as np
 from pathlib import Path
 from scipy.io import loadmat
 
-from isetcam import ie_color_transform, iset_root_path
+from isetcam import ie_color_transform, data_path
 from isetcam.illuminant import illuminant_create
 
 
@@ -27,10 +27,9 @@ def test_ie_color_transform_xyz():
     T = ie_color_transform(sensor_qe, wave, "XYZ", illum)
     assert T.shape == (3, 3)
 
-    root = iset_root_path()
-    sur = loadmat(root / "data" / "surfaces" / "reflectances" / "macbethChart.mat")
+    sur = loadmat(data_path("surfaces/reflectances/macbethChart.mat"))
     sur_ref = _interp(sur["wavelength"].ravel(), sur["data"], wave)
-    cmf = loadmat(root / "data" / "human" / "XYZ.mat")
+    cmf = loadmat(data_path("human/XYZ.mat"))
     xyz = _interp(cmf["wavelength"].ravel(), cmf["data"], wave)
     sensor_resp = (sensor_qe.T @ (illum[:, None] * sur_ref)).T
     target_resp = (xyz.T @ (illum[:, None] * sur_ref)).T

--- a/python/tests/test_ie_read_spectra.py
+++ b/python/tests/test_ie_read_spectra.py
@@ -1,12 +1,11 @@
 import numpy as np
 from scipy.io import loadmat
 
-from isetcam import ie_read_spectra, iset_root_path
+from isetcam import ie_read_spectra, data_path
 
 
 def test_ie_read_spectra_interpolation():
-    root = iset_root_path()
-    path = root / "data" / "lights" / "D65.mat"
+    path = data_path("lights/D65.mat")
     mat = loadmat(path)
     wave = np.arange(400, 701, 10)
     data = np.interp(wave, mat["wavelength"].ravel(), mat["data"].ravel()).reshape(-1, 1)
@@ -20,8 +19,7 @@ def test_ie_read_spectra_interpolation():
 
 
 def test_ie_read_spectra_extrapolation():
-    root = iset_root_path()
-    path = root / "data" / "lights" / "D65.mat"
+    path = data_path("lights/D65.mat")
     mat = loadmat(path)
     wave = np.array([295, 300, 320, 835])
     expected = np.interp(

--- a/python/tests/test_luminance.py
+++ b/python/tests/test_luminance.py
@@ -2,7 +2,7 @@ import numpy as np
 from pathlib import Path
 from scipy.io import loadmat
 
-from isetcam import iset_root_path
+from isetcam import data_path
 
 from isetcam import (
     luminance_from_energy,
@@ -12,8 +12,7 @@ from isetcam import (
 
 
 def _expected_luminance(wave, energy):
-    root = iset_root_path()
-    mat = loadmat(root / 'data' / 'human' / 'luminosity.mat')
+    mat = loadmat(data_path('human/luminosity.mat'))
     V = np.interp(wave, mat['wavelength'].ravel(), mat['data'].ravel(), left=0.0, right=0.0)
     binwidth = wave[1] - wave[0] if len(wave) > 1 else 10
     xw = energy.reshape(-1, len(wave))

--- a/python/tests/test_oi_calculate.py
+++ b/python/tests/test_oi_calculate.py
@@ -6,7 +6,7 @@ from isetcam.opticalimage import (
     oi_calculate_irradiance,
     oi_calculate_illuminance,
 )
-from isetcam import quanta_to_energy, iset_root_path
+from isetcam import quanta_to_energy, data_path
 
 
 def _expected_irradiance(wave, photons):
@@ -16,8 +16,7 @@ def _expected_irradiance(wave, photons):
 
 def _expected_illuminance(wave, photons):
     energy = quanta_to_energy(wave, photons)
-    root = iset_root_path()
-    mat = loadmat(root / "data" / "human" / "luminosity.mat")
+    mat = loadmat(data_path("human/luminosity.mat"))
     V = np.interp(wave, mat["wavelength"].ravel(), mat["data"].ravel(), left=0.0, right=0.0)
     bw = wave[1] - wave[0] if len(wave) > 1 else 10
     xw = energy.reshape(-1, len(wave))

--- a/python/tests/test_scene_adjust_illuminant.py
+++ b/python/tests/test_scene_adjust_illuminant.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from isetcam.scene import Scene, scene_adjust_illuminant
 from isetcam.luminance_from_photons import luminance_from_photons
-from isetcam import iset_root_path
+from isetcam import data_path
 
 
 def _simple_scene() -> Scene:
@@ -24,8 +24,7 @@ def test_scene_adjust_illuminant_vector():
 
 def test_scene_adjust_illuminant_matfile():
     sc = _simple_scene()
-    root = iset_root_path()
-    path = root / "data" / "lights" / "D65.mat"
+    path = data_path("lights/D65.mat")
     out = scene_adjust_illuminant(sc, path)
     lum_before = luminance_from_photons(sc.photons, sc.wave).mean()
     lum_after = luminance_from_photons(out.photons, out.wave).mean()

--- a/python/tests/test_scene_from_file.py
+++ b/python/tests/test_scene_from_file.py
@@ -2,12 +2,11 @@ import numpy as np
 from pathlib import Path
 
 from isetcam.scene import scene_from_file, Scene
-from isetcam import luminance_from_energy, iset_root_path
+from isetcam import luminance_from_energy, data_path
 
 
 def test_scene_from_file_rgb():
-    root = iset_root_path()
-    fpath = root / 'data' / 'images' / 'rgb' / 'adelson.png'
+    fpath = data_path('images/rgb/adelson.png')
     wave = np.array([450, 550, 650, 750])
     sc = scene_from_file(fpath, wave=wave)
     assert isinstance(sc, Scene)
@@ -17,8 +16,7 @@ def test_scene_from_file_rgb():
 
 
 def test_scene_from_file_mean_luminance():
-    root = iset_root_path()
-    fpath = root / 'data' / 'images' / 'rgb' / 'adelson.png'
+    fpath = data_path('images/rgb/adelson.png')
     wave = np.array([450, 550, 650, 750])
     target = 10.0
     sc = scene_from_file(fpath, mean_luminance=target, wave=wave)
@@ -27,8 +25,7 @@ def test_scene_from_file_mean_luminance():
 
 
 def test_scene_from_file_gray():
-    root = iset_root_path()
-    fpath = root / 'data' / 'images' / 'targets' / 'usaf1951' / 'USAF1951-72dpi.jpg'
+    fpath = data_path('images/targets/usaf1951/USAF1951-72dpi.jpg')
     wave = np.array([550])
     sc = scene_from_file(fpath, wave=wave)
     assert sc.photons.ndim == 3 and sc.photons.shape[2] == 1

--- a/python/tests/test_scene_to_file.py
+++ b/python/tests/test_scene_to_file.py
@@ -2,12 +2,11 @@ import numpy as np
 import scipy.io
 
 from isetcam.scene import scene_from_file, scene_to_file
-from isetcam import iset_root_path
+from isetcam import data_path
 
 
 def test_scene_to_file_roundtrip(tmp_path):
-    root = iset_root_path()
-    fpath = root / 'data' / 'images' / 'rgb' / 'adelson.png'
+    fpath = data_path('images/rgb/adelson.png')
     wave = np.array([450, 550, 650, 750])
     scene = scene_from_file(fpath, wave=wave)
 

--- a/python/tests/test_scotopic_luminance.py
+++ b/python/tests/test_scotopic_luminance.py
@@ -2,14 +2,13 @@ import numpy as np
 from pathlib import Path
 from scipy.io import loadmat
 
-from isetcam import iset_root_path
+from isetcam import data_path
 
 from isetcam import scotopic_luminance_from_energy
 
 
 def _expected_scotopic_luminance(wave, energy):
-    root = iset_root_path()
-    mat = loadmat(root / 'data' / 'human' / 'rods.mat')
+    mat = loadmat(data_path('human/rods.mat'))
     Vp = np.interp(wave, mat['wavelength'].ravel(), mat['data'].ravel(), left=0.0, right=0.0)
     binwidth = wave[1] - wave[0] if len(wave) > 1 else 10
     xw = energy.reshape(-1, len(wave))

--- a/python/tests/test_xyz_chromaticity.py
+++ b/python/tests/test_xyz_chromaticity.py
@@ -2,7 +2,7 @@ import numpy as np
 from pathlib import Path
 from scipy.io import loadmat
 
-from isetcam import iset_root_path
+from isetcam import data_path
 
 from isetcam import (
     energy_to_quanta,
@@ -14,8 +14,7 @@ from isetcam import (
 
 
 def _expected_xyz(wave: np.ndarray, energy: np.ndarray) -> np.ndarray:
-    root = iset_root_path()
-    mat = loadmat(root / 'data' / 'human' / 'XYZ.mat')
+    mat = loadmat(data_path('human/XYZ.mat'))
     src_wave = mat['wavelength'].ravel()
     data = mat['data']
     cmf = np.vstack([


### PR DESCRIPTION
## Summary
- add helper `data_path` using `importlib.resources`
- use `data_path` in spectral and illuminant utilities
- adjust display and scene creation modules
- update unit tests for new helper

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a683554cc8323a7a66dced4137afb