### PR TITLE
Add basic plotting utilities for Python modules

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -98,7 +98,7 @@ from .human import (
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
 from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip  # noqa: E501
-from .opticalimage import oi_to_file
+from .opticalimage import oi_to_file, oi_plot
 from .sensor import sensor_to_file
 from .display import (
     display_to_file,
@@ -117,6 +117,7 @@ from .camera import (
     camera_moire,
 )
 from .optics import optics_to_file, optics_from_file
+from .scene import scene_plot
 from .illuminant import (
     illuminant_to_file,
     illuminant_from_file,
@@ -124,7 +125,7 @@ from .illuminant import (
     illuminant_set,
     illuminant_list,
 )
-from .ip import ip_to_file, ip_from_file
+from .ip import ip_to_file, ip_from_file, ip_plot
 from .io import openexr_read, openexr_write, pfm_read, pfm_write, dng_read, dng_write
 
 __all__ = [
@@ -245,10 +246,13 @@ __all__ = [
     'camera_from_file',
     'camera_plot',
     'camera_moire',
+    'scene_plot',
+    'oi_plot',
     'optics_to_file',
     'optics_from_file',
     'ip_to_file',
     'ip_from_file',
+    'ip_plot',
     'openexr_read',
     'openexr_write',
     'pfm_read',

--- a/python/isetcam/ip/__init__.py
+++ b/python/isetcam/ip/__init__.py
@@ -7,6 +7,7 @@ from .ip_get import ip_get
 from .ip_set import ip_set
 from .ip_to_file import ip_to_file
 from .ip_from_file import ip_from_file
+from .ip_plot import ip_plot
 
 __all__ = [
     "VCImage",
@@ -16,4 +17,5 @@ __all__ = [
     "ip_set",
     "ip_to_file",
     "ip_from_file",
+    "ip_plot",
 ]

--- a/python/isetcam/ip/ip_plot.py
+++ b/python/isetcam/ip/ip_plot.py
@@ -1,0 +1,96 @@
+"""Basic IP plotting utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - matplotlib might not be installed
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Rectangle
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+    Rectangle = None  # type: ignore
+
+from .vcimage_class import VCImage
+from ..ie_param_format import ie_param_format
+
+
+_DEF_KINDS = {
+    "horizontallineluminance",
+    "verticallineluminance",
+    "image",
+    "imagewithgrid",
+}
+
+
+def _compute_luminance(rgb: np.ndarray) -> np.ndarray:
+    coeffs = np.array([0.2126, 0.7152, 0.0722])
+    return np.tensordot(rgb, coeffs, axes=([2], [0]))
+
+
+def ip_plot(
+    ip: VCImage,
+    kind: str = "horizontallineluminance",
+    loc: int | None = None,
+    *,
+    grid_spacing: int | None = None,
+    roi: tuple[int, int, int, int] | None = None,
+    ax: "plt.Axes | None" = None,
+) -> "plt.Axes":
+    """Plot properties of ``ip`` similar to MATLAB ``ipPlot``."""
+    if plt is None:
+        raise ImportError("matplotlib is required for ip_plot")
+
+    key = ie_param_format(kind)
+    if key not in _DEF_KINDS:
+        raise ValueError(f"Unknown plot kind '{kind}'")
+
+    rgb = np.asarray(ip.rgb, dtype=float)
+    rows, cols = rgb.shape[:2]
+
+    if key in {"horizontallineluminance", "verticallineluminance"}:
+        lum = _compute_luminance(rgb)
+        if key == "horizontallineluminance":
+            r = rows // 2 if loc is None else int(loc)
+            profile = lum[r, :]
+            pos = np.arange(cols)
+            xlabel = "Column index"
+        else:
+            c = cols // 2 if loc is None else int(loc)
+            profile = lum[:, c]
+            pos = np.arange(rows)
+            xlabel = "Row index"
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.figure
+        ax.plot(pos, profile, "b-")
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel("Luminance (a.u.)")
+        fig.tight_layout()
+        return ax
+
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = ax.figure
+    img = np.clip(rgb, 0.0, 1.0)
+    ax.imshow(img)
+    ax.axis("off")
+
+    if grid_spacing is not None:
+        g = int(grid_spacing)
+        for r in range(0, rows, g):
+            ax.axhline(r - 0.5, color="k", linewidth=0.5)
+        for c in range(0, cols, g):
+            ax.axvline(c - 0.5, color="k", linewidth=0.5)
+    if roi is not None and Rectangle is not None:
+        r0, c0, h, w = [int(v) for v in roi]
+        rect = Rectangle((c0, r0), w, h, edgecolor="y", facecolor="none", linewidth=1)
+        ax.add_patch(rect)
+
+    fig.tight_layout()
+    return ax
+
+
+__all__ = ["ip_plot"]

--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -26,6 +26,7 @@ from .oi_save_image import oi_save_image
 from .oi_thumbnail import oi_thumbnail
 from .oi_illuminant_pattern import oi_illuminant_pattern
 from .oi_illuminant_ss import oi_illuminant_ss
+from .oi_plot import oi_plot
 
 __all__ = [
     "OpticalImage",
@@ -52,6 +53,7 @@ __all__ = [
     "oi_calculate_irradiance",
     "oi_calculate_illuminance",
     "oi_show_image",
+    "oi_plot",
     "oi_save_image",
     "oi_thumbnail",
     "oi_illuminant_pattern",

--- a/python/isetcam/opticalimage/oi_plot.py
+++ b/python/isetcam/opticalimage/oi_plot.py
@@ -1,0 +1,141 @@
+"""Basic optical image plotting utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - matplotlib might not be installed
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Rectangle
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+    Rectangle = None  # type: ignore
+
+from .oi_class import OpticalImage
+from ..ie_param_format import ie_param_format
+from ..opticalimage.oi_calculate_illuminance import oi_calculate_illuminance
+from ..opticalimage.oi_calculate_irradiance import oi_calculate_irradiance
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+from ..display import Display, display_create, display_render, display_apply_gamma
+from ..rgb_to_xw_format import rgb_to_xw_format
+from ..xw_to_rgb_format import xw_to_rgb_format
+
+
+_DEF_KINDS = {
+    "illuminancehline",
+    "illuminancevline",
+    "irradiancehline",
+    "irradiancevline",
+    "irradianceimage",
+    "irradianceimagewithgrid",
+}
+
+
+def _photons_to_srgb(oi: OpticalImage, display: Display) -> np.ndarray:
+    photons = np.asarray(oi.photons, dtype=float)
+    spd = np.asarray(display.spd, dtype=float)
+    xw, rows, cols = rgb_to_xw_format(photons)
+    rgb_lin = xw @ np.linalg.pinv(spd)
+    if display.gamma is not None:
+        rgb = display_apply_gamma(rgb_lin, display, inverse=True)
+    else:
+        rgb = rgb_lin
+    rgb = xw_to_rgb_format(rgb, rows, cols)
+    spectral = display_render(rgb, display, apply_gamma=True)
+    xyz = ie_xyz_from_photons(spectral, display.wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    return np.clip(srgb, 0.0, 1.0)
+
+
+def oi_plot(
+    oi: OpticalImage,
+    kind: str = "illuminancehline",
+    loc: int | None = None,
+    *,
+    grid_spacing: int | None = None,
+    roi: tuple[int, int, int, int] | None = None,
+    display: Display | None = None,
+    ax: "plt.Axes | None" = None,
+) -> "plt.Axes":
+    """Plot properties of ``oi`` similar to MATLAB ``oiPlot``."""
+    if plt is None:
+        raise ImportError("matplotlib is required for oi_plot")
+
+    key = ie_param_format(kind)
+    if key not in _DEF_KINDS:
+        raise ValueError(f"Unknown plot kind '{kind}'")
+
+    rows, cols = oi.photons.shape[:2]
+
+    if key in {"illuminancehline", "illuminancevline"}:
+        illum = oi_calculate_illuminance(oi)
+        if key == "illuminancehline":
+            r = rows // 2 if loc is None else int(loc)
+            profile = illum[r, :]
+            pos = np.arange(cols)
+            xlabel = "Column index"
+        else:
+            c = cols // 2 if loc is None else int(loc)
+            profile = illum[:, c]
+            pos = np.arange(rows)
+            xlabel = "Row index"
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.figure
+        ax.plot(pos, profile, "r-")
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel("Illuminance (lux)")
+        fig.tight_layout()
+        return ax
+
+    if key in {"irradiancehline", "irradiancevline"}:
+        irr = oi_calculate_irradiance(oi)
+        if key == "irradiancehline":
+            r = rows // 2 if loc is None else int(loc)
+            profile = irr[r, :]
+            pos = np.arange(cols)
+            xlabel = "Column index"
+        else:
+            c = cols // 2 if loc is None else int(loc)
+            profile = irr[:, c]
+            pos = np.arange(rows)
+            xlabel = "Row index"
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.figure
+        ax.plot(pos, profile, "r-")
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel("Irradiance (photons)")
+        fig.tight_layout()
+        return ax
+
+    if display is None:
+        # Simple identity display matching the optical image wavelengths
+        display = Display(spd=np.eye(len(oi.wave)), wave=oi.wave, gamma=None)
+    img = _photons_to_srgb(oi, display)
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = ax.figure
+    ax.imshow(img)
+    ax.axis("off")
+
+    if grid_spacing is not None:
+        g = int(grid_spacing)
+        for r in range(0, rows, g):
+            ax.axhline(r - 0.5, color="k", linewidth=0.5)
+        for c in range(0, cols, g):
+            ax.axvline(c - 0.5, color="k", linewidth=0.5)
+    if roi is not None and Rectangle is not None:
+        r0, c0, h, w = [int(v) for v in roi]
+        rect = Rectangle((c0, r0), w, h, edgecolor="y", facecolor="none", linewidth=1)
+        ax.add_patch(rect)
+
+    fig.tight_layout()
+    return ax
+
+
+__all__ = ["oi_plot"]

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -35,6 +35,7 @@ from .scene_depth_overlay import scene_depth_overlay
 from .scene_depth_range import scene_depth_range
 from .scene_list import scene_list
 from .scene_wb_create import scene_wb_create
+from .scene_plot import scene_plot
 
 __all__ = [
     "Scene",
@@ -66,6 +67,7 @@ __all__ = [
     "scene_combine",
     "scene_adjust_pixel_size",
     "scene_show_image",
+    "scene_plot",
     "scene_save_image",
     "scene_thumbnail",
     "scene_illuminant_pattern",

--- a/python/isetcam/scene/scene_plot.py
+++ b/python/isetcam/scene/scene_plot.py
@@ -1,0 +1,149 @@
+"""Basic scene plotting utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - matplotlib might not be installed
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Rectangle
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+    Rectangle = None  # type: ignore
+
+from .scene_class import Scene
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+from ..luminance_from_photons import luminance_from_photons
+from ..ie_param_format import ie_param_format
+
+
+_DEF_KINDS = {
+    "luminancehline",
+    "luminancevline",
+    "radiancehline",
+    "radiancevline",
+    "radianceimage",
+    "radianceimagewithgrid",
+}
+
+
+def scene_plot(
+    scene: Scene,
+    kind: str = "luminancehline",
+    loc: int | None = None,
+    *,
+    grid_spacing: int | None = None,
+    roi: tuple[int, int, int, int] | None = None,
+    ax: "plt.Axes | None" = None,
+) -> "plt.Axes":
+    """Plot various properties of ``scene``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Scene to visualize.
+    kind : str, optional
+        One of ``'luminance hline'``, ``'luminance vline'``,
+        ``'radiance hline'``, ``'radiance vline'``, ``'radiance image'`` or
+        ``'radiance image with grid'``.
+    loc : int, optional
+        Row or column index for line plots. Defaults to the image center.
+    grid_spacing : int, optional
+        Overlay grid lines with this spacing in pixels when plotting the image.
+    roi : tuple of int, optional
+        ``(row, col, height, width)`` rectangle to overlay on the image.
+    ax : matplotlib.axes.Axes, optional
+        Axis to plot into. When ``None`` a new figure and axis are created.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        Axis containing the plot.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for scene_plot")
+
+    key = ie_param_format(kind)
+    if key not in _DEF_KINDS:
+        raise ValueError(f"Unknown plot kind '{kind}'")
+
+    photons = np.asarray(scene.photons, dtype=float)
+    wave = np.asarray(scene.wave, dtype=float).reshape(-1)
+    rows, cols = photons.shape[:2]
+
+    if key in {"luminancehline", "luminancevline"}:
+        lum = luminance_from_photons(photons, wave)
+        if key == "luminancehline":
+            r = rows // 2 if loc is None else int(loc)
+            profile = lum[r, :]
+            pos = np.arange(cols)
+            xlabel = "Column index"
+        else:
+            c = cols // 2 if loc is None else int(loc)
+            profile = lum[:, c]
+            pos = np.arange(rows)
+            xlabel = "Row index"
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.figure
+        ax.plot(pos, profile, "k-")
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel("Luminance (cd/m$^2$)")
+        fig.tight_layout()
+        return ax
+
+    if key in {"radiancehline", "radiancevline"}:
+        if key == "radiancehline":
+            r = rows // 2 if loc is None else int(loc)
+            data = photons[r, :, :]
+            pos = np.arange(cols)
+            xlabel = "Column index"
+        else:
+            c = cols // 2 if loc is None else int(loc)
+            data = photons[:, c, :]
+            pos = np.arange(rows)
+            xlabel = "Row index"
+
+        if data.ndim == 1:
+            profile = data
+        else:
+            profile = data.mean(axis=1)
+        if ax is None:
+            fig, ax = plt.subplots()
+        else:
+            fig = ax.figure
+        ax.plot(pos, profile, "k-")
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel("Radiance (photons)")
+        fig.tight_layout()
+        return ax
+
+    # Image rendering
+    xyz = ie_xyz_from_photons(photons, wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    img = np.clip(srgb, 0.0, 1.0)
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = ax.figure
+    ax.imshow(img)
+    ax.axis("off")
+
+    if grid_spacing is not None:
+        g = int(grid_spacing)
+        for r in range(0, rows, g):
+            ax.axhline(r - 0.5, color="k", linewidth=0.5)
+        for c in range(0, cols, g):
+            ax.axvline(c - 0.5, color="k", linewidth=0.5)
+    if roi is not None and Rectangle is not None:
+        r0, c0, h, w = [int(v) for v in roi]
+        rect = Rectangle((c0, r0), w, h, edgecolor="y", facecolor="none", linewidth=1)
+        ax.add_patch(rect)
+
+    fig.tight_layout()
+    return ax
+
+
+__all__ = ["scene_plot"]

--- a/python/tests/test_ip_plot.py
+++ b/python/tests/test_ip_plot.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.ip import VCImage, ip_plot
+
+
+def _mpl_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _mpl_available(), reason="matplotlib not installed")
+def test_ip_plot_profiles():
+    ip = VCImage(rgb=np.ones((5, 6, 3)), wave=np.array([500, 600, 700]))
+    ax1 = ip_plot(ip, kind="horizontal line luminance", loc=2)
+    assert ax1 is not None
+    ax2 = ip_plot(ip, kind="vertical line luminance", loc=1)
+    assert ax2 is not None
+
+
+@pytest.mark.skipif(not _mpl_available(), reason="matplotlib not installed")
+def test_ip_plot_image_grid_roi():
+    ip = VCImage(rgb=np.ones((4, 4, 3)), wave=np.array([500, 600, 700]))
+    ax = ip_plot(ip, kind="image with grid", grid_spacing=2, roi=(1, 1, 2, 2))
+    assert ax is not None
+

--- a/python/tests/test_oi_plot.py
+++ b/python/tests/test_oi_plot.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.opticalimage import OpticalImage, oi_plot
+
+
+def _mpl_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _mpl_available(), reason="matplotlib not installed")
+def test_oi_plot_profiles():
+    oi = OpticalImage(photons=np.ones((5, 6, 3)), wave=np.array([500, 600, 700]))
+    ax1 = oi_plot(oi, kind="illuminance hline", loc=2)
+    assert ax1 is not None
+    ax2 = oi_plot(oi, kind="irradiance vline", loc=1)
+    assert ax2 is not None
+
+
+@pytest.mark.skipif(not _mpl_available(), reason="matplotlib not installed")
+def test_oi_plot_image_grid_roi():
+    oi = OpticalImage(photons=np.ones((4, 4, 3)), wave=np.array([500, 600, 700]))
+    ax = oi_plot(oi, kind="irradiance image with grid", grid_spacing=2, roi=(1, 1, 2, 2))
+    assert ax is not None
+

--- a/python/tests/test_scene_plot.py
+++ b/python/tests/test_scene_plot.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.scene import Scene, scene_plot
+
+
+def _mpl_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _mpl_available(), reason="matplotlib not installed")
+def test_scene_plot_profiles():
+    sc = Scene(photons=np.ones((5, 6, 3)), wave=np.array([500, 600, 700]))
+    ax1 = scene_plot(sc, kind="luminance hline", loc=2)
+    assert ax1 is not None
+    ax2 = scene_plot(sc, kind="radiance vline", loc=1)
+    assert ax2 is not None
+
+
+@pytest.mark.skipif(not _mpl_available(), reason="matplotlib not installed")
+def test_scene_plot_image_grid_roi():
+    sc = Scene(photons=np.ones((4, 4, 3)), wave=np.array([500, 600, 700]))
+    ax = scene_plot(sc, kind="radiance image with grid", grid_spacing=2, roi=(1, 1, 2, 2))
+    assert ax is not None
+


### PR DESCRIPTION
## Summary
- implement `scene_plot`, `oi_plot`, and `ip_plot` to display line profiles and images with optional overlays
- export plotting helpers through package `__init__` files
- re-export in top-level `isetcam` package
- test plotting functions with matplotlib

## Testing
- `pytest -q python/tests/test_scene_plot.py::test_scene_plot_profiles python/tests/test_oi_plot.py::test_oi_plot_image_grid_roi python/tests/test_ip_plot.py::test_ip_plot_profiles`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b72bffedc83239ab65614c7171818