### PR TITLE
Add vc_clear_objects helper

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -36,6 +36,7 @@ from .vc_get_object import vc_get_object
 from .vc_replace_object import vc_replace_object
 from .vc_replace_and_select_object import vc_replace_and_select_object
 from .vc_delete_object import vc_delete_object
+from .vc_clear_objects import vc_clear_objects
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 from .xyz_to_lab import xyz_to_lab
@@ -264,4 +265,5 @@ __all__ = [
     'vc_replace_object',
     'vc_replace_and_select_object',
     'vc_delete_object',
+    'vc_clear_objects',
 ]

--- a/python/isetcam/vc_clear_objects.py
+++ b/python/isetcam/vc_clear_objects.py
@@ -1,0 +1,30 @@
+"""Clear stored objects in ``vcSESSION``."""
+
+from __future__ import annotations
+
+from .ie_init_session import vcSESSION
+
+# Fields in ``vcSESSION`` that hold lists of objects
+_OBJECT_FIELDS = [
+    "SCENE",
+    "OPTICALIMAGE",
+    "ISA",
+    "VCIMAGE",
+    "DISPLAY",
+    "GRAPHWIN",
+    "CAMERA",
+]
+
+
+def vc_clear_objects() -> None:
+    """Remove all objects and reset selection indices."""
+
+    for field in _OBJECT_FIELDS:
+        if field == "GRAPHWIN":
+            vcSESSION[field] = []
+        else:
+            vcSESSION[field] = [None]
+
+    selected = vcSESSION.setdefault("SELECTED", {})
+    for field in _OBJECT_FIELDS:
+        selected[field] = []

--- a/python/tests/test_vc_object_management.py
+++ b/python/tests/test_vc_object_management.py
@@ -7,8 +7,13 @@ from isetcam import (
     vc_replace_object,
     vc_replace_and_select_object,
     vc_delete_object,
+    vc_clear_objects,
 )
 from isetcam.scene import Scene
+from isetcam.opticalimage import OpticalImage
+from isetcam.sensor import Sensor
+from isetcam.display import Display
+from isetcam.camera import camera_create
 from isetcam.ie_init_session import vcSESSION
 
 
@@ -68,4 +73,40 @@ def test_vc_delete_selected_object():
     assert remaining == 1
     assert vc_get_object("scene", 1) is sc1
     assert vcSESSION["SELECTED"]["SCENE"] == 1
+
+
+def test_vc_clear_objects():
+    ie_init()
+    sc = Scene(photons=np.zeros((1, 1, 1)))
+    oi = OpticalImage(photons=np.zeros((1, 1, 1)))
+    si = Sensor(volts=np.zeros((1, 1, 1)), exposure_time=0.01)
+    dp = Display(spd=np.zeros((1, 3)), wave=np.array([500, 600, 700]))
+    cam = camera_create(sensor=si)
+
+    vc_add_and_select_object("scene", sc)
+    vc_add_and_select_object("opticalimage", oi)
+    vc_add_and_select_object("sensor", si)
+    vc_add_and_select_object("display", dp)
+    vc_add_and_select_object("camera", cam)
+
+    vc_clear_objects()
+
+    assert vcSESSION["SCENE"] == [None]
+    assert vcSESSION["OPTICALIMAGE"] == [None]
+    assert vcSESSION["ISA"] == [None]
+    assert vcSESSION["VCIMAGE"] == [None]
+    assert vcSESSION["DISPLAY"] == [None]
+    assert vcSESSION["GRAPHWIN"] == []
+    assert vcSESSION["CAMERA"] == [None]
+
+    for fld in [
+        "SCENE",
+        "OPTICALIMAGE",
+        "ISA",
+        "VCIMAGE",
+        "DISPLAY",
+        "GRAPHWIN",
+        "CAMERA",
+    ]:
+        assert vcSESSION["SELECTED"][fld] == []
 


### PR DESCRIPTION
## Summary
- add `vc_clear_objects` to reset all object lists and selections
- export helper in `isetcam.__init__`
- extend object management tests to cover clearing

## Testing
- `PYTHONPATH=python pytest python/tests/test_vc_object_management.py -q`
- `PYTHONPATH=python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b76559c4c8323b0291ada41f4312a