### PR TITLE
Add sensor_rotate

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -20,6 +20,7 @@ from .sensor_plot import sensor_plot
 from .sensor_ccm import sensor_ccm
 from .sensor_dng_read import sensor_dng_read
 from .sensor_show_image import sensor_show_image
+from .sensor_rotate import sensor_rotate
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -69,4 +70,5 @@ __all__ = [
     "sensor_ccm",
     "sensor_dng_read",
     "sensor_show_image",
+    "sensor_rotate",
 ]

--- a/python/isetcam/sensor/sensor_rotate.py
+++ b/python/isetcam/sensor/sensor_rotate.py
@@ -1,0 +1,43 @@
+"""Rotate the voltage data of a :class:`Sensor`."""
+
+from __future__ import annotations
+
+from scipy.ndimage import rotate as nd_rotate
+
+from .sensor_class import Sensor
+
+
+def sensor_rotate(sensor: Sensor, angle: float, fill: float = 0) -> Sensor:
+    """Rotate ``sensor`` by ``angle`` degrees.
+
+    Parameters
+    ----------
+    sensor : Sensor
+        Input sensor to rotate.
+    angle : float
+        Rotation angle in degrees. Positive values rotate counter-clockwise.
+    fill : float, optional
+        Value used to fill areas created by the rotation. Defaults to ``0``.
+
+    Returns
+    -------
+    Sensor
+        New sensor containing the rotated voltage data with the same
+        wavelength samples and name.
+    """
+
+    rotated = nd_rotate(
+        sensor.volts,
+        angle,
+        axes=(1, 0),
+        reshape=True,
+        order=1,
+        mode="constant",
+        cval=float(fill),
+    )
+    return Sensor(
+        volts=rotated,
+        wave=sensor.wave,
+        exposure_time=sensor.exposure_time,
+        name=sensor.name,
+    )

--- a/python/tests/test_sensor_rotate.py
+++ b/python/tests/test_sensor_rotate.py
@@ -1,0 +1,36 @@
+import numpy as np
+from scipy.ndimage import rotate as nd_rotate
+
+from isetcam.sensor import Sensor, sensor_rotate
+
+
+def _simple_sensor(width: int = 3, height: int = 3) -> Sensor:
+    volts = np.arange(width * height, dtype=float).reshape(height, width)
+    return Sensor(volts=volts, wave=np.array([500]), exposure_time=0.01, name="simple")
+
+
+def test_sensor_rotate_90():
+    s = _simple_sensor(2, 3)
+    out = sensor_rotate(s, 90)
+    expected = np.rot90(s.volts, axes=(0, 1))
+    assert np.array_equal(out.volts, expected)
+    assert np.array_equal(out.wave, s.wave)
+    assert out.name == s.name
+
+
+def test_sensor_rotate_general():
+    s = _simple_sensor(3, 3)
+    angle = 30
+    out = sensor_rotate(s, angle, fill=-1)
+    expected = nd_rotate(
+        s.volts,
+        angle,
+        axes=(1, 0),
+        reshape=True,
+        order=1,
+        mode="constant",
+        cval=-1,
+    )
+    assert np.allclose(out.volts, expected)
+    assert np.array_equal(out.wave, s.wave)
+    assert out.name == s.name


### PR DESCRIPTION
## Summary
- add `sensor_rotate` for rotating sensor volts
- expose `sensor_rotate` in sensor API
- test rotating Sensor objects

## Testing
- `PYTHONPATH=python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b0e1146fc8323a740d301711c2a7a