### PR TITLE
Add faulty pixel utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -72,6 +72,9 @@ from .imgproc import (
     ie_nearest_neighbor,
     ie_bilinear,
     bayer_indices,
+    faulty_insert,
+    faulty_list,
+    faulty_pixel_correction,
 )
 from .ie_spectra_sphere import ie_spectra_sphere
 from .metrics.ie_psnr import ie_psnr
@@ -179,6 +182,9 @@ __all__ = [
     'ie_nearest_neighbor',
     'ie_bilinear',
     'bayer_indices',
+    'faulty_insert',
+    'faulty_list',
+    'faulty_pixel_correction',
     'ie_psnr',
     'scielab',
     'sc_params',

--- a/python/isetcam/imgproc/__init__.py
+++ b/python/isetcam/imgproc/__init__.py
@@ -2,7 +2,14 @@
 
 from .image_distort import image_distort
 from .ie_internal_to_display import ie_internal_to_display
-from .demosaic import ie_nearest_neighbor, ie_bilinear, bayer_indices
+from .demosaic import (
+    ie_nearest_neighbor,
+    ie_bilinear,
+    bayer_indices,
+    faulty_insert,
+    faulty_list,
+    faulty_pixel_correction,
+)
 
 __all__ = [
     "image_distort",
@@ -10,4 +17,7 @@ __all__ = [
     "ie_nearest_neighbor",
     "ie_bilinear",
     "bayer_indices",
+    "faulty_insert",
+    "faulty_list",
+    "faulty_pixel_correction",
 ]

--- a/python/isetcam/imgproc/demosaic/__init__.py
+++ b/python/isetcam/imgproc/demosaic/__init__.py
@@ -3,5 +3,17 @@
 from .ie_nearest_neighbor import ie_nearest_neighbor
 from .ie_bilinear import ie_bilinear
 from .bayer_indices import bayer_indices
+from .faulty_pixel import (
+    faulty_insert,
+    faulty_list,
+    faulty_pixel_correction,
+)
 
-__all__ = ["ie_nearest_neighbor", "ie_bilinear", "bayer_indices"]
+__all__ = [
+    "ie_nearest_neighbor",
+    "ie_bilinear",
+    "bayer_indices",
+    "faulty_insert",
+    "faulty_list",
+    "faulty_pixel_correction",
+]

--- a/python/isetcam/imgproc/demosaic/faulty_pixel/__init__.py
+++ b/python/isetcam/imgproc/demosaic/faulty_pixel/__init__.py
@@ -1,0 +1,11 @@
+"""Utilities for handling faulty pixels."""
+
+from .faulty_insert import faulty_insert
+from .faulty_list import faulty_list
+from .faulty_pixel_correction import faulty_pixel_correction
+
+__all__ = [
+    "faulty_insert",
+    "faulty_list",
+    "faulty_pixel_correction",
+]

--- a/python/isetcam/imgproc/demosaic/faulty_pixel/faulty_insert.py
+++ b/python/isetcam/imgproc/demosaic/faulty_pixel/faulty_insert.py
@@ -1,0 +1,37 @@
+"""Insert faulty pixels into an image."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def faulty_insert(list_: np.ndarray, img: np.ndarray, val: float | int = 0) -> np.ndarray:
+    """Return ``img`` with specified pixels set to ``val``.
+
+    Parameters
+    ----------
+    list_ : np.ndarray
+        ``(N, 2)`` array of ``(x, y)`` positions for faulty pixels.
+    img : np.ndarray
+        Image array with shape ``(rows, cols, channels)`` or ``(rows, cols)``.
+    val : float | int, optional
+        Value assigned to the faulty pixels. Default is ``0``.
+
+    Returns
+    -------
+    np.ndarray
+        Copy of ``img`` with the faulty pixel locations set to ``val``.
+    """
+    if list_.ndim != 2 or list_.shape[1] != 2:
+        raise ValueError("list_ must be (N, 2) array")
+
+    out = np.array(img, copy=True)
+    h, w = out.shape[:2]
+    for x, y in list_.astype(int):
+        if not (0 <= x < w and 0 <= y < h):
+            raise ValueError("faulty pixel location out of bounds")
+        if out.ndim == 2:
+            out[y, x] = val
+        else:
+            out[y, x, ...] = val
+    return out

--- a/python/isetcam/imgproc/demosaic/faulty_pixel/faulty_list.py
+++ b/python/isetcam/imgproc/demosaic/faulty_pixel/faulty_list.py
@@ -1,0 +1,62 @@
+"""Generate a list of random faulty pixel coordinates."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def faulty_list(
+    row: int,
+    col: int,
+    n_bad_pixels: int | None = None,
+    min_separation: int = 2,
+) -> np.ndarray:
+    """Return a list of randomly spaced pixel locations.
+
+    Parameters
+    ----------
+    row, col : int
+        Image size in rows and columns.
+    n_bad_pixels : int, optional
+        Number of faulty pixels to generate. Default is ``1%`` of pixels.
+    min_separation : int, optional
+        Minimum Euclidean distance between faulty pixels. Default is ``2``.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape ``(N, 2)`` with columns ``(x, y)``.
+    """
+    if n_bad_pixels is None:
+        n_bad_pixels = int(round(row * col * 0.01))
+    if n_bad_pixels < 0:
+        raise ValueError("n_bad_pixels must be non-negative")
+    if n_bad_pixels == 0:
+        return np.empty((0, 2), dtype=int)
+
+    if n_bad_pixels * min_separation * 4 > row * col:
+        raise ValueError("Separation parameter and size are poorly chosen")
+
+    coords: list[tuple[int, int]] = []
+    rng = np.random.default_rng()
+    attempts = 0
+    while len(coords) < n_bad_pixels:
+        x = int(rng.integers(0, col))
+        y = int(rng.integers(0, row))
+        candidate = (x, y)
+        # ensure unique and adequately separated
+        ok = True
+        for ex in coords:
+            if ex == candidate:
+                ok = False
+                break
+            if np.hypot(ex[0] - x, ex[1] - y) < min_separation:
+                ok = False
+                break
+        if ok:
+            coords.append(candidate)
+        attempts += 1
+        if attempts > 10000:
+            raise RuntimeError("unable to generate faulty pixel list")
+
+    return np.array(coords, dtype=int)

--- a/python/isetcam/imgproc/demosaic/faulty_pixel/faulty_pixel_correction.py
+++ b/python/isetcam/imgproc/demosaic/faulty_pixel/faulty_pixel_correction.py
@@ -1,0 +1,78 @@
+"""Repair faulty pixels in a Bayer mosaic."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def faulty_pixel_correction(
+    list_: np.ndarray,
+    bayer: np.ndarray,
+    pattern: str,
+    method: str = "bilinear",
+) -> np.ndarray:
+    """Return ``bayer`` with faulty pixels replaced.
+
+    Parameters
+    ----------
+    list_ : np.ndarray
+        ``(N, 2)`` array with faulty pixel ``(x, y)`` coordinates.
+    bayer : np.ndarray
+        2-D Bayer mosaic image.
+    pattern : str
+        CFA pattern string such as ``"rggb"``.
+    method : {{"bilinear", "nearest"}}, optional
+        Interpolation method. Default is ``"bilinear"``.
+
+    Returns
+    -------
+    np.ndarray
+        Corrected Bayer mosaic.
+    """
+    if list_.ndim != 2 or list_.shape[1] != 2:
+        raise ValueError("list_ must be (N, 2) array")
+    if bayer.ndim != 2:
+        raise ValueError("bayer must be a 2-D array")
+
+    pattern = pattern.lower()
+    if pattern not in {"rggb", "bggr", "grbg", "gbrg"}:
+        raise ValueError("Unsupported CFA pattern")
+
+    grid = np.array([[pattern[0], pattern[1]], [pattern[2], pattern[3]]])
+
+    bayer = np.array(bayer, dtype=float)
+    out = bayer.copy()
+
+    pad = 2 if method == "bilinear" else 2
+    padded = np.pad(bayer, pad, mode="edge")
+
+    for x, y in list_.astype(int):
+        if not (0 <= y < bayer.shape[0] and 0 <= x < bayer.shape[1]):
+            raise ValueError("faulty pixel location out of bounds")
+        color = grid[y % 2, x % 2]
+        yp = y + pad
+        xp = x + pad
+        if method == "nearest":
+            if color in {"r", "b"}:
+                val = padded[yp + 2, xp]
+            else:
+                val = padded[yp + 1, xp + 1]
+        else:  # bilinear
+            if color in {"r", "b"}:
+                vals = [
+                    padded[yp - 2, xp],
+                    padded[yp + 2, xp],
+                    padded[yp, xp - 2],
+                    padded[yp, xp + 2],
+                ]
+            else:  # green
+                vals = [
+                    padded[yp - 1, xp - 1],
+                    padded[yp - 1, xp + 1],
+                    padded[yp + 1, xp - 1],
+                    padded[yp + 1, xp + 1],
+                ]
+            val = sum(vals) / 4.0
+        out[y, x] = val
+
+    return out

--- a/python/tests/test_faulty_pixel.py
+++ b/python/tests/test_faulty_pixel.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from isetcam.imgproc.demosaic.faulty_pixel import (
+    faulty_insert,
+    faulty_list,
+    faulty_pixel_correction,
+)
+
+
+def test_faulty_list_spacing():
+    lst = faulty_list(10, 10, n_bad_pixels=5, min_separation=2)
+    assert lst.shape == (5, 2)
+    for i in range(len(lst)):
+        for j in range(i + 1, len(lst)):
+            dist = np.hypot(*(lst[i] - lst[j]))
+            assert dist >= 2
+
+
+def test_faulty_insert_and_correction():
+    pattern = "rggb"
+    bayer = np.arange(36, dtype=float).reshape(6, 6)
+    coords = np.array([[2, 2]])
+    faulty = faulty_insert(coords, bayer, val=0)
+    corrected = faulty_pixel_correction(coords, faulty, pattern, method="bilinear")
+    expected = bayer.copy()
+    expected[2, 2] = (bayer[0, 2] + bayer[4, 2] + bayer[2, 0] + bayer[2, 4]) / 4
+    assert np.allclose(corrected, expected)


### PR DESCRIPTION
## Summary
- add faulty pixel submodules with utilities for inserting, listing and correcting defective Bayer data
- export new functions through `imgproc.demosaic` and `isetcam.imgproc`
- expose them at the package root
- test detection and correction logic

## Testing
- `PYTHONPATH=$PWD/python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aaf73cebc8323982d7a239b8443e0