### PR TITLE
Add scene_wb_create utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -33,6 +33,7 @@ from .scene_illuminant_ss import scene_illuminant_ss
 from .scene_depth_overlay import scene_depth_overlay
 from .scene_depth_range import scene_depth_range
 from .scene_list import scene_list
+from .scene_wb_create import scene_wb_create
 
 __all__ = [
     "Scene",
@@ -70,4 +71,5 @@ __all__ = [
     "scene_depth_overlay",
     "scene_depth_range",
     "scene_list",
+    "scene_wb_create",
 ]

--- a/python/isetcam/scene/scene_wb_create.py
+++ b/python/isetcam/scene/scene_wb_create.py
@@ -1,0 +1,87 @@
+"""Create individual wavelength scene files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, List
+
+import numpy as np
+from scipy.io import savemat
+
+from .scene_class import Scene
+from .scene_to_file import scene_to_file
+from .scene_create import _load_macbeth_data
+from ..illuminant import illuminant_create
+
+
+def _default_scene(patch_size: int, illuminant: str) -> Scene:
+    illum = illuminant_create(illuminant)
+    refl, wave = _load_macbeth_data(illum.wave)
+    nrows, ncols = 4, 6
+    photons = np.zeros((patch_size * nrows, patch_size * ncols, wave.size), dtype=float)
+    idx = 0
+    for r in range(nrows):
+        for c in range(ncols):
+            patch = refl[:, idx] * illum.spd
+            photons[r * patch_size:(r + 1) * patch_size,
+                    c * patch_size:(c + 1) * patch_size, :] = patch
+            idx += 1
+    name = f"Macbeth {illum.name}" if illum.name else "Macbeth"
+    return Scene(photons=photons, wave=wave, name=name)
+
+
+def scene_wb_create(
+    scene: Optional[Scene] = None,
+    work_dir: Optional[str | Path] = None,
+    *,
+    patch_size: int = 16,
+    illuminant: str = "D65",
+) -> List[Path]:
+    """Write ``scene`` as a series of single-wavelength MAT-files.
+
+    When ``scene`` is omitted, a Macbeth ColorChecker is generated using the
+    specified ``patch_size`` and ``illuminant`` before splitting.
+
+    Parameters
+    ----------
+    scene : Scene, optional
+        Scene to split. If ``None``, a Macbeth chart is created.
+    work_dir : str or Path, optional
+        Destination directory for the files. If not provided, a directory named
+        after the scene is created in the current working directory.
+    patch_size : int, optional
+        Size of each Macbeth patch when creating the default scene.
+    illuminant : str, optional
+        Illuminant name used when creating the default scene. ``"D65"`` is the
+        default.
+
+    Returns
+    -------
+    list of Path
+        Paths to the MAT-files created.
+    """
+
+    if scene is None:
+        scene = _default_scene(patch_size, illuminant)
+    if not isinstance(scene, Scene):
+        raise TypeError("scene must be a Scene")
+
+    if work_dir is None:
+        name = scene.name or "scene"
+        work_dir = Path.cwd() / name.replace(" ", "_")
+    else:
+        work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    paths: List[Path] = []
+    for idx, w in enumerate(scene.wave):
+        sub = Scene(
+            photons=scene.photons[:, :, idx:idx + 1].copy(),
+            wave=np.array([float(w)], dtype=float),
+            name=scene.name,
+        )
+        fname = f"scene{int(round(float(w)))}.mat"
+        path = work_dir / fname
+        savemat(str(path), {"scene": {"photons": sub.photons, "wave": sub.wave}})
+        paths.append(path)
+    return paths

--- a/python/tests/test_scene_wb_create.py
+++ b/python/tests/test_scene_wb_create.py
@@ -1,0 +1,30 @@
+import numpy as np
+from scipy.io import loadmat
+
+from isetcam.scene import scene_wb_create, Scene
+
+
+def test_scene_wb_create_basic(tmp_path):
+    wave = np.array([500, 510])
+    photons = np.arange(8).reshape(2, 2, 2).astype(float)
+    scene = Scene(photons=photons, wave=wave, name="test")
+    paths = scene_wb_create(scene, tmp_path)
+    assert len(paths) == 2
+    for p, w in zip(paths, wave):
+        assert p.exists()
+        data = loadmat(p)
+        sc = data["scene"]
+        assert sc["wave"].ravel()[0] == w
+        saved = sc["photons"]
+        assert saved.shape == (2, 2, 1)
+        assert np.allclose(saved.squeeze(), photons[:, :, np.where(wave == w)[0][0]])
+
+
+def test_scene_wb_create_default_scene(tmp_path):
+    paths = scene_wb_create(work_dir=tmp_path, patch_size=2, illuminant="D65")
+    # D65 data has 107 wavelengths
+    assert len(paths) == 107
+    sample = loadmat(paths[0])
+    sc = sample["scene"]
+    assert sc["photons"].shape[0] == 8  # 4 rows * patch_size
+    assert sc["photons"].shape[1] == 12  # 6 cols * patch_size


### PR DESCRIPTION
## Summary
- port `sceneWBCreate.m` as `scene_wb_create` with extra options
- export new helper from `scene/__init__.py`
- test waveband file creation

## Testing
- `python3 -m py_compile python/isetcam/scene/scene_wb_create.py python/tests/test_scene_wb_create.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'isetcam')*
- `pip install -e python flake8` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_683acba50fc48323b612bf5922a9f812