### PR TITLE
Add sensor_show_image utility

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -19,6 +19,7 @@ from .sensor_crop import sensor_crop
 from .sensor_plot import sensor_plot
 from .sensor_ccm import sensor_ccm
 from .sensor_dng_read import sensor_dng_read
+from .sensor_show_image import sensor_show_image
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -67,4 +68,5 @@ __all__ = [
     "sensor_plot",
     "sensor_ccm",
     "sensor_dng_read",
+    "sensor_show_image",
 ]

--- a/python/tests/test_sensor_show_image.py
+++ b/python/tests/test_sensor_show_image.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.sensor import Sensor, sensor_show_image
+from isetcam.display import Display
+
+
+def _matplotlib_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_sensor_show_image_runs():
+    volts = np.array([[[0.2, 0.4, 0.6]]], dtype=float)
+    wave = np.array([500, 600, 700])
+    sensor = Sensor(volts=volts, wave=wave, exposure_time=0.01)
+    disp = Display(spd=np.eye(3), wave=wave, gamma=None)
+    ax = sensor_show_image(sensor, disp)
+    assert ax is not None


### PR DESCRIPTION
## Summary
- add `sensor_show_image` for visualising sensor volts
- export the new helper in `sensor/__init__`
- test `sensor_show_image`

## Testing
- `PYTHONPATH=$PWD/python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683af2f3d46c832394dfd2522b9638cb