### PR TITLE
Add ie_format_figure utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -69,6 +69,11 @@ from .mk_inv_gamma_table import mk_inv_gamma_table
 from .ie_cov_ellipsoid import ie_cov_ellipsoid
 from .ie_read_spectra import ie_read_spectra
 from .ie_hist_image import ie_hist_image
+from .ie_format_figure import (
+    ie_format_figure,
+    set_ie_figure_defaults,
+    _IE_FIGURE_DEFAULTS,
+)
 from .imgproc import (
     image_distort,
     ie_internal_to_display,
@@ -189,6 +194,9 @@ __all__ = [
     'ie_cov_ellipsoid',
     'ie_read_spectra',
     'ie_hist_image',
+    'ie_format_figure',
+    'set_ie_figure_defaults',
+    '_IE_FIGURE_DEFAULTS',
     'ie_spectra_sphere',
     'image_distort',
     'ie_internal_to_display',

--- a/python/isetcam/camera/camera_plot.py
+++ b/python/isetcam/camera/camera_plot.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import numpy as np
-
 try:
     import matplotlib.pyplot as plt
 except Exception:  # pragma: no cover - matplotlib might not be installed
@@ -12,6 +10,7 @@ except Exception:  # pragma: no cover - matplotlib might not be installed
 from .camera_class import Camera
 from .camera_mtf import camera_mtf
 from ..sensor import sensor_plot
+from ..ie_format_figure import ie_format_figure
 
 
 _DEF_TITLE_IMG = "Sensor response"
@@ -41,10 +40,9 @@ def camera_plot(camera: Camera, *, show_filters: bool = False,
         raise ImportError("matplotlib is required for camera_plot")
 
     if axes is None:
-        fig, (ax_img, ax_mtf) = plt.subplots(1, 2, figsize=(8, 4))
+        _, (ax_img, ax_mtf) = plt.subplots(1, 2, figsize=(8, 4))
     else:
         ax_img, ax_mtf = axes
-        fig = ax_img.figure
 
     sensor_plot(camera.sensor, show_filters=show_filters, ax=ax_img)
     ax_img.set_title(_DEF_TITLE_IMG)
@@ -56,7 +54,8 @@ def camera_plot(camera: Camera, *, show_filters: bool = False,
     ax_mtf.set_title(_DEF_TITLE_MTF)
     ax_mtf.set_ylim(0.0, 1.05)
 
-    fig.tight_layout()
+    ie_format_figure(ax_img)
+    ie_format_figure(ax_mtf)
     return ax_img, ax_mtf
 
 

--- a/python/isetcam/chromaticity_plot.py
+++ b/python/isetcam/chromaticity_plot.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-from pathlib import Path
 from scipy.io import loadmat
 
 try:
@@ -13,6 +12,7 @@ except Exception:  # pragma: no cover - matplotlib might not be installed
 
 from .chromaticity import chromaticity
 from .srgb_xyz import xyz_to_srgb
+from .ie_format_figure import ie_format_figure
 
 
 def chromaticity_plot(
@@ -46,9 +46,7 @@ def chromaticity_plot(
         raise ValueError("x and y must have the same shape")
 
     if ax is None:
-        fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
+        _, ax = plt.subplots()
 
     # Load CIE XYZ color matching functions for wavelengths 370-730 nm
     from .data_path import data_path
@@ -75,9 +73,6 @@ def chromaticity_plot(
 
     ax.set_xlim(0.0, 0.8)
     ax.set_ylim(0.0, 0.9)
-    ax.set_xlabel("CIE x")
-    ax.set_ylabel("CIE y")
-    ax.grid(True)
 
-    fig.tight_layout()
+    ie_format_figure(ax, xlabel="CIE x", ylabel="CIE y", grid=True)
     return ax

--- a/python/isetcam/display/display_plot.py
+++ b/python/isetcam/display/display_plot.py
@@ -12,6 +12,7 @@ except Exception:  # pragma: no cover - matplotlib might not be installed
 from .display_class import Display
 from ..ie_xyz_from_energy import ie_xyz_from_energy
 from ..chromaticity import chromaticity
+from ..ie_format_figure import ie_format_figure
 
 
 _DEF_COLORS = ["r", "g", "b"]
@@ -41,9 +42,7 @@ def display_plot(display: Display, kind: str = "spd", ax: "plt.Axes | None" = No
         raise ImportError("matplotlib is required for display_plot")
 
     if ax is None:
-        fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
+        _, ax = plt.subplots()
 
     kind = kind.lower()
     if kind == "spd":
@@ -81,7 +80,7 @@ def display_plot(display: Display, kind: str = "spd", ax: "plt.Axes | None" = No
     else:
         raise ValueError("Unknown kind '%s'" % kind)
 
-    fig.tight_layout()
+    ie_format_figure(ax)
     return ax
 
 

--- a/python/isetcam/display/display_show_image.py
+++ b/python/isetcam/display/display_show_image.py
@@ -11,6 +11,7 @@ except Exception:  # pragma: no cover - matplotlib might not be installed
 
 from .display_class import Display
 from .display_apply_gamma import display_apply_gamma
+from ..ie_format_figure import ie_format_figure
 
 
 def display_show_image(image: np.ndarray, display: Display):
@@ -42,5 +43,5 @@ def display_show_image(image: np.ndarray, display: Display):
     fig, ax = plt.subplots()
     ax.imshow(np.clip(img, 0.0, 1.0))
     ax.axis("off")
-    fig.tight_layout()
+    ie_format_figure(ax)
     return ax

--- a/python/isetcam/ie_format_figure.py
+++ b/python/isetcam/ie_format_figure.py
@@ -1,0 +1,79 @@
+"""Utility to format Matplotlib axes with ISETCam defaults."""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - matplotlib might not be installed
+    import matplotlib.pyplot as plt  # noqa: F401
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+
+_IE_FIGURE_DEFAULTS: dict[str, object] = {
+    "font_size": 10,
+    "grid": False,
+}
+
+
+def set_ie_figure_defaults(**kwargs: object) -> None:
+    """Update default formatting parameters.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        ``font_size`` and ``grid`` can be updated.
+    """
+    for key in kwargs:
+        if key not in _IE_FIGURE_DEFAULTS:
+            raise KeyError(f"Unknown default '{key}'")
+    _IE_FIGURE_DEFAULTS.update(kwargs)
+
+
+def ie_format_figure(
+    ax: "plt.Axes",
+    *,
+    xlabel: str | None = None,
+    ylabel: str | None = None,
+    font_size: int | None = None,
+    grid: bool | None = None,
+) -> "plt.Axes":
+    """Apply ISETCam formatting to ``ax``.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        Axis to format.
+    xlabel, ylabel : str, optional
+        Axis label strings. When ``None`` existing labels are kept.
+    font_size : int, optional
+        Font size for labels and tick marks. Uses default when ``None``.
+    grid : bool, optional
+        Toggle grid visibility. Uses default when ``None``.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The formatted axis.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for ie_format_figure")
+
+    fs = _IE_FIGURE_DEFAULTS["font_size"] if font_size is None else font_size
+    gr = _IE_FIGURE_DEFAULTS["grid"] if grid is None else grid
+
+    if xlabel is not None:
+        ax.set_xlabel(xlabel)
+    if ylabel is not None:
+        ax.set_ylabel(ylabel)
+
+    # Apply font sizes
+    ax.xaxis.label.set_size(fs)
+    ax.yaxis.label.set_size(fs)
+    ax.title.set_size(fs)
+    ax.tick_params(axis="both", labelsize=fs)
+
+    ax.grid(gr)
+    ax.figure.tight_layout()
+    return ax
+
+
+__all__ = ["ie_format_figure", "set_ie_figure_defaults", "_IE_FIGURE_DEFAULTS"]

--- a/python/isetcam/ie_hist_image.py
+++ b/python/isetcam/ie_hist_image.py
@@ -9,8 +9,12 @@ try:  # pragma: no cover - matplotlib might not be installed
 except Exception:  # pragma: no cover - matplotlib might not be installed
     plt = None  # type: ignore
 
+from .ie_format_figure import ie_format_figure
 
-def ie_hist_image(img: np.ndarray, bins: int = 256, ax: "plt.Axes | None" = None) -> "plt.Axes":
+
+def ie_hist_image(
+    img: np.ndarray, bins: int = 256, ax: "plt.Axes | None" = None
+) -> "plt.Axes":
     """Plot a histogram of ``img`` pixel values.
 
     Parameters
@@ -41,9 +45,7 @@ def ie_hist_image(img: np.ndarray, bins: int = 256, ax: "plt.Axes | None" = None
         raise ValueError("img must be 2-D grayscale or 3-D RGB array")
 
     if ax is None:
-        fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
+        _, ax = plt.subplots()
 
     vmin = float(img.min())
     vmax = float(img.max())
@@ -58,11 +60,16 @@ def ie_hist_image(img: np.ndarray, bins: int = 256, ax: "plt.Axes | None" = None
             data = img[:, :, i].ravel()
             hist, edges = np.histogram(data, bins=bins, range=(vmin, vmax))
             width = edges[1] - edges[0]
-            ax.bar(edges[:-1], hist, width=width, color=color, alpha=0.5, edgecolor="none")
+            ax.bar(
+                edges[:-1],
+                hist,
+                width=width,
+                color=color,
+                alpha=0.5,
+                edgecolor="none",
+            )
 
-    ax.set_xlabel("Pixel value")
-    ax.set_ylabel("Count")
-    fig.tight_layout()
+    ie_format_figure(ax, xlabel="Pixel value", ylabel="Count")
     return ax
 
 

--- a/python/isetcam/ip/ip_plot.py
+++ b/python/isetcam/ip/ip_plot.py
@@ -13,6 +13,7 @@ except Exception:  # pragma: no cover - matplotlib might not be installed
 
 from .vcimage_class import VCImage
 from ..ie_param_format import ie_param_format
+from ..ie_format_figure import ie_format_figure
 
 
 _DEF_KINDS = {
@@ -61,19 +62,13 @@ def ip_plot(
             pos = np.arange(rows)
             xlabel = "Row index"
         if ax is None:
-            fig, ax = plt.subplots()
-        else:
-            fig = ax.figure
+            _, ax = plt.subplots()
         ax.plot(pos, profile, "b-")
-        ax.set_xlabel(xlabel)
-        ax.set_ylabel("Luminance (a.u.)")
-        fig.tight_layout()
+        ie_format_figure(ax, xlabel=xlabel, ylabel="Luminance (a.u.)")
         return ax
 
     if ax is None:
-        fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
+        _, ax = plt.subplots()
     img = np.clip(rgb, 0.0, 1.0)
     ax.imshow(img)
     ax.axis("off")
@@ -89,7 +84,7 @@ def ip_plot(
         rect = Rectangle((c0, r0), w, h, edgecolor="y", facecolor="none", linewidth=1)
         ax.add_patch(rect)
 
-    fig.tight_layout()
+    ie_format_figure(ax)
     return ax
 
 

--- a/python/isetcam/opticalimage/oi_plot.py
+++ b/python/isetcam/opticalimage/oi_plot.py
@@ -17,9 +17,10 @@ from ..opticalimage.oi_calculate_illuminance import oi_calculate_illuminance
 from ..opticalimage.oi_calculate_irradiance import oi_calculate_irradiance
 from ..ie_xyz_from_photons import ie_xyz_from_photons
 from ..srgb_xyz import xyz_to_srgb
-from ..display import Display, display_create, display_render, display_apply_gamma
+from ..display import Display, display_render, display_apply_gamma
 from ..rgb_to_xw_format import rgb_to_xw_format
 from ..xw_to_rgb_format import xw_to_rgb_format
+from ..ie_format_figure import ie_format_figure
 
 
 _DEF_KINDS = {
@@ -81,13 +82,9 @@ def oi_plot(
             pos = np.arange(rows)
             xlabel = "Row index"
         if ax is None:
-            fig, ax = plt.subplots()
-        else:
-            fig = ax.figure
+            _, ax = plt.subplots()
         ax.plot(pos, profile, "r-")
-        ax.set_xlabel(xlabel)
-        ax.set_ylabel("Illuminance (lux)")
-        fig.tight_layout()
+        ie_format_figure(ax, xlabel=xlabel, ylabel="Illuminance (lux)")
         return ax
 
     if key in {"irradiancehline", "irradiancevline"}:
@@ -103,13 +100,9 @@ def oi_plot(
             pos = np.arange(rows)
             xlabel = "Row index"
         if ax is None:
-            fig, ax = plt.subplots()
-        else:
-            fig = ax.figure
+            _, ax = plt.subplots()
         ax.plot(pos, profile, "r-")
-        ax.set_xlabel(xlabel)
-        ax.set_ylabel("Irradiance (photons)")
-        fig.tight_layout()
+        ie_format_figure(ax, xlabel=xlabel, ylabel="Irradiance (photons)")
         return ax
 
     if display is None:
@@ -117,9 +110,7 @@ def oi_plot(
         display = Display(spd=np.eye(len(oi.wave)), wave=oi.wave, gamma=None)
     img = _photons_to_srgb(oi, display)
     if ax is None:
-        fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
+        _, ax = plt.subplots()
     ax.imshow(img)
     ax.axis("off")
 
@@ -134,7 +125,7 @@ def oi_plot(
         rect = Rectangle((c0, r0), w, h, edgecolor="y", facecolor="none", linewidth=1)
         ax.add_patch(rect)
 
-    fig.tight_layout()
+    ie_format_figure(ax)
     return ax
 
 

--- a/python/isetcam/opticalimage/oi_show_image.py
+++ b/python/isetcam/opticalimage/oi_show_image.py
@@ -15,6 +15,7 @@ from ..rgb_to_xw_format import rgb_to_xw_format
 from ..xw_to_rgb_format import xw_to_rgb_format
 from ..ie_xyz_from_photons import ie_xyz_from_photons
 from ..srgb_xyz import xyz_to_srgb
+from ..ie_format_figure import ie_format_figure
 
 
 def _photons_to_rgb(oi: OpticalImage, display: Display) -> np.ndarray:
@@ -52,5 +53,5 @@ def oi_show_image(oi: OpticalImage, display: Display | None = None):
     fig, ax = plt.subplots()
     ax.imshow(np.clip(srgb, 0.0, 1.0))
     ax.axis("off")
-    fig.tight_layout()
+    ie_format_figure(ax)
     return ax

--- a/python/isetcam/scene/scene_depth_overlay.py
+++ b/python/isetcam/scene/scene_depth_overlay.py
@@ -12,6 +12,7 @@ except Exception:  # pragma: no cover - matplotlib might not be installed
 from .scene_class import Scene
 from ..ie_xyz_from_photons import ie_xyz_from_photons
 from ..srgb_xyz import xyz_to_srgb
+from ..ie_format_figure import ie_format_figure
 
 
 def scene_depth_overlay(scene: Scene, n: int = 10):
@@ -48,7 +49,7 @@ def scene_depth_overlay(scene: Scene, n: int = 10):
     levels = np.linspace(dmap.min(), dmap.max(), n)
     ax.contour(dmap, levels=levels, colors="k", linewidths=1)
     ax.axis("off")
-    fig.tight_layout()
+    ie_format_figure(ax)
     return ax
 
 

--- a/python/isetcam/scene/scene_plot.py
+++ b/python/isetcam/scene/scene_plot.py
@@ -16,6 +16,7 @@ from ..ie_xyz_from_photons import ie_xyz_from_photons
 from ..srgb_xyz import xyz_to_srgb
 from ..luminance_from_photons import luminance_from_photons
 from ..ie_param_format import ie_param_format
+from ..ie_format_figure import ie_format_figure
 
 
 _DEF_KINDS = {
@@ -85,13 +86,9 @@ def scene_plot(
             pos = np.arange(rows)
             xlabel = "Row index"
         if ax is None:
-            fig, ax = plt.subplots()
-        else:
-            fig = ax.figure
+            _, ax = plt.subplots()
         ax.plot(pos, profile, "k-")
-        ax.set_xlabel(xlabel)
-        ax.set_ylabel("Luminance (cd/m$^2$)")
-        fig.tight_layout()
+        ie_format_figure(ax, xlabel=xlabel, ylabel="Luminance (cd/m$^2$)")
         return ax
 
     if key in {"radiancehline", "radiancevline"}:
@@ -111,13 +108,9 @@ def scene_plot(
         else:
             profile = data.mean(axis=1)
         if ax is None:
-            fig, ax = plt.subplots()
-        else:
-            fig = ax.figure
+            _, ax = plt.subplots()
         ax.plot(pos, profile, "k-")
-        ax.set_xlabel(xlabel)
-        ax.set_ylabel("Radiance (photons)")
-        fig.tight_layout()
+        ie_format_figure(ax, xlabel=xlabel, ylabel="Radiance (photons)")
         return ax
 
     # Image rendering
@@ -125,9 +118,7 @@ def scene_plot(
     srgb, _, _ = xyz_to_srgb(xyz)
     img = np.clip(srgb, 0.0, 1.0)
     if ax is None:
-        fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
+        _, ax = plt.subplots()
     ax.imshow(img)
     ax.axis("off")
 
@@ -142,7 +133,7 @@ def scene_plot(
         rect = Rectangle((c0, r0), w, h, edgecolor="y", facecolor="none", linewidth=1)
         ax.add_patch(rect)
 
-    fig.tight_layout()
+    ie_format_figure(ax)
     return ax
 
 

--- a/python/isetcam/scene/scene_show_image.py
+++ b/python/isetcam/scene/scene_show_image.py
@@ -12,6 +12,7 @@ except Exception:  # pragma: no cover - matplotlib might not be installed
 from .scene_class import Scene
 from ..ie_xyz_from_photons import ie_xyz_from_photons
 from ..srgb_xyz import xyz_to_srgb
+from ..ie_format_figure import ie_format_figure
 
 
 def scene_show_image(scene: Scene):
@@ -37,5 +38,5 @@ def scene_show_image(scene: Scene):
     fig, ax = plt.subplots()
     ax.imshow(img)
     ax.axis("off")
-    fig.tight_layout()
+    ie_format_figure(ax)
     return ax

--- a/python/isetcam/sensor/sensor_plot.py
+++ b/python/isetcam/sensor/sensor_plot.py
@@ -12,6 +12,7 @@ except Exception:  # pragma: no cover - matplotlib might not be installed
     to_rgb = None  # type: ignore
 
 from .sensor_class import Sensor
+from ..ie_format_figure import ie_format_figure
 
 
 _COLOR_MAP = {
@@ -53,9 +54,7 @@ def sensor_plot(sensor: Sensor, *, show_filters: bool = False, ax: "plt.Axes | N
         raise ValueError("sensor.volts must be a 2-D array")
 
     if ax is None:
-        fig, ax = plt.subplots()
-    else:
-        fig = ax.figure
+        _, ax = plt.subplots()
     ax.imshow(volts, cmap="gray", origin="upper")
     ax.axis("off")
 
@@ -77,7 +76,7 @@ def sensor_plot(sensor: Sensor, *, show_filters: bool = False, ax: "plt.Axes | N
                 overlay[mask, 3] = 0.4
             ax.imshow(overlay, interpolation="none")
 
-    fig.tight_layout()
+    ie_format_figure(ax)
     return ax
 
 

--- a/python/isetcam/sensor/sensor_show_image.py
+++ b/python/isetcam/sensor/sensor_show_image.py
@@ -14,7 +14,7 @@ from ..display import Display, display_create, display_render
 from ..srgb_to_lrgb import srgb_to_lrgb
 from ..ie_xyz_from_photons import ie_xyz_from_photons
 from ..srgb_xyz import xyz_to_srgb
-
+from ..ie_format_figure import ie_format_figure
 
 
 def sensor_show_image(sensor: Sensor, display: Display | None = None):
@@ -50,5 +50,5 @@ def sensor_show_image(sensor: Sensor, display: Display | None = None):
     fig, ax = plt.subplots()
     ax.imshow(np.clip(srgb, 0.0, 1.0))
     ax.axis("off")
-    fig.tight_layout()
+    ie_format_figure(ax)
     return ax

--- a/python/tests/test_ie_format_figure.py
+++ b/python/tests/test_ie_format_figure.py
@@ -1,0 +1,26 @@
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+
+from isetcam import ie_format_figure, set_ie_figure_defaults, _IE_FIGURE_DEFAULTS
+
+
+def test_ie_format_figure_basic():
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+    ie_format_figure(ax, xlabel="x", ylabel="y", font_size=11, grid=True)
+    assert ax.get_xlabel() == "x"
+    assert ax.get_ylabel() == "y"
+    assert ax.xaxis.label.get_size() == 11
+    assert all(gl.get_visible() for gl in ax.xaxis.get_gridlines())
+
+
+def test_set_ie_figure_defaults():
+    old_size = _IE_FIGURE_DEFAULTS["font_size"]
+    set_ie_figure_defaults(font_size=8)
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+    ie_format_figure(ax, xlabel="a", ylabel="b")
+    assert ax.xaxis.label.get_size() == 8
+    set_ie_figure_defaults(font_size=old_size)


### PR DESCRIPTION
## Summary
- add figure formatting helper `ie_format_figure`
- use it across plotting functions for consistent styling
- expose helper via package `__init__`
- add unit tests for the new utility

## Testing
- `pytest -q`
- `flake8 python/isetcam`

------
https://chatgpt.com/codex/tasks/task_e_683b7aa6894c83239e8b18d1447409df