### PR TITLE
Add sensor_dng_read

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -17,6 +17,7 @@ from .sensor_snr_luxsec import sensor_snr_luxsec
 from .sensor_crop import sensor_crop
 from .sensor_plot import sensor_plot
 from .sensor_ccm import sensor_ccm
+from .sensor_dng_read import sensor_dng_read
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -63,4 +64,5 @@ __all__ = [
     "sensor_snr_luxsec",
     "sensor_plot",
     "sensor_ccm",
+    "sensor_dng_read",
 ]

--- a/python/isetcam/sensor/sensor_dng_read.py
+++ b/python/isetcam/sensor/sensor_dng_read.py
@@ -1,0 +1,51 @@
+"""Load raw data from a DNG file into a :class:`Sensor`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import rawpy  # type: ignore
+except Exception:  # pragma: no cover - library may not be present
+    rawpy = None  # type: ignore
+
+from ..io import dng_read
+from .sensor_class import Sensor
+
+
+def sensor_dng_read(path: str | Path) -> Sensor:
+    """Read ``path`` as a DNG image and return a :class:`Sensor`.
+
+    The raw pixel data are stored in ``sensor.volts`` and common metadata
+    such as ISO speed, exposure time, orientation and black level are stored
+    as attributes on the returned object when available.
+    """
+    if rawpy is None:  # pragma: no cover - dependency missing
+        raise RuntimeError("rawpy library is not available")
+
+    p = Path(path)
+
+    # Raw sensor values
+    data = dng_read(p)
+
+    # Extract metadata using rawpy
+    with rawpy.imread(str(p)) as raw:
+        meta = raw.metadata
+        iso_speed = getattr(meta, "iso_speed", None)
+        exposure = getattr(meta, "exposure", None)
+        orientation = getattr(meta, "orientation", None)
+        black_level = getattr(meta, "black_level_per_channel", None)
+
+    exposure_time = float(exposure) if exposure is not None else 0.0
+    sensor = Sensor(volts=data.astype(float), exposure_time=exposure_time, name=p.name)
+
+    if iso_speed is not None:
+        sensor.iso_speed = iso_speed
+    if orientation is not None:
+        sensor.orientation = orientation
+    if black_level is not None:
+        sensor.black_level = np.asarray(black_level).reshape(-1)
+
+    return sensor

--- a/python/tests/test_sensor_dng_read.py
+++ b/python/tests/test_sensor_dng_read.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+from isetcam.io import dng_write
+from isetcam.sensor import Sensor, sensor_dng_read
+
+
+def _backend_available() -> bool:
+    try:
+        import rawpy  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _backend_available(), reason="rawpy not available")
+def test_sensor_dng_read_roundtrip(tmp_path):
+    data = (np.arange(12, dtype=np.uint16).reshape(3, 4) * 17) % 65535
+    path = tmp_path / "test.dng"
+    dng_write(path, data)
+    sensor = sensor_dng_read(path)
+    assert isinstance(sensor, Sensor)
+    assert np.array_equal(sensor.volts.astype(np.uint16), data)
+    assert isinstance(sensor.exposure_time, float)


### PR DESCRIPTION
## Summary
- implement `sensor_dng_read` for loading raw DNG data
- expose the function from the sensor package
- test round‑tripping via `dng_write`

## Testing
- `PYTHONPATH=$PWD/python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ac68783988323b3bdf9ee3a646fe5