### PR TITLE
Add metrics_compute utility

### DIFF
--- a/python/isetcam/metrics/__init__.py
+++ b/python/isetcam/metrics/__init__.py
@@ -10,6 +10,7 @@ from .xyz_to_vsnr import xyz_to_vsnr
 from .ssim_metric import ssim_metric
 from .exposure_value import exposure_value
 from .iso_acutance import iso_acutance
+from .metrics_compute import metrics_compute
 
 __all__ = [
     "ie_psnr",
@@ -24,4 +25,5 @@ __all__ = [
     "ssim_metric",
     "exposure_value",
     "iso_acutance",
+    "metrics_compute",
 ]

--- a/python/isetcam/metrics/metrics_compute.py
+++ b/python/isetcam/metrics/metrics_compute.py
@@ -1,0 +1,84 @@
+"""Compute common image quality metrics."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Sequence
+
+from .delta_e_ab import delta_e_ab
+from .delta_e_uv import delta_e_uv
+from .ie_psnr import ie_psnr
+from .scielab import scielab, sc_params, SCIELABParams
+from ..xyz_to_lab import xyz_to_lab
+from ..xyz_to_luv import xyz_to_luv
+
+
+def _parse_whitepoint(white_point: Sequence[np.ndarray] | np.ndarray | None) -> tuple[np.ndarray, np.ndarray]:
+    if white_point is None:
+        raise ValueError("white_point is required")
+
+    if isinstance(white_point, Sequence) and not isinstance(white_point, np.ndarray):
+        if len(white_point) != 2:
+            raise ValueError("white_point must have 2 elements when given as a sequence")
+        wp1 = np.asarray(white_point[0], dtype=float).reshape(3)
+        wp2 = np.asarray(white_point[1], dtype=float).reshape(3)
+    else:
+        wp1 = wp2 = np.asarray(white_point, dtype=float).reshape(3)
+    return wp1, wp2
+
+
+def metrics_compute(
+    img1: np.ndarray,
+    img2: np.ndarray,
+    method: str,
+    *,
+    white_point: Sequence[np.ndarray] | np.ndarray | None = None,
+    params: SCIELABParams | None = None,
+    delta_e_version: str = "2000",
+) -> np.ndarray | float:
+    """Compute image quality metric between ``img1`` and ``img2``.
+
+    Supported ``method`` values are ``"cielab"``, ``"cieluv"``, ``"mse"``,
+    ``"rmse"``, ``"psnr"`` and ``"scielab"``.
+    """
+    img1 = np.asarray(img1, dtype=float)
+    img2 = np.asarray(img2, dtype=float)
+    if img1.shape != img2.shape:
+        raise ValueError("img1 and img2 must have the same shape")
+
+    m = method.lower()
+    if m == "cielab":
+        wp1, wp2 = _parse_whitepoint(white_point)
+        lab1 = xyz_to_lab(img1, wp1)
+        lab2 = xyz_to_lab(img2, wp2)
+        return delta_e_ab(lab1, lab2, delta_e_version)
+    elif m == "cieluv":
+        wp1, wp2 = _parse_whitepoint(white_point)
+        luv1 = xyz_to_luv(img1, wp1)
+        luv2 = xyz_to_luv(img2, wp2)
+        return delta_e_uv(luv1, luv2)
+    elif m == "mse":
+        diff = img1 - img2
+        if diff.ndim == 3:
+            return np.sum(diff ** 2, axis=-1)
+        else:
+            return diff ** 2
+    elif m == "rmse":
+        diff = img1 - img2
+        if diff.ndim == 3:
+            return np.sqrt(np.sum(diff ** 2, axis=-1))
+        else:
+            return np.abs(diff)
+    elif m == "psnr":
+        return float(ie_psnr(img1, img2))
+    elif m == "scielab":
+        if white_point is None:
+            raise ValueError("white_point is required for scielab")
+        if params is None:
+            params = sc_params()
+        return scielab(img1, img2, white_point, params)
+    else:
+        raise ValueError(f"Unknown metric: {method}")
+
+
+__all__ = ["metrics_compute"]

--- a/python/tests/test_metrics_compute.py
+++ b/python/tests/test_metrics_compute.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+from isetcam.metrics import metrics_compute, sc_params, delta_e_ab, delta_e_uv, scielab
+from isetcam import xyz_to_lab, xyz_to_luv
+
+WHITEPOINT = np.array([0.95047, 1.0, 1.08883])
+
+
+def test_metrics_compute_cielab():
+    img1 = np.array([[[0.5, 0.4, 0.3]]])
+    img2 = np.array([[[0.4, 0.4, 0.4]]])
+    val = metrics_compute(img1, img2, "cielab", white_point=WHITEPOINT)
+    expected = delta_e_ab(xyz_to_lab(img1, WHITEPOINT), xyz_to_lab(img2, WHITEPOINT))
+    assert np.allclose(val, expected)
+
+
+def test_metrics_compute_cieluv():
+    img1 = np.array([[[0.1, 0.2, 0.3]]])
+    img2 = np.array([[[0.2, 0.1, 0.3]]])
+    val = metrics_compute(img1, img2, "cieluv", white_point=WHITEPOINT)
+    expected = delta_e_uv(xyz_to_luv(img1, WHITEPOINT), xyz_to_luv(img2, WHITEPOINT))
+    assert np.allclose(val, expected)
+
+
+def test_metrics_compute_mse_rmse():
+    a = np.zeros((2, 2), dtype=float)
+    b = np.ones((2, 2), dtype=float)
+    mse = metrics_compute(a, b, "mse")
+    rmse = metrics_compute(a, b, "rmse")
+    assert np.allclose(mse, (a - b) ** 2)
+    assert np.allclose(rmse, np.abs(a - b))
+
+
+def test_metrics_compute_psnr():
+    a = np.zeros((1, 1), dtype=float)
+    b = np.array([[1 / 255]], dtype=float)
+    val = metrics_compute(a, b, "psnr")
+    from isetcam.metrics import ie_psnr
+
+    expected = ie_psnr(a, b)
+    assert np.isclose(val, expected)
+
+
+def test_metrics_compute_scielab():
+    img1 = np.random.rand(2, 2, 3)
+    img2 = np.random.rand(2, 2, 3)
+    params = sc_params()
+    val = metrics_compute(img1, img2, "scielab", white_point=WHITEPOINT, params=params)
+    expected = scielab(img1, img2, WHITEPOINT, params)
+    assert np.allclose(val, expected)


### PR DESCRIPTION
## Summary
- provide `metrics_compute` wrapper for several metrics
- export it via `isetcam.metrics`
- test new functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a9ab177f48323842555bc343d2619