### PR TITLE
Add illuminant_get/set utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -102,7 +102,12 @@ from .display import (
 )
 from .camera import camera_to_file, camera_from_file
 from .optics import optics_to_file, optics_from_file
-from .illuminant import illuminant_to_file, illuminant_from_file
+from .illuminant import (
+    illuminant_to_file,
+    illuminant_from_file,
+    illuminant_get,
+    illuminant_set,
+)
 from .io import openexr_read, openexr_write, pfm_read, pfm_write
 
 __all__ = [
@@ -206,6 +211,8 @@ __all__ = [
     'display_plot',
     'illuminant_to_file',
     'illuminant_from_file',
+    'illuminant_get',
+    'illuminant_set',
     'camera_to_file',
     'camera_from_file',
     'optics_to_file',

--- a/python/isetcam/illuminant/__init__.py
+++ b/python/isetcam/illuminant/__init__.py
@@ -5,6 +5,8 @@ from .illuminant_blackbody import illuminant_blackbody
 from .illuminant_create import illuminant_create
 from .illuminant_from_file import illuminant_from_file
 from .illuminant_to_file import illuminant_to_file
+from .illuminant_get import illuminant_get
+from .illuminant_set import illuminant_set
 
 __all__ = [
     "Illuminant",
@@ -12,4 +14,6 @@ __all__ = [
     "illuminant_create",
     "illuminant_from_file",
     "illuminant_to_file",
+    "illuminant_get",
+    "illuminant_set",
 ]

--- a/python/isetcam/illuminant/illuminant_get.py
+++ b/python/isetcam/illuminant/illuminant_get.py
@@ -1,0 +1,27 @@
+"""Retrieve parameters from :class:`Illuminant` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .illuminant_class import Illuminant
+from ..ie_param_format import ie_param_format
+
+
+def illuminant_get(illuminant: Illuminant, param: str) -> Any:
+    """Return a parameter value from ``illuminant``.
+
+    Supported parameters are ``spd``, ``wave``, ``n_wave``/``nwave`` and ``name``.
+    """
+    key = ie_param_format(param)
+    if key == "spd":
+        return illuminant.spd
+    if key == "wave":
+        return illuminant.wave
+    if key in {"nwave", "n_wave"}:
+        return len(illuminant.wave)
+    if key == "name":
+        return getattr(illuminant, "name", None)
+    raise KeyError(f"Unknown illuminant parameter '{param}'")

--- a/python/isetcam/illuminant/illuminant_set.py
+++ b/python/isetcam/illuminant/illuminant_set.py
@@ -1,0 +1,29 @@
+"""Assign parameters on :class:`Illuminant` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .illuminant_class import Illuminant
+from ..ie_param_format import ie_param_format
+
+
+def illuminant_set(illuminant: Illuminant, param: str, val: Any) -> None:
+    """Set a parameter value on ``illuminant``.
+
+    Supported parameters are ``spd``, ``wave`` and ``name``. ``n_wave`` is
+    derived from ``wave`` and therefore cannot be set.
+    """
+    key = ie_param_format(param)
+    if key == "spd":
+        illuminant.spd = np.asarray(val)
+        return
+    if key == "wave":
+        illuminant.wave = np.asarray(val)
+        return
+    if key == "name":
+        illuminant.name = None if val is None else str(val)
+        return
+    raise KeyError(f"Unknown or read-only illuminant parameter '{param}'")

--- a/python/tests/test_illuminant_get_set.py
+++ b/python/tests/test_illuminant_get_set.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from isetcam.illuminant import Illuminant, illuminant_get, illuminant_set
+
+
+def test_illuminant_get_set():
+    wave = np.array([500, 510])
+    spd = np.ones(2)
+    illum = Illuminant(spd=spd.copy(), wave=wave, name="orig")
+
+    assert np.allclose(illuminant_get(illum, " sPd"), spd)
+    assert np.array_equal(illuminant_get(illum, "WAVE"), wave)
+    assert illuminant_get(illum, "N WAVE") == 2
+    assert illuminant_get(illum, " NAME ") == "orig"
+
+    new_spd = np.zeros_like(spd)
+    illuminant_set(illum, " Spd ", new_spd)
+    assert np.allclose(illuminant_get(illum, "SPD"), new_spd)
+
+    new_wave = np.array([400, 500, 600])
+    illuminant_set(illum, "wave", new_wave)
+    assert np.array_equal(illuminant_get(illum, "wave"), new_wave)
+    assert illuminant_get(illum, "n_wave") == len(new_wave)
+
+    illuminant_set(illum, "NAME", "new")
+    assert illuminant_get(illum, "name") == "new"


### PR DESCRIPTION
## Summary
- implement `illuminant_get`/`illuminant_set`
- expose new illuminant utilities through package __init__
- test retrieving and assigning illuminant fields

## Testing
- `PYTHONPATH=$PWD/python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a74b733048323888168ab065a55c2