### PR TITLE
Add display_compute and display_convert utilities

### DIFF
--- a/python/isetcam/display/__init__.py
+++ b/python/isetcam/display/__init__.py
@@ -11,6 +11,8 @@ from .display_get import display_get
 from .display_set import display_set
 from .display_apply_gamma import display_apply_gamma
 from .display_render import display_render
+from .display_compute import display_compute
+from .display_convert import display_convert
 from .display_show_image import display_show_image
 from .display_from_file import display_from_file
 from .display_to_file import display_to_file
@@ -25,6 +27,8 @@ __all__ = [
     "display_set",
     "display_apply_gamma",
     "display_render",
+    "display_compute",
+    "display_convert",
     "display_show_image",
     "display_from_file",
     "display_to_file",

--- a/python/isetcam/display/display_compute.py
+++ b/python/isetcam/display/display_compute.py
@@ -1,0 +1,60 @@
+"""Compute spectral radiance for an RGB image using a ``Display``."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .display_class import Display
+from .display_apply_gamma import display_apply_gamma
+from ..rgb_to_xw_format import rgb_to_xw_format
+from ..xw_to_rgb_format import xw_to_rgb_format
+
+
+def display_compute(image: np.ndarray, display: Display, apply_gamma: bool = True) -> np.ndarray:
+    """Return spectral radiance for ``image`` on ``display``.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        Digital RGB image values in ``(R, C, 3)`` or ``(N, 3)`` format.
+    display : Display
+        Display providing spectral primaries and optional gamma table.
+    apply_gamma : bool, optional
+        When ``True`` apply ``display``'s gamma table to ``image`` before
+        computing the spectral radiance.
+
+    Returns
+    -------
+    np.ndarray
+        Spectral radiance image with one band per display wavelength. The
+        output has the same spatial organisation as ``image``.
+    """
+    img = np.asarray(image, dtype=float)
+
+    if img.ndim == 3:
+        reshape = True
+        xw, rows, cols = rgb_to_xw_format(img)
+    elif img.ndim == 2 and img.shape[1] == 3:
+        reshape = False
+        xw = img
+    else:
+        raise ValueError("image must be (rows, cols, 3) or (n, 3)")
+
+    if apply_gamma and display.gamma is not None:
+        xw = display_apply_gamma(xw, display)
+
+    spd = np.asarray(display.spd, dtype=float)
+    if spd.shape[1] != 3:
+        raise ValueError("display.spd must have shape (n_wave, 3)")
+
+    out_xw = xw @ spd.T
+
+    if reshape:
+        out = xw_to_rgb_format(out_xw, rows, cols)
+    else:
+        out = out_xw
+
+    return out
+
+
+__all__ = ["display_compute"]

--- a/python/isetcam/display/display_convert.py
+++ b/python/isetcam/display/display_convert.py
@@ -1,0 +1,63 @@
+"""Convert a ctToolbox display definition to a :class:`Display`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import numpy as np
+
+from .display_class import Display
+from .display_to_file import display_to_file
+
+
+def _parse_ct_dict(ct_disp: Mapping) -> tuple[np.ndarray, np.ndarray, np.ndarray, str | None]:
+    """Extract wave, spd, gamma and name from a toolbox dictionary."""
+    name = ct_disp.get("m_strDisplayName")
+    phys = ct_disp.get("sPhysicalDisplay", {})
+    dixel = phys.get("m_objCDixelStructure", {})
+
+    wave = np.asarray(dixel.get("m_aWaveLengthSamples"), dtype=float).ravel()
+    spd = np.asarray(dixel.get("m_aSpectrumOfPrimaries"), dtype=float)
+    if spd.ndim == 2 and spd.shape[0] != wave.size:
+        spd = spd.T
+
+    gamma_list = dixel.get("m_cellGammaStructure", [])
+    if isinstance(gamma_list, Mapping):
+        gamma_list = [gamma_list]
+    gamma = np.column_stack([np.asarray(g["vGammaRampLUT"], dtype=float).ravel() for g in gamma_list]) if gamma_list else None
+
+    return wave, spd, gamma, name
+
+
+def display_convert(
+    ct_disp: Mapping,
+    wave: Sequence[float] | None = None,
+    out_file: str | Path | None = None,
+    overwrite: bool = False,
+    name: str | None = None,
+) -> Display:
+    """Convert ``ct_disp`` to a :class:`Display` instance."""
+
+    cwave, cspd, cgamma, cname = _parse_ct_dict(ct_disp)
+
+    if wave is not None:
+        wave = np.asarray(wave, dtype=float).ravel()
+        cspd = np.array([np.interp(wave, cwave, cspd[:, i]) for i in range(cspd.shape[1])]).T
+        cwave = wave
+
+    if name is not None:
+        cname = name
+
+    disp = Display(spd=cspd, wave=cwave, gamma=cgamma, name=cname)
+
+    if out_file is not None:
+        path = Path(out_file)
+        if path.exists() and not overwrite:
+            raise FileExistsError(path)
+        display_to_file(disp, path)
+
+    return disp
+
+
+__all__ = ["display_convert"]

--- a/python/tests/test_display_compute_convert.py
+++ b/python/tests/test_display_compute_convert.py
@@ -1,0 +1,80 @@
+import numpy as np
+
+from isetcam.display import (
+    Display,
+    display_apply_gamma,
+    display_compute,
+    display_convert,
+    display_from_file,
+)
+from isetcam.rgb_to_xw_format import rgb_to_xw_format
+from isetcam.xw_to_rgb_format import xw_to_rgb_format
+
+
+def _make_display(n_levels: int = 8) -> Display:
+    wave = np.array([500, 510, 520])
+    spd = np.eye(3)
+    gamma = np.linspace(0, 1, n_levels).reshape(n_levels, 1).repeat(3, axis=1)
+    return Display(spd=spd, wave=wave, gamma=gamma)
+
+
+def test_display_compute_matches_manual():
+    disp = _make_display()
+    img = np.random.rand(4, 5, 3)
+
+    lin = display_apply_gamma(img, disp)
+    xw, r, c = rgb_to_xw_format(lin)
+    expected = xw @ disp.spd.T
+    expected = xw_to_rgb_format(expected, r, c)
+
+    out = display_compute(img, disp, apply_gamma=True)
+    assert np.allclose(out, expected)
+
+
+def test_display_convert_dict_roundtrip(tmp_path):
+    wave = np.array([500, 510])
+    spd = np.array([
+        [0.1, 0.2],
+        [0.3, 0.4],
+        [0.5, 0.6],
+    ])  # primaries x wave
+    gamma = np.linspace(0, 1, 4).reshape(4, 1).repeat(3, axis=1)
+    ct_disp = {
+        "m_strDisplayName": "demo",
+        "sPhysicalDisplay": {
+            "m_objCDixelStructure": {
+                "m_aWaveLengthSamples": wave,
+                "m_aSpectrumOfPrimaries": spd,
+                "m_cellGammaStructure": [
+                    {"vGammaRampLUT": gamma[:, i]} for i in range(3)
+                ],
+            },
+            "m_fVerticalRefreshRate": 60,
+        },
+        "sViewingContext": {"m_fViewingDistance": 0.6},
+    }
+
+    new_wave = np.array([500, 505, 510])
+    out_file = tmp_path / "d.mat"
+    disp = display_convert(
+        ct_disp,
+        wave=new_wave,
+        out_file=out_file,
+        overwrite=True,
+        name="new",
+    )
+
+    expected_spd = np.array(
+        [np.interp(new_wave, wave, spd[i]) for i in range(spd.shape[0])]
+    ).T
+
+    assert isinstance(disp, Display)
+    assert disp.name == "new"
+    assert np.array_equal(disp.wave, new_wave)
+    assert np.allclose(disp.spd, expected_spd)
+    assert disp.gamma is not None and np.allclose(disp.gamma, gamma)
+
+    loaded = display_from_file(out_file)
+    assert np.allclose(loaded.spd, disp.spd)
+    assert np.array_equal(loaded.wave, disp.wave)
+    assert loaded.gamma is not None and np.allclose(loaded.gamma, disp.gamma)


### PR DESCRIPTION
## Summary
- implement `display_compute` for spectral rendering using Display dataclass
- implement `display_convert` to convert ctToolbox dictionaries
- export new helpers
- add tests for compute and convert functions

## Testing
- `PYTHONPATH=python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a76958eac8323ae4a1c1fbbe88605