### PR TITLE
Add vc_delete_object

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -35,6 +35,7 @@ from .vc_add_and_select_object import vc_add_and_select_object
 from .vc_get_object import vc_get_object
 from .vc_replace_object import vc_replace_object
 from .vc_replace_and_select_object import vc_replace_and_select_object
+from .vc_delete_object import vc_delete_object
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 from .xyz_to_lab import xyz_to_lab
@@ -258,4 +259,5 @@ __all__ = [
     'vc_get_object',
     'vc_replace_object',
     'vc_replace_and_select_object',
+    'vc_delete_object',
 ]

--- a/python/isetcam/vc_delete_object.py
+++ b/python/isetcam/vc_delete_object.py
@@ -1,0 +1,54 @@
+"""Delete an object stored in ``vcSESSION``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_delete_object(obj_type: str, index: Optional[int] = None) -> int:
+    """Remove an object from ``vcSESSION``.
+
+    Parameters
+    ----------
+    obj_type : str
+        Object type to remove (e.g. ``'scene'`` or ``'sensor'``).
+    index : int, optional
+        1-based index of the object.  When omitted the currently selected
+        object of ``obj_type`` is deleted.
+
+    Returns
+    -------
+    int
+        The number of remaining objects of ``obj_type``.
+    """
+    field = _norm_objtype(obj_type)
+
+    if index is None:
+        index = vcSESSION.get("SELECTED", {}).get(field)
+        if index is None:
+            return 0
+
+    lst = vcSESSION.get(field)
+    if not lst or index <= 0 or index >= len(lst):
+        raise IndexError("Index out of range")
+
+    lst.pop(index)
+    vcSESSION[field] = lst
+
+    remaining = len(lst) - 1
+
+    selected = vcSESSION.setdefault("SELECTED", {})
+    cur_sel = selected.get(field)
+    if cur_sel is not None:
+        if cur_sel == index:
+            if remaining == 0:
+                selected[field] = []
+            else:
+                selected[field] = min(index - 1, remaining)
+        elif cur_sel > index:
+            selected[field] = cur_sel - 1
+
+    return remaining

--- a/python/tests/test_vc_object_management.py
+++ b/python/tests/test_vc_object_management.py
@@ -6,6 +6,7 @@ from isetcam import (
     vc_get_object,
     vc_replace_object,
     vc_replace_and_select_object,
+    vc_delete_object,
 )
 from isetcam.scene import Scene
 from isetcam.ie_init_session import vcSESSION
@@ -41,4 +42,30 @@ def test_vc_replace_and_select_object():
     assert out == idx
     assert vc_get_object("scene", idx) is sc2
     assert vcSESSION["SELECTED"]["SCENE"] == idx
+
+
+def test_vc_delete_object():
+    ie_init()
+    sc1 = Scene(photons=np.zeros((1, 1, 1)))
+    sc2 = Scene(photons=np.ones((1, 1, 1)))
+    idx1 = vc_add_and_select_object("scene", sc1)
+    idx2 = vc_add_and_select_object("scene", sc2)
+
+    remaining = vc_delete_object("scene", idx1)
+    assert remaining == 1
+    assert vc_get_object("scene", 1) is sc2
+    assert vcSESSION["SELECTED"]["SCENE"] == 1
+
+
+def test_vc_delete_selected_object():
+    ie_init()
+    sc1 = Scene(photons=np.zeros((1, 1, 1)))
+    sc2 = Scene(photons=np.ones((1, 1, 1)))
+    vc_add_and_select_object("scene", sc1)
+    vc_add_and_select_object("scene", sc2)
+
+    remaining = vc_delete_object("scene")
+    assert remaining == 1
+    assert vc_get_object("scene", 1) is sc1
+    assert vcSESSION["SELECTED"]["SCENE"] == 1
 


### PR DESCRIPTION
## Summary
- implement `vc_delete_object` to remove an item from `vcSESSION`
- export the new helper in `__init__`
- test deleting stored objects

## Testing
- `pytest -q python/tests/test_vc_object_management.py -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b0689d9fc8323b8b7ab2670771b5a