### PR TITLE
Add IP file save/load helpers

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -122,6 +122,7 @@ from .illuminant import (
     illuminant_set,
     illuminant_list,
 )
+from .ip import ip_to_file, ip_from_file
 from .io import openexr_read, openexr_write, pfm_read, pfm_write, dng_read, dng_write
 
 __all__ = [
@@ -243,6 +244,8 @@ __all__ = [
     'camera_moire',
     'optics_to_file',
     'optics_from_file',
+    'ip_to_file',
+    'ip_from_file',
     'openexr_read',
     'openexr_write',
     'pfm_read',

--- a/python/isetcam/ip/__init__.py
+++ b/python/isetcam/ip/__init__.py
@@ -5,6 +5,8 @@ from .ip_create import ip_create
 from .ip_compute import ip_compute
 from .ip_get import ip_get
 from .ip_set import ip_set
+from .ip_to_file import ip_to_file
+from .ip_from_file import ip_from_file
 
 __all__ = [
     "VCImage",
@@ -12,4 +14,6 @@ __all__ = [
     "ip_compute",
     "ip_get",
     "ip_set",
+    "ip_to_file",
+    "ip_from_file",
 ]

--- a/python/isetcam/ip/ip_from_file.py
+++ b/python/isetcam/ip/ip_from_file.py
@@ -1,0 +1,31 @@
+"""Load a :class:`VCImage` from a MATLAB ``.mat`` file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from scipy.io import loadmat
+
+from .vcimage_class import VCImage
+
+
+def ip_from_file(path: str | Path) -> VCImage:
+    """Load ``path`` and return a :class:`VCImage`.
+
+    Parameters
+    ----------
+    path : str or Path
+        MAT-file containing ``rgb`` and ``wave`` variables.
+    """
+    mat = loadmat(str(Path(path)), squeeze_me=True, struct_as_record=False)
+    if "rgb" not in mat or "wave" not in mat:
+        raise KeyError("File must contain 'rgb' and 'wave'")
+
+    rgb = np.asarray(mat["rgb"], dtype=float)
+    wave = np.asarray(mat["wave"], dtype=float).reshape(-1)
+    name = mat.get("name")
+    if isinstance(name, np.ndarray):
+        name = str(name.squeeze())
+
+    return VCImage(rgb=rgb, wave=wave, name=name)

--- a/python/isetcam/ip/ip_to_file.py
+++ b/python/isetcam/ip/ip_to_file.py
@@ -1,0 +1,24 @@
+"""Utilities for saving :class:`VCImage` objects to disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scipy.io import savemat
+
+from .vcimage_class import VCImage
+
+
+def ip_to_file(ip: VCImage, path: str | Path) -> None:
+    """Save ``ip`` to ``path`` as a MATLAB ``.mat`` file.
+
+    The RGB data and wavelength samples are stored using the variables
+    ``rgb`` and ``wave``.  When present, the ``name`` field is also saved.
+    """
+    data = {
+        "rgb": ip.rgb,
+        "wave": ip.wave,
+    }
+    if getattr(ip, "name", None) is not None:
+        data["name"] = ip.name
+    savemat(str(Path(path)), data)

--- a/python/tests/test_ip_file_io.py
+++ b/python/tests/test_ip_file_io.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from isetcam.ip import VCImage, ip_to_file, ip_from_file
+
+
+def test_ip_file_roundtrip(tmp_path):
+    ip = VCImage(rgb=np.ones((2, 2, 3)), wave=np.array([500, 510, 520]), name="demo")
+    path = tmp_path / "ip.mat"
+    ip_to_file(ip, path)
+
+    loaded = ip_from_file(path)
+    assert isinstance(loaded, VCImage)
+    assert np.allclose(loaded.rgb, ip.rgb)
+    assert np.array_equal(loaded.wave, ip.wave)
+    assert loaded.name == ip.name


### PR DESCRIPTION
## Summary
- save and load VCImage objects from MAT-files
- expose ip_from_file and ip_to_file via package init
- re-export at top level
- test round-trip for VCImage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683af54c5cec832387f234dbbd93375f