### PR TITLE
Add pixel dataclass and accessors

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -91,7 +91,7 @@ from .human import (
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, display, illuminant, camera, imgproc, metrics, optics, human, ip  # noqa: E501
+from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip  # noqa: E501
 from .opticalimage import oi_to_file
 from .sensor import sensor_to_file
 from .display import (
@@ -202,6 +202,7 @@ __all__ = [
     'scene',
     'opticalimage',
     'sensor',
+    'pixel',
     'display',
     'illuminant',
     'imgproc',

--- a/python/isetcam/pixel/__init__.py
+++ b/python/isetcam/pixel/__init__.py
@@ -1,0 +1,11 @@
+"""Pixel-related functions."""
+
+from .pixel_class import Pixel
+from .pixel_get import pixel_get
+from .pixel_set import pixel_set
+
+__all__ = [
+    "Pixel",
+    "pixel_get",
+    "pixel_set",
+]

--- a/python/isetcam/pixel/pixel_class.py
+++ b/python/isetcam/pixel/pixel_class.py
@@ -1,0 +1,15 @@
+"""Basic :class:`Pixel` dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Pixel:
+    """Minimal representation of an ISETCam pixel."""
+
+    width: float
+    height: float
+    well_capacity: float
+    fill_factor: float

--- a/python/isetcam/pixel/pixel_get.py
+++ b/python/isetcam/pixel/pixel_get.py
@@ -1,0 +1,22 @@
+"""Retrieve parameters from :class:`Pixel` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .pixel_class import Pixel
+from ..ie_param_format import ie_param_format
+
+
+def pixel_get(pixel: Pixel, param: str) -> Any:
+    """Return a parameter value from ``pixel``."""
+    key = ie_param_format(param)
+    if key == "width":
+        return pixel.width
+    if key == "height":
+        return pixel.height
+    if key in {"wellcapacity", "well_capacity"}:
+        return pixel.well_capacity
+    if key in {"fillfactor", "fill_factor"}:
+        return pixel.fill_factor
+    raise KeyError(f"Unknown pixel parameter '{param}'")

--- a/python/isetcam/pixel/pixel_set.py
+++ b/python/isetcam/pixel/pixel_set.py
@@ -1,0 +1,26 @@
+"""Assign parameters on :class:`Pixel` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .pixel_class import Pixel
+from ..ie_param_format import ie_param_format
+
+
+def pixel_set(pixel: Pixel, param: str, val: Any) -> None:
+    """Set a parameter value on ``pixel``."""
+    key = ie_param_format(param)
+    if key == "width":
+        pixel.width = float(val)
+        return
+    if key == "height":
+        pixel.height = float(val)
+        return
+    if key in {"wellcapacity", "well_capacity"}:
+        pixel.well_capacity = float(val)
+        return
+    if key in {"fillfactor", "fill_factor"}:
+        pixel.fill_factor = float(val)
+        return
+    raise KeyError(f"Unknown pixel parameter '{param}'")

--- a/python/tests/test_pixel_get_set.py
+++ b/python/tests/test_pixel_get_set.py
@@ -1,0 +1,22 @@
+from isetcam.pixel import Pixel, pixel_get, pixel_set
+
+
+def test_pixel_get_set():
+    p = Pixel(width=2.8e-6, height=2.8e-6, well_capacity=5000, fill_factor=0.5)
+
+    assert pixel_get(p, " width ") == 2.8e-6
+    assert pixel_get(p, "HEIGHT") == 2.8e-6
+    assert pixel_get(p, "well capacity") == 5000
+    assert pixel_get(p, "Fill_Factor") == 0.5
+
+    pixel_set(p, "Width", 3e-6)
+    assert pixel_get(p, "width") == 3e-6
+
+    pixel_set(p, "height", 3e-6)
+    assert pixel_get(p, "HEIGHT") == 3e-6
+
+    pixel_set(p, "wellCapacity", 6000)
+    assert pixel_get(p, "well_capacity") == 6000
+
+    pixel_set(p, "fill factor", 0.6)
+    assert pixel_get(p, "fillFactor") == 0.6


### PR DESCRIPTION
## Summary
- add `Pixel` dataclass representing simple pixel properties
- implement `pixel_get` and `pixel_set` utilities
- expose pixel utilities in subpackage and top level
- test pixel parameter access functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683aad3ef3d08323ba5826cc3aec25e3