### PR TITLE
Add camera plot and moire utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -100,7 +100,12 @@ from .display import (
     display_max_contrast,
     display_plot,
 )
-from .camera import camera_to_file, camera_from_file
+from .camera import (
+    camera_to_file,
+    camera_from_file,
+    camera_plot,
+    camera_moire,
+)
 from .optics import optics_to_file, optics_from_file
 from .illuminant import (
     illuminant_to_file,
@@ -215,6 +220,8 @@ __all__ = [
     'illuminant_set',
     'camera_to_file',
     'camera_from_file',
+    'camera_plot',
+    'camera_moire',
     'optics_to_file',
     'optics_from_file',
     'openexr_read',

--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -8,6 +8,8 @@ from .camera_from_file import camera_from_file
 from .camera_create import camera_create
 from .camera_compute import camera_compute
 from .camera_mtf import camera_mtf
+from .camera_plot import camera_plot
+from .camera_moire import camera_moire
 from .camera_vsnr import camera_vsnr
 from .camera_acutance import camera_acutance
 from .camera_color_accuracy import camera_color_accuracy
@@ -22,6 +24,8 @@ __all__ = [
     "camera_create",
     "camera_compute",
     "camera_mtf",
+    "camera_plot",
+    "camera_moire",
     "camera_vsnr",
     "camera_acutance",
     "camera_color_accuracy",

--- a/python/isetcam/camera/camera_moire.py
+++ b/python/isetcam/camera/camera_moire.py
@@ -1,0 +1,57 @@
+"""Generate moir\u00e9 pattern response of a camera."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .camera_class import Camera
+from .camera_compute import camera_compute
+from ..scene import Scene
+
+
+_DEF_SIZE = 256
+
+
+def _moire_target(size: int = _DEF_SIZE, f: float | None = None) -> np.ndarray:
+    """Return a radial sinusoidal pattern used for moir\u00e9 testing."""
+    if f is None:
+        f = 1.0 / size / 10.0
+    y, x = np.mgrid[0:size, 0:size]
+    dist2 = x.astype(float) ** 2 + y.astype(float) ** 2
+    pattern = np.sin(np.pi * f * dist2)
+    pattern = (pattern - pattern.min()) / (pattern.max() - pattern.min())
+    return pattern
+
+
+def camera_moire(camera: Camera, *, size: int = _DEF_SIZE,
+                 f: float | None = None) -> tuple[np.ndarray, Camera]:
+    """Simulate imaging a moir\u00e9 target with ``camera``.
+
+    Parameters
+    ----------
+    camera : Camera
+        Camera instance to evaluate.
+    size : int, optional
+        Size in pixels of the square moir\u00e9 scene. Default is ``256``.
+    f : float, optional
+        Spatial frequency scale factor for the target. When ``None`` a
+        reasonable default based on ``size`` is used.
+
+    Returns
+    -------
+    pattern : np.ndarray
+        Sensor voltage image produced by the camera.
+    Camera
+        Updated camera with computed sensor voltages.
+    """
+    pattern = _moire_target(size, f)
+    wave = camera.sensor.wave
+    n_wave = wave.size if wave is not None else 1
+    photons = np.repeat(pattern[:, :, None], n_wave, axis=2)
+    scene = Scene(photons=photons, wave=wave, name="Moire")
+
+    camera_compute(camera, scene)
+    return camera.sensor.volts.copy(), camera
+
+
+__all__ = ["camera_moire"]

--- a/python/isetcam/camera/camera_plot.py
+++ b/python/isetcam/camera/camera_plot.py
@@ -1,0 +1,63 @@
+"""Plot camera sensor response and MTF curves."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+from .camera_class import Camera
+from .camera_mtf import camera_mtf
+from ..sensor import sensor_plot
+
+
+_DEF_TITLE_IMG = "Sensor response"
+_DEF_TITLE_MTF = "MTF"
+
+
+def camera_plot(camera: Camera, *, show_filters: bool = False,
+                axes: "tuple[plt.Axes, plt.Axes] | None" = None) -> "tuple[plt.Axes, plt.Axes]":  # noqa: E501
+    """Display sensor voltage image and MTF curve.
+
+    Parameters
+    ----------
+    camera : Camera
+        Camera instance to visualize.
+    show_filters : bool, optional
+        Overlay CFA letters on the sensor plot when ``True``.
+    axes : tuple of matplotlib.axes.Axes, optional
+        Tuple ``(ax_img, ax_mtf)`` used for plotting. If ``None`` new axes
+        are created.
+
+    Returns
+    -------
+    tuple[matplotlib.axes.Axes, matplotlib.axes.Axes]
+        The axes used for the sensor image and MTF plot respectively.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for camera_plot")
+
+    if axes is None:
+        fig, (ax_img, ax_mtf) = plt.subplots(1, 2, figsize=(8, 4))
+    else:
+        ax_img, ax_mtf = axes
+        fig = ax_img.figure
+
+    sensor_plot(camera.sensor, show_filters=show_filters, ax=ax_img)
+    ax_img.set_title(_DEF_TITLE_IMG)
+
+    freqs, mtf = camera_mtf(camera)
+    ax_mtf.plot(freqs, mtf)
+    ax_mtf.set_xlabel("Spatial frequency (cycles/mm)")
+    ax_mtf.set_ylabel("MTF")
+    ax_mtf.set_title(_DEF_TITLE_MTF)
+    ax_mtf.set_ylim(0.0, 1.05)
+
+    fig.tight_layout()
+    return ax_img, ax_mtf
+
+
+__all__ = ["camera_plot"]

--- a/python/tests/test_camera_moire.py
+++ b/python/tests/test_camera_moire.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from isetcam.camera import camera_create, camera_moire
+
+
+def test_camera_moire_basic():
+    cam = camera_create()
+    pattern, returned = camera_moire(cam, size=32)
+    assert returned is cam
+    assert pattern.shape == cam.sensor.volts.shape
+    assert np.all(pattern >= 0)
+    assert np.all(pattern <= 1)

--- a/python/tests/test_camera_plot.py
+++ b/python/tests/test_camera_plot.py
@@ -1,0 +1,23 @@
+import matplotlib
+matplotlib.use("Agg")
+
+import pytest
+
+from isetcam.camera import camera_create, camera_plot
+
+
+def _mpl_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _mpl_available(), reason="matplotlib not installed")
+def test_camera_plot_basic():
+    cam = camera_create()
+    ax_img, ax_mtf = camera_plot(cam)
+    assert ax_img is not None
+    assert ax_mtf is not None
+    assert len(ax_mtf.lines) == 1


### PR DESCRIPTION
## Summary
- implement `camera_plot` to visualize sensor data and MTF
- implement `camera_moire` to simulate moiré patterns
- export utilities from camera and top-level package
- add basic unit tests for both functions

## Testing
- `PYTHONPATH=$PWD/python pytest -q python/tests/test_camera_plot.py python/tests/test_camera_moire.py`

------
https://chatgpt.com/codex/tasks/task_e_683aa3f16a4c8323884f791098ff5ee3