### PR TITLE
Add scene depth utilities

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -30,6 +30,8 @@ from .scene_save_image import scene_save_image
 from .scene_thumbnail import scene_thumbnail
 from .scene_illuminant_pattern import scene_illuminant_pattern
 from .scene_illuminant_ss import scene_illuminant_ss
+from .scene_depth_overlay import scene_depth_overlay
+from .scene_depth_range import scene_depth_range
 
 __all__ = [
     "Scene",
@@ -64,4 +66,6 @@ __all__ = [
     "scene_thumbnail",
     "scene_illuminant_pattern",
     "scene_illuminant_ss",
+    "scene_depth_overlay",
+    "scene_depth_range",
 ]

--- a/python/isetcam/scene/scene_depth_overlay.py
+++ b/python/isetcam/scene/scene_depth_overlay.py
@@ -1,0 +1,55 @@
+"""Overlay depth map contours on a Scene RGB image."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - matplotlib might not be installed
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+from .scene_class import Scene
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def scene_depth_overlay(scene: Scene, n: int = 10):
+    """Display the scene RGB image with depth map contours overlaid.
+
+    Parameters
+    ----------
+    scene : Scene
+        Scene containing a ``depth_map`` attribute.
+    n : int, optional
+        Number of contour levels. Default is 10.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        Axis containing the displayed image and contour overlay.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for scene_depth_overlay")
+
+    dmap = getattr(scene, "depth_map", None)
+    if dmap is None:
+        raise AttributeError("scene must have a depth_map attribute")
+    dmap = np.asarray(dmap)
+    if dmap.ndim != 2:
+        raise ValueError("scene.depth_map must be a 2-D array")
+
+    xyz = ie_xyz_from_photons(scene.photons, scene.wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    img = np.clip(srgb, 0.0, 1.0)
+
+    fig, ax = plt.subplots()
+    ax.imshow(img)
+    levels = np.linspace(dmap.min(), dmap.max(), n)
+    ax.contour(dmap, levels=levels, colors="k", linewidths=1)
+    ax.axis("off")
+    fig.tight_layout()
+    return ax
+
+
+__all__ = ["scene_depth_overlay"]

--- a/python/isetcam/scene/scene_depth_range.py
+++ b/python/isetcam/scene/scene_depth_range.py
@@ -1,0 +1,53 @@
+"""Restrict a scene to a particular depth range."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def scene_depth_range(scene: Scene, depth_edges: Sequence[float]) -> tuple[Scene, np.ndarray]:
+    """Mask photons outside ``depth_edges`` and return the depth-plane mask.
+
+    Parameters
+    ----------
+    scene : Scene
+        Scene containing a ``depth_map`` attribute.
+    depth_edges : sequence of float
+        ``(low, high)`` bounds of the desired depth range in meters.
+
+    Returns
+    -------
+    (Scene, ndarray)
+        Tuple of the new scene with masked photons and the boolean mask of
+        pixels within the depth range.
+    """
+    dmap = getattr(scene, "depth_map", None)
+    if dmap is None:
+        raise AttributeError("scene must have a depth_map attribute")
+
+    if len(depth_edges) != 2:
+        raise ValueError("depth_edges must contain two values")
+    low, high = float(depth_edges[0]), float(depth_edges[1])
+
+    dmap = np.asarray(dmap)
+    if dmap.ndim != 2:
+        raise ValueError("scene.depth_map must be a 2-D array")
+
+    d_plane = (low <= dmap) & (dmap < high)
+
+    photons = np.asarray(scene.photons, dtype=float).copy()
+    for i in range(photons.shape[2]):
+        band = photons[:, :, i]
+        band[~d_plane] = 0
+        photons[:, :, i] = band
+
+    out = Scene(photons=photons, wave=scene.wave, name=scene.name)
+    out.depth_map = dmap * d_plane
+    return out, d_plane
+
+
+__all__ = ["scene_depth_range"]

--- a/python/tests/test_scene_depth_utils.py
+++ b/python/tests/test_scene_depth_utils.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.scene import Scene, scene_depth_overlay, scene_depth_range
+
+
+def _matplotlib_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([500, 600, 700])
+    photons = np.ones((2, 2, 3))
+    sc = Scene(photons=photons, wave=wave)
+    sc.depth_map = np.array([[0.4, 0.5], [0.6, 0.7]])
+    return sc
+
+
+def test_scene_depth_range_masking():
+    sc = _simple_scene()
+    out, mask = scene_depth_range(sc, (0.45, 0.65))
+    expected_mask = np.array([[False, True], [True, False]])
+    assert np.array_equal(mask, expected_mask)
+    expected_photons = np.ones_like(sc.photons)
+    for i in range(expected_photons.shape[2]):
+        expected_photons[:, :, i] = expected_mask
+    assert np.array_equal(out.photons, expected_photons)
+    assert np.array_equal(out.depth_map, sc.depth_map * expected_mask)
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_scene_depth_overlay_runs():
+    sc = _simple_scene()
+    ax = scene_depth_overlay(sc, n=3)
+    assert ax is not None


### PR DESCRIPTION
## Summary
- add `scene_depth_overlay` to visualize depth maps
- add `scene_depth_range` to mask a scene by depth
- expose the new utilities from `scene` package
- test the depth utilities

## Testing
- `PYTHONPATH=$PWD/python pytest -q python/tests/test_scene_depth_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_683a78c5f7c48323b7884315cd41e39a