### PR TITLE
Implement scene_list utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -32,6 +32,7 @@ from .scene_illuminant_pattern import scene_illuminant_pattern
 from .scene_illuminant_ss import scene_illuminant_ss
 from .scene_depth_overlay import scene_depth_overlay
 from .scene_depth_range import scene_depth_range
+from .scene_list import scene_list
 
 __all__ = [
     "Scene",
@@ -68,4 +69,5 @@ __all__ = [
     "scene_illuminant_ss",
     "scene_depth_overlay",
     "scene_depth_range",
+    "scene_list",
 ]

--- a/python/isetcam/scene/scene_list.py
+++ b/python/isetcam/scene/scene_list.py
@@ -1,0 +1,35 @@
+"""List available sample scenes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..data_path import data_path
+
+
+# We search both for MATLAB ``.mat`` files and common image formats.
+_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".exr"}
+_MATLAB_EXTS = {".mat", ".m"}
+
+
+def scene_list() -> list[str]:
+    """Return available sample scene names.
+
+    The names correspond to files located under ``data/scenes`` in the
+    ISETCam repository. Both ``.mat`` files and common image formats are
+    included. The returned list is sorted alphabetically and the file
+    extensions are stripped.
+    """
+    sc_dir = data_path("scenes")
+    names: list[str] = []
+    if sc_dir.exists():
+        for f in sc_dir.iterdir():
+            if not f.is_file():
+                continue
+            suffix = f.suffix.lower()
+            if suffix in _MATLAB_EXTS or suffix in _IMAGE_EXTS:
+                names.append(Path(f).stem)
+    return sorted(names)
+
+
+__all__ = ["scene_list"]

--- a/python/tests/test_scene_list.py
+++ b/python/tests/test_scene_list.py
@@ -1,0 +1,8 @@
+from isetcam.scene import scene_list
+
+
+def test_scene_list_contains_sample():
+    names = scene_list()
+    assert isinstance(names, list)
+    assert "d_sceneICVL" in names
+    assert all(isinstance(n, str) for n in names)


### PR DESCRIPTION
## Summary
- add `scene_list` function to enumerate sample scenes
- expose `scene_list` from the scene module
- test that `scene_list` finds default samples

## Testing
- `pytest -q python/tests/test_scene_list.py`

------
https://chatgpt.com/codex/tasks/task_e_683ac924d06483239eccfd912515b813