### PR TITLE
Add ie_hist_image plotting utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -68,6 +68,7 @@ from .init_default_spectrum import init_default_spectrum
 from .mk_inv_gamma_table import mk_inv_gamma_table
 from .ie_cov_ellipsoid import ie_cov_ellipsoid
 from .ie_read_spectra import ie_read_spectra
+from .ie_hist_image import ie_hist_image
 from .imgproc import (
     image_distort,
     ie_internal_to_display,
@@ -187,6 +188,7 @@ __all__ = [
     'mk_inv_gamma_table',
     'ie_cov_ellipsoid',
     'ie_read_spectra',
+    'ie_hist_image',
     'ie_spectra_sphere',
     'image_distort',
     'ie_internal_to_display',

--- a/python/isetcam/ie_hist_image.py
+++ b/python/isetcam/ie_hist_image.py
@@ -1,0 +1,69 @@
+"""Image histogram plotting utility."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - matplotlib might not be installed
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+
+def ie_hist_image(img: np.ndarray, bins: int = 256, ax: "plt.Axes | None" = None) -> "plt.Axes":
+    """Plot a histogram of ``img`` pixel values.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Input image array. Can be 2-D grayscale or 3-D RGB with shape
+        ``(R, C, 3)``.
+    bins : int, optional
+        Number of histogram bins, by default ``256``.
+    ax : matplotlib.axes.Axes, optional
+        Axis to plot the histogram into. When ``None`` a new figure and
+        axis are created.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        Axis containing the histogram plot.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for ie_hist_image")
+
+    img = np.asarray(img, dtype=float)
+    if img.ndim == 2:
+        channels = 1
+    elif img.ndim == 3 and img.shape[2] == 3:
+        channels = 3
+    else:
+        raise ValueError("img must be 2-D grayscale or 3-D RGB array")
+
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = ax.figure
+
+    vmin = float(img.min())
+    vmax = float(img.max())
+
+    if channels == 1:
+        hist, edges = np.histogram(img.ravel(), bins=bins, range=(vmin, vmax))
+        width = edges[1] - edges[0]
+        ax.bar(edges[:-1], hist, width=width, color="gray", edgecolor="none")
+    else:
+        colors = ("r", "g", "b")
+        for i, color in enumerate(colors):
+            data = img[:, :, i].ravel()
+            hist, edges = np.histogram(data, bins=bins, range=(vmin, vmax))
+            width = edges[1] - edges[0]
+            ax.bar(edges[:-1], hist, width=width, color=color, alpha=0.5, edgecolor="none")
+
+    ax.set_xlabel("Pixel value")
+    ax.set_ylabel("Count")
+    fig.tight_layout()
+    return ax
+
+
+__all__ = ["ie_hist_image"]

--- a/python/tests/test_ie_hist_image.py
+++ b/python/tests/test_ie_hist_image.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam import ie_hist_image
+
+
+def _matplotlib_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_ie_hist_image_gray():
+    img = np.random.rand(10, 10)
+    ax = ie_hist_image(img)
+    assert ax is not None
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_ie_hist_image_rgb_reuse_axis():
+    import matplotlib.pyplot as plt
+
+    img = np.random.rand(5, 5, 3)
+    fig, ax = plt.subplots()
+    ax2 = ie_hist_image(img, ax=ax)
+    assert ax2 is ax


### PR DESCRIPTION
## Summary
- implement `ie_hist_image` for plotting image histograms
- export `ie_hist_image` from package
- test grayscale and RGB cases

## Testing
- `pytest -q` *(fails: 156 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683b78c58b7c83238968abc90ca846bc