### PR TITLE
Add scene_description utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -36,6 +36,7 @@ from .scene_depth_range import scene_depth_range
 from .scene_list import scene_list
 from .scene_wb_create import scene_wb_create
 from .scene_plot import scene_plot
+from .scene_description import scene_description
 
 __all__ = [
     "Scene",
@@ -76,4 +77,5 @@ __all__ = [
     "scene_depth_range",
     "scene_list",
     "scene_wb_create",
+    "scene_description",
 ]

--- a/python/isetcam/scene/scene_description.py
+++ b/python/isetcam/scene/scene_description.py
@@ -1,0 +1,42 @@
+"""Generate a short textual description of a :class:`Scene`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+from .scene_get import scene_get
+from ..luminance_from_photons import luminance_from_photons
+
+
+ndefault = "No scene structure"
+
+
+def scene_description(scene: Scene | None) -> str:
+    """Return a multi-line description of ``scene``."""
+    if scene is None:
+        return ndefault
+
+    lines: list[str] = []
+    name = scene_get(scene, "name")
+    if name:
+        lines.append(f"Name:\t{name}")
+
+    photons = np.asarray(scene_get(scene, "photons"))
+    if photons.size:
+        rows, cols = photons.shape[:2]
+        lines.append(f"Size:\t{rows} x {cols}")
+
+    wave = np.asarray(scene_get(scene, "wave"), dtype=float)
+    if wave.size:
+        spacing = wave[1] - wave[0] if wave.size > 1 else 0
+        lines.append(f"Wave:\t{int(wave[0])}:{int(spacing)}:{int(wave[-1])} nm")
+
+    lum = luminance_from_photons(photons, wave)
+    if lum.size:
+        lines.append(f"Mean luminance:\t{float(lum.mean()):.4g} cd/m^2")
+
+    return "\n".join(lines) if lines else ndefault
+
+
+__all__ = ["scene_description"]

--- a/python/tests/test_scene_description.py
+++ b/python/tests/test_scene_description.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_description
+from isetcam.luminance_from_photons import luminance_from_photons
+
+
+def test_scene_description_basic():
+    wave = np.array([500, 510, 520])
+    photons = np.ones((2, 3, 3))
+    sc = Scene(photons=photons.copy(), wave=wave, name="demo")
+    desc = scene_description(sc)
+
+    assert "demo" in desc
+    assert "2 x 3" in desc
+    assert "500:10:520" in desc
+    expected_lum = luminance_from_photons(photons, wave).mean()
+    assert f"{expected_lum:.4g}" in desc


### PR DESCRIPTION
## Summary
- add `scene_description` for summarizing a Scene
- expose `scene_description` in `isetcam.scene`
- test the description output

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_scene_description.py`

------
https://chatgpt.com/codex/tasks/task_e_683b859a3db48323a6cb3c9573ed0630