### PR TITLE
Add illuminant_list helper

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -120,6 +120,7 @@ from .illuminant import (
     illuminant_from_file,
     illuminant_get,
     illuminant_set,
+    illuminant_list,
 )
 from .io import openexr_read, openexr_write, pfm_read, pfm_write, dng_read, dng_write
 
@@ -235,6 +236,7 @@ __all__ = [
     'illuminant_from_file',
     'illuminant_get',
     'illuminant_set',
+    'illuminant_list',
     'camera_to_file',
     'camera_from_file',
     'camera_plot',

--- a/python/isetcam/illuminant/__init__.py
+++ b/python/isetcam/illuminant/__init__.py
@@ -7,6 +7,7 @@ from .illuminant_from_file import illuminant_from_file
 from .illuminant_to_file import illuminant_to_file
 from .illuminant_get import illuminant_get
 from .illuminant_set import illuminant_set
+from .illuminant_list import illuminant_list
 
 __all__ = [
     "Illuminant",
@@ -16,4 +17,5 @@ __all__ = [
     "illuminant_to_file",
     "illuminant_get",
     "illuminant_set",
+    "illuminant_list",
 ]

--- a/python/isetcam/illuminant/illuminant_list.py
+++ b/python/isetcam/illuminant/illuminant_list.py
@@ -1,0 +1,25 @@
+"""List available illuminant spectral data files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..data_path import data_path
+
+
+def illuminant_list() -> list[str]:
+    """Return available illuminant names.
+
+    The names correspond to ``.mat`` files under ``data/lights`` in the
+    ISETCam repository. The returned list is sorted alphabetically and the
+    ``.mat`` extension is stripped.
+    """
+    illum_dir = data_path("lights")
+    names: list[str] = []
+    if illum_dir.exists():
+        for f in illum_dir.glob("*.mat"):
+            names.append(Path(f).stem)
+    return sorted(names)
+
+
+__all__ = ["illuminant_list"]

--- a/python/tests/test_illuminant_list.py
+++ b/python/tests/test_illuminant_list.py
@@ -1,0 +1,8 @@
+from isetcam.illuminant import illuminant_list
+
+
+def test_illuminant_list_contains_sample():
+    names = illuminant_list()
+    assert isinstance(names, list)
+    assert "D65" in names
+    assert all(isinstance(n, str) for n in names)


### PR DESCRIPTION
## Summary
- support listing sample illuminant files in `data/lights`
- expose `illuminant_list` from `illuminant` and `isetcam` packages
- test that a known illuminant (D65) is included in the list

## Testing
- `PYTHONPATH=python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683af0f796d883239d71ff6150a6f600