### PR TITLE
Add basic DNG I/O using rawpy

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -121,7 +121,7 @@ from .illuminant import (
     illuminant_get,
     illuminant_set,
 )
-from .io import openexr_read, openexr_write, pfm_read, pfm_write
+from .io import openexr_read, openexr_write, pfm_read, pfm_write, dng_read, dng_write
 
 __all__ = [
     'vc_constants',
@@ -245,6 +245,8 @@ __all__ = [
     'openexr_write',
     'pfm_read',
     'pfm_write',
+    'dng_read',
+    'dng_write',
     'vc_add_and_select_object',
     'vc_get_object',
     'vc_replace_object',

--- a/python/isetcam/io/__init__.py
+++ b/python/isetcam/io/__init__.py
@@ -3,6 +3,8 @@
 from .openexr_read import openexr_read
 from .openexr_write import openexr_write
 from .pfm_read import pfm_read
+from .dng_read import dng_read
+from .dng_write import dng_write
 from .pfm_write import pfm_write
 
-__all__ = ["openexr_read", "openexr_write", "pfm_read", "pfm_write"]
+__all__ = ["openexr_read", "openexr_write", "pfm_read", "pfm_write", "dng_read", "dng_write"]

--- a/python/isetcam/io/dng_read.py
+++ b/python/isetcam/io/dng_read.py
@@ -1,0 +1,33 @@
+"""Read DNG images using rawpy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import rawpy  # type: ignore
+except Exception:  # pragma: no cover - library may not be present
+    rawpy = None  # type: ignore
+
+
+def dng_read(path: str | Path) -> np.ndarray:
+    """Load ``path`` and return the raw pixel data.
+
+    Parameters
+    ----------
+    path:
+        File to read.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``(H, W)`` array of ``uint16`` values containing the raw sensor data.
+    """
+    if rawpy is None:  # pragma: no cover - dependency missing
+        raise RuntimeError("rawpy library is not available")
+    p = Path(path)
+    with rawpy.imread(str(p)) as raw:
+        data = np.asarray(raw.raw_image, dtype=np.uint16)
+    return data

--- a/python/isetcam/io/dng_write.py
+++ b/python/isetcam/io/dng_write.py
@@ -1,0 +1,20 @@
+"""Write DNG images using rawpy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import rawpy  # type: ignore
+except Exception:  # pragma: no cover - library may not be present
+    rawpy = None  # type: ignore
+
+
+def dng_write(path: str | Path, data: np.ndarray) -> None:
+    """Save ``data`` to ``path`` as a DNG file."""
+    if rawpy is None:  # pragma: no cover - dependency missing
+        raise RuntimeError("rawpy library is not available")
+    arr = np.asarray(data, dtype=np.uint16)
+    rawpy.enhance.write_dng(str(path), arr)

--- a/python/tests/test_dng_io.py
+++ b/python/tests/test_dng_io.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+
+from isetcam.io import dng_read, dng_write
+
+
+def _backend_available() -> bool:
+    try:
+        import rawpy  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _backend_available(), reason="rawpy not available")
+def test_dng_roundtrip(tmp_path):
+    data = (np.arange(12, dtype=np.uint16).reshape(3, 4) * 17) % 65535
+    path = tmp_path / "test.dng"
+    dng_write(path, data)
+    loaded = dng_read(path)
+    assert loaded.shape == data.shape
+    assert np.all(loaded == data)


### PR DESCRIPTION
## Summary
- add `dng_read` and `dng_write` helpers in `isetcam.io`
- expose the new utilities in public `isetcam` API
- test round‑trip of a raw buffer when rawpy is installed

## Testing
- `pytest python/tests/test_dng_io.py -q`
- `pytest python/tests/test_openexr_io.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683ac324d82c832382842a861cf36bf6