### PR TITLE
Add PSF/OTF utilities

### DIFF
--- a/python/isetcam/optics/__init__.py
+++ b/python/isetcam/optics/__init__.py
@@ -6,6 +6,8 @@ from .optics_set import optics_set
 from .optics_create import optics_create
 from .optics_to_file import optics_to_file
 from .optics_from_file import optics_from_file
+from .optics_psf import optics_psf
+from .optics_otf import optics_otf
 
 __all__ = [
     "Optics",
@@ -14,4 +16,6 @@ __all__ = [
     "optics_create",
     "optics_to_file",
     "optics_from_file",
+    "optics_psf",
+    "optics_otf",
 ]

--- a/python/isetcam/optics/optics_otf.py
+++ b/python/isetcam/optics/optics_otf.py
@@ -1,0 +1,35 @@
+"""Convert an optical transfer function (OTF) to a point spread function (PSF)."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.fft import ifft2, fftshift
+
+
+_DEF_ATOL = 1e-12
+
+
+def optics_otf(otf: np.ndarray) -> np.ndarray:
+    """Return the spatial PSF derived from ``otf``.
+
+    ``otf`` should have the zero frequency component at index ``(0, 0)``.
+    The returned PSF is centered and real valued. Energy is preserved so
+    that the PSF sums to one.
+    """
+    otf = np.asarray(otf)
+    if otf.ndim < 2:
+        raise ValueError("otf must have at least 2 dimensions")
+
+    out = np.zeros(otf.shape, dtype=float)
+    if otf.ndim == 2:
+        psf = fftshift(ifft2(otf))
+        psf = np.real(psf)
+        psf /= np.sum(psf)
+        out = psf
+    else:
+        for i in range(otf.shape[-1]):
+            psf = fftshift(ifft2(otf[..., i]))
+            psf = np.real(psf)
+            psf /= np.sum(psf)
+            out[..., i] = psf
+    return out

--- a/python/isetcam/optics/optics_psf.py
+++ b/python/isetcam/optics/optics_psf.py
@@ -1,0 +1,32 @@
+"""Convert a point spread function (PSF) to an optical transfer function (OTF)."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.fft import fft2, ifftshift
+
+
+_DEF_ATOL = 1e-12
+
+
+def optics_psf(psf: np.ndarray) -> np.ndarray:
+    """Return the frequency domain OTF of ``psf``.
+
+    The PSF is assumed to be centered. The returned OTF has the zero
+    frequency component at the (0, 0) index, following the ISETCam
+    convention. Energy is preserved so that ``otf[0, 0]`` equals one.
+    """
+    psf = np.asarray(psf, dtype=float)
+    if psf.ndim < 2:
+        raise ValueError("psf must have at least 2 dimensions")
+
+    out = np.zeros(psf.shape, dtype=complex)
+    if psf.ndim == 2:
+        psf2 = psf / np.sum(psf)
+        out = fft2(ifftshift(psf2))
+    else:
+        for i in range(psf.shape[-1]):
+            plane = psf[..., i]
+            plane = plane / np.sum(plane)
+            out[..., i] = fft2(ifftshift(plane))
+    return out

--- a/python/tests/test_optics_psf_otf.py
+++ b/python/tests/test_optics_psf_otf.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from isetcam.optics import optics_psf, optics_otf
+
+
+def _gaussian_psf(size: int, sigma: float) -> np.ndarray:
+    ax = np.linspace(-(size // 2), size // 2, size)
+    xx, yy = np.meshgrid(ax, ax)
+    psf = np.exp(-(xx ** 2 + yy ** 2) / (2 * sigma ** 2))
+    psf /= psf.sum()
+    return psf
+
+
+def test_psf_otf_roundtrip():
+    psf = _gaussian_psf(32, 3.0)
+    otf = optics_psf(psf)
+    recon = optics_otf(otf)
+    assert np.allclose(recon, psf, atol=1e-12)
+    assert np.isclose(np.real(otf[0, 0]), 1.0, atol=1e-12)


### PR DESCRIPTION
## Summary
- port opticsPSF.m and opticsOTF.m as Python helpers
- expose the new helpers from the optics package
- test round‑trip PSF/OTF conversion using FFTs

## Testing
- `PYTHONPATH=python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683af7eff6b88323bbed99839b11239b