### PR TITLE
Add scene_spd_scale utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -16,6 +16,7 @@ from .scene_pad import scene_pad
 from .scene_insert import scene_insert
 from .scene_translate import scene_translate
 from .scene_rotate import scene_rotate
+from .scene_spd_scale import scene_spd_scale
 from .scene_spatial_support import scene_spatial_support
 from .scene_spatial_resample import scene_spatial_resample
 from .scene_frequency_support import scene_frequency_support
@@ -52,6 +53,7 @@ __all__ = [
     "scene_insert",
     "scene_translate",
     "scene_rotate",
+    "scene_spd_scale",
     "scene_spatial_support",
     "scene_spatial_resample",
     "scene_frequency_support",

--- a/python/isetcam/scene/scene_spd_scale.py
+++ b/python/isetcam/scene/scene_spd_scale.py
@@ -1,0 +1,35 @@
+"""Scale the spectral power distribution of a scene."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def scene_spd_scale(scene: Scene, scale: float) -> Scene:
+    """Multiply the photon data of ``scene`` by ``scale``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene whose photons will be scaled.
+    scale : float
+        Multiplicative factor applied to the photons.
+
+    Returns
+    -------
+    Scene
+        New scene with scaled photons. The name is updated to reflect the
+        scaling factor.
+    """
+
+    photons = np.asarray(scene.photons, dtype=float)
+    scaled_photons = photons * float(scale)
+
+    if scene.name:
+        name = f"{scene.name} x{scale}" if scale != 1 else scene.name
+    else:
+        name = None
+
+    return Scene(photons=scaled_photons, wave=scene.wave, name=name)

--- a/python/tests/test_scene_spd_scale.py
+++ b/python/tests/test_scene_spd_scale.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_spd_scale
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([500, 510])
+    photons = np.arange(8, dtype=float).reshape((2, 2, 2))
+    return Scene(photons=photons, wave=wave, name="orig")
+
+
+def test_scene_spd_scale_basic():
+    sc = _simple_scene()
+    scale = 2.5
+    out = scene_spd_scale(sc, scale)
+    assert np.allclose(out.photons, sc.photons * scale)
+    assert np.array_equal(out.wave, sc.wave)
+    assert out.name != sc.name
+    assert str(scale) in out.name


### PR DESCRIPTION
## Summary
- add `scene_spd_scale` to scale photons and annotate the scene name
- expose `scene_spd_scale` in the scene module
- add regression tests for the new function

## Testing
- `PYTHONPATH=python pytest -q`
- `PYTHONPATH=python pytest python/tests/test_scene_spd_scale.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683b10662bc48323b9069220729480e0