### PR TITLE
Implement scene_clear_data utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -37,6 +37,7 @@ from .scene_list import scene_list
 from .scene_wb_create import scene_wb_create
 from .scene_plot import scene_plot
 from .scene_description import scene_description
+from .scene_clear_data import scene_clear_data
 
 __all__ = [
     "Scene",
@@ -78,4 +79,5 @@ __all__ = [
     "scene_list",
     "scene_wb_create",
     "scene_description",
+    "scene_clear_data",
 ]

--- a/python/isetcam/scene/scene_clear_data.py
+++ b/python/isetcam/scene/scene_clear_data.py
@@ -1,0 +1,39 @@
+"""Utility to remove optional attributes from a Scene."""
+
+from __future__ import annotations
+
+from .scene_class import Scene
+
+# Attributes that may be attached to Scene instances by various helpers
+# or user interfaces. These are removed by :func:`scene_clear_data`.
+_OPTIONAL_ATTRS = [
+    "depth_map",
+    "ui",
+    "crop_rect",
+    "full_size",
+    "sample_spacing",
+    "pad_size",
+]
+
+
+def scene_clear_data(scene: Scene) -> Scene:
+    """Remove cached or optional attributes from ``scene``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Scene object to clean.
+
+    Returns
+    -------
+    Scene
+        The same ``scene`` instance with extraneous attributes removed.
+    """
+
+    for attr in _OPTIONAL_ATTRS:
+        if hasattr(scene, attr):
+            delattr(scene, attr)
+    return scene
+
+
+__all__ = ["scene_clear_data"]

--- a/python/tests/test_scene_clear_data.py
+++ b/python/tests/test_scene_clear_data.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_clear_data
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([500, 510])
+    photons = np.ones((2, 2, 2), dtype=float)
+    return Scene(photons=photons, wave=wave)
+
+
+def test_scene_clear_data_removes_fields():
+    sc = _simple_scene()
+    sc.depth_map = np.ones((2, 2))
+    sc.ui = object()
+    sc.crop_rect = (0, 0, 1, 1)
+    sc.full_size = (2, 2)
+    sc.sample_spacing = 0.5
+
+    out = scene_clear_data(sc)
+    assert out is sc
+    for fld in [
+        "depth_map",
+        "ui",
+        "crop_rect",
+        "full_size",
+        "sample_spacing",
+    ]:
+        assert not hasattr(out, fld)
+
+
+def test_scene_clear_data_no_fields():
+    sc = _simple_scene()
+    out = scene_clear_data(sc)
+    assert out is sc
+    assert np.array_equal(out.photons, sc.photons)
+    assert np.array_equal(out.wave, sc.wave)


### PR DESCRIPTION
## Summary
- add `scene_clear_data` for removing optional attributes
- export `scene_clear_data` from the scene package
- test that `scene_clear_data` removes extra fields

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_scene_clear_data.py`
- `PYTHONPATH=python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b881661b88323a805a40f1510bbb0