### PR TITLE
Add optical image creation helper

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -6,6 +6,7 @@ from .oi_add import oi_add
 from .oi_get import oi_get
 from .oi_set import oi_set
 from .oi_from_file import oi_from_file
+from .oi_create import oi_create
 from .oi_compute import oi_compute
 from .oi_photon_noise import oi_photon_noise
 from .oi_to_file import oi_to_file
@@ -35,6 +36,7 @@ __all__ = [
     "oi_get",
     "oi_set",
     "oi_from_file",
+    "oi_create",
     "oi_compute",
     "oi_crop",
     "oi_pad",

--- a/python/isetcam/opticalimage/oi_create.py
+++ b/python/isetcam/opticalimage/oi_create.py
@@ -1,0 +1,44 @@
+"""Create a simple :class:`OpticalImage` with uniform photons."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+_DEF_SIZE = 128
+_DEF_WAVE = np.arange(400, 701, 10, dtype=float)
+
+
+def oi_create(
+    name: Optional[str] = None,
+    size: int = _DEF_SIZE,
+    wave: Optional[np.ndarray] = None,
+) -> OpticalImage:
+    """Return a uniform :class:`OpticalImage`.
+
+    Parameters
+    ----------
+    name:
+        Optional name for the optical image.
+    size:
+        Spatial dimension in pixels for the square photon data.
+    wave:
+        Optional wavelength samples. Defaults to 400--700 nm in 10 nm steps.
+    """
+    if size <= 0:
+        raise ValueError("size must be positive")
+
+    if wave is None:
+        wave_arr = _DEF_WAVE
+    else:
+        wave_arr = np.asarray(wave, dtype=float).reshape(-1)
+
+    photons = np.ones((size, size, wave_arr.size), dtype=float)
+    return OpticalImage(photons=photons, wave=wave_arr, name=name)
+
+
+__all__ = ["oi_create"]

--- a/python/tests/test_oi_create.py
+++ b/python/tests/test_oi_create.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from isetcam.opticalimage import oi_create, OpticalImage
+
+
+def test_oi_create_default():
+    oi = oi_create()
+    assert isinstance(oi, OpticalImage)
+    assert oi.photons.shape == (128, 128, oi.wave.size)
+    assert np.allclose(oi.photons, 1.0)
+
+
+def test_oi_create_custom():
+    wave = np.array([500, 510, 520])
+    oi = oi_create(name="demo", size=4, wave=wave)
+    assert oi.name == "demo"
+    assert np.array_equal(oi.wave, wave)
+    assert oi.photons.shape == (4, 4, wave.size)
+    assert np.allclose(oi.photons, 1.0)


### PR DESCRIPTION
## Summary
- implement `oi_create` to generate a uniform optical image
- export `oi_create` from the opticalimage package
- test default and custom behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b6c23ad48832387d9000f92201da7