### PR TITLE
Add display utility functions

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -103,6 +103,10 @@ from .display import (
     display_list,
     display_max_contrast,
     display_plot,
+    display_description,
+    display_reflectance,
+    display_set_max_luminance,
+    display_set_white_point,
 )
 from .camera import (
     camera_to_file,
@@ -223,6 +227,10 @@ __all__ = [
     'display_list',
     'display_max_contrast',
     'display_plot',
+    'display_description',
+    'display_reflectance',
+    'display_set_max_luminance',
+    'display_set_white_point',
     'illuminant_to_file',
     'illuminant_from_file',
     'illuminant_get',

--- a/python/isetcam/display/__init__.py
+++ b/python/isetcam/display/__init__.py
@@ -19,6 +19,10 @@ from .display_to_file import display_to_file
 from .display_list import display_list
 from .display_max_contrast import display_max_contrast
 from .display_plot import display_plot
+from .display_description import display_description
+from .display_reflectance import display_reflectance
+from .display_set_max_luminance import display_set_max_luminance
+from .display_set_white_point import display_set_white_point
 
 __all__ = [
     "Display",
@@ -35,4 +39,8 @@ __all__ = [
     "display_list",
     "display_max_contrast",
     "display_plot",
+    "display_description",
+    "display_reflectance",
+    "display_set_max_luminance",
+    "display_set_white_point",
 ]

--- a/python/isetcam/display/display_class.py
+++ b/python/isetcam/display/display_class.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from ..ie_xyz_from_energy import ie_xyz_from_energy
+
 
 @dataclass
 class Display:
@@ -15,3 +17,14 @@ class Display:
     wave: np.ndarray
     gamma: np.ndarray | None = None
     name: str | None = None
+    max_luminance: float | None = None
+    white_point: np.ndarray | None = None
+
+    def __post_init__(self) -> None:
+        if self.white_point is None:
+            try:
+                self.white_point = ie_xyz_from_energy(self.spd.sum(axis=1), self.wave).reshape(3)
+            except Exception:
+                self.white_point = np.zeros(3)
+        if self.max_luminance is None:
+            self.max_luminance = float(self.white_point[1])

--- a/python/isetcam/display/display_description.py
+++ b/python/isetcam/display/display_description.py
@@ -1,0 +1,38 @@
+"""Generate a short textual description of a :class:`Display`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .display_class import Display
+
+
+ndefault = "No display structure"
+
+
+def display_description(display: Display | None) -> str:
+    """Return a multi-line description of ``display``."""
+    if display is None:
+        return ndefault
+
+    lines: list[str] = []
+    if display.name is not None:
+        lines.append(f"Name:\t{display.name}")
+
+    wave = np.asarray(display.wave, dtype=float)
+    if wave.size:
+        spacing = wave[1] - wave[0] if wave.size > 1 else 0
+        lines.append(f"Wave:\t{int(wave[0])}:{int(spacing)}:{int(wave[-1])} nm")
+
+    spd = np.asarray(display.spd)
+    lines.append(f"# primaries:\t{spd.shape[1]}")
+
+    if display.gamma is not None:
+        n_levels = display.gamma.shape[0]
+        bits = int(round(np.log2(n_levels)))
+        lines.append(f"Color bit depth:\t{bits}")
+
+    return "\n".join(lines) if lines else ndefault
+
+
+__all__ = ["display_description"]

--- a/python/isetcam/display/display_get.py
+++ b/python/isetcam/display/display_get.py
@@ -13,8 +13,9 @@ from ..ie_param_format import ie_param_format
 def display_get(display: Display, param: str) -> Any:
     """Return a parameter value from ``display``.
 
-    Supported parameters are ``spd``, ``wave``, ``n_wave``/``nwave``, ``gamma``
-    and ``name``.
+    Supported parameters are ``spd``, ``wave``, ``n_wave``/``nwave``, ``gamma``,
+    ``max_luminance`` and ``white_point``/``whitepoint`` in addition to
+    ``name``.
     """
     key = ie_param_format(param)
     if key == "spd":
@@ -23,6 +24,10 @@ def display_get(display: Display, param: str) -> Any:
         return display.wave
     if key == "gamma":
         return display.gamma
+    if key in {"maxluminance", "max_luminance"}:
+        return getattr(display, "max_luminance", None)
+    if key in {"whitepoint", "white_point"}:
+        return getattr(display, "white_point", None)
     if key in {"nwave", "n_wave"}:
         return len(display.wave)
     if key == "name":

--- a/python/isetcam/display/display_reflectance.py
+++ b/python/isetcam/display/display_reflectance.py
@@ -1,0 +1,51 @@
+"""Create a reflectance based display model."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .display_class import Display
+from .display_create import display_create
+from .display_set import display_set
+from .display_get import display_get
+from .display_set_max_luminance import display_set_max_luminance
+from ..ie_read_spectra import ie_read_spectra
+from ..data_path import data_path
+from ..color_transform_matrix import color_transform_matrix
+from ..illuminant import illuminant_blackbody
+from ..ie_xyz_from_energy import ie_xyz_from_energy
+
+
+def display_reflectance(ctemp: float, wave: np.ndarray | None = None) -> tuple[Display, np.ndarray, np.ndarray]:
+    """Return a display representing surfaces illuminated by a blackbody."""
+    if wave is None:
+        wave = np.arange(400, 701, 5, dtype=float)
+    else:
+        wave = np.asarray(wave, dtype=float)
+
+    basis, _, _, _ = ie_read_spectra(data_path('surfaces/reflectanceBasis.mat'), wave)
+    basis[:, 0] *= -1
+
+    ill_energy = illuminant_blackbody(float(ctemp), wave)
+
+    radiance_basis = basis[:, :3] * ill_energy[:, np.newaxis]
+
+    lrgb2xyz = color_transform_matrix('lrgb2xyz')
+    lXYZinCols = lrgb2xyz.T
+    XYZ, _, _, _ = ie_read_spectra(data_path('human/XYZEnergy.mat'), wave)
+
+    T = np.linalg.pinv(XYZ.T @ radiance_basis) @ lXYZinCols
+    rgb_primaries = radiance_basis @ T
+
+    disp = display_create()
+    display_set(disp, 'wave', wave)
+    display_set(disp, 'spd', rgb_primaries)
+    display_set_max_luminance(disp, 100)
+    disp.gamma = display_create('LCD-Apple').gamma
+    disp.name = f'Natural (ill {int(ctemp)}K)'
+
+    scaled_ill = ill_energy * (display_get(disp, 'max_luminance') / 100)
+    return disp, disp.spd, scaled_ill
+
+
+__all__ = ["display_reflectance"]

--- a/python/isetcam/display/display_set.py
+++ b/python/isetcam/display/display_set.py
@@ -13,8 +13,9 @@ from ..ie_param_format import ie_param_format
 def display_set(display: Display, param: str, val: Any) -> None:
     """Set a parameter value on ``display``.
 
-    Supported parameters are ``spd``, ``wave``, ``gamma`` and ``name``.
-    ``n_wave`` is a derived value and therefore cannot be set.
+    Supported parameters are ``spd``, ``wave``, ``gamma``, ``max_luminance`` and
+    ``white_point`` as well as ``name``. ``n_wave`` is a derived value and
+    therefore cannot be set.
     """
     key = ie_param_format(param)
     if key == "spd":
@@ -25,6 +26,12 @@ def display_set(display: Display, param: str, val: Any) -> None:
         return
     if key == "gamma":
         display.gamma = None if val is None else np.asarray(val)
+        return
+    if key in {"maxluminance", "max_luminance"}:
+        display.max_luminance = None if val is None else float(val)
+        return
+    if key in {"whitepoint", "white_point"}:
+        display.white_point = None if val is None else np.asarray(val, dtype=float)
         return
     if key == "name":
         display.name = None if val is None else str(val)

--- a/python/isetcam/display/display_set_max_luminance.py
+++ b/python/isetcam/display/display_set_max_luminance.py
@@ -1,0 +1,26 @@
+"""Scale a display's primaries to match a target peak luminance."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .display_class import Display
+from ..ie_xyz_from_energy import ie_xyz_from_energy
+
+
+def display_set_max_luminance(display: Display, lum: float) -> None:
+    """Scale ``display.spd`` so that white luminance equals ``lum`` cd/m^2."""
+    spd = np.asarray(display.spd, dtype=float)
+    wave = np.asarray(display.wave, dtype=float)
+    white_spd = spd.sum(axis=1)
+    xyz = ie_xyz_from_energy(white_spd, wave).reshape(3)
+    curr_l = xyz[1]
+    if curr_l == 0:
+        raise ValueError("Display has zero luminance")
+    scale = float(lum) / curr_l
+    display.spd = spd * scale
+    display.max_luminance = float(lum)
+    display.white_point = ie_xyz_from_energy(display.spd.sum(axis=1), wave).reshape(3)
+
+
+__all__ = ["display_set_max_luminance"]

--- a/python/isetcam/display/display_set_white_point.py
+++ b/python/isetcam/display/display_set_white_point.py
@@ -1,0 +1,28 @@
+"""Adjust display primaries to achieve a specified white point."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .display_class import Display
+from ..ie_xyz_from_energy import ie_xyz_from_energy
+from ..xyy_to_xyz import xyy_to_xyz
+
+
+def display_set_white_point(display: Display, xy: tuple[float, float] | list[float] | np.ndarray) -> None:
+    """Scale ``display.spd`` so that its white point matches ``xy``."""
+    spd = np.asarray(display.spd, dtype=float)
+    wave = np.asarray(display.wave, dtype=float)
+
+    xy = np.asarray(xy, dtype=float).reshape(2)
+    Y = display.max_luminance if display.max_luminance is not None else ie_xyz_from_energy(spd.sum(axis=1), wave).reshape(3)[1]
+    target_xyz = xyy_to_xyz(np.array([[xy[0], xy[1], Y]])).reshape(3)
+
+    prim_xyz = ie_xyz_from_energy(spd.T, wave)
+    scale = np.linalg.lstsq(prim_xyz, target_xyz, rcond=None)[0]
+    display.spd = spd * scale.reshape(1, -1)
+    display.white_point = ie_xyz_from_energy(display.spd.sum(axis=1), wave).reshape(3)
+    display.max_luminance = display.white_point[1]
+
+
+__all__ = ["display_set_white_point"]

--- a/python/tests/test_display_extras.py
+++ b/python/tests/test_display_extras.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+from isetcam.display import (
+    Display,
+    display_description,
+    display_reflectance,
+    display_set_max_luminance,
+    display_set_white_point,
+)
+from isetcam.ie_xyz_from_energy import ie_xyz_from_energy
+
+
+def test_display_description():
+    wave = np.array([500, 510, 520])
+    spd = np.ones((3, 3))
+    gamma = np.linspace(0, 1, 4).reshape(4, 1).repeat(3, axis=1)
+    disp = Display(spd=spd, wave=wave, gamma=gamma, name="demo")
+    desc = display_description(disp)
+    assert "demo" in desc
+    assert "# primaries" in desc
+    assert "Color bit depth" in desc
+
+
+def test_display_set_max_luminance():
+    wave = np.linspace(400, 700, 10)
+    spd = np.ones((len(wave), 3))
+    disp = Display(spd=spd.copy(), wave=wave)
+    display_set_max_luminance(disp, 200)
+    white_xyz = ie_xyz_from_energy(disp.spd.sum(axis=1), disp.wave).reshape(3)
+    assert np.isclose(white_xyz[1], 200, atol=1e-4)
+    assert disp.max_luminance == 200
+
+
+def test_display_set_white_point():
+    wave = np.array([500, 510, 520])
+    spd = np.eye(3)
+    disp = Display(spd=spd.copy(), wave=wave)
+    display_set_max_luminance(disp, 100)
+    xy_before = disp.white_point[:2] / disp.white_point.sum()
+    display_set_white_point(disp, (0.4, 0.4))
+    xy_after = disp.white_point[:2] / disp.white_point.sum()
+    assert not np.allclose(xy_before, xy_after)
+
+
+def test_display_reflectance_basic():
+    disp, prim, ill = display_reflectance(6500)
+    assert isinstance(disp, Display)
+    assert prim.shape[1] == 3
+    assert ill.ndim == 1 and ill.size == prim.shape[0]
+    assert disp.max_luminance is not None


### PR DESCRIPTION
## Summary
- implement additional display helpers: description, reflectance, and setter utilities
- extend Display data class with luminance and white point
- update accessor modules for new fields
- export new helpers from package
- test display extras

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ab553847883238b61804925687c32