### PR TITLE
Add wavelength interpolation utilities

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -17,6 +17,7 @@ from .oi_spatial_support import oi_spatial_support
 from .oi_spatial_resample import oi_spatial_resample
 from .oi_frequency_support import oi_frequency_support
 from .oi_frequency_resample import oi_frequency_resample
+from .oi_interpolate_w import oi_interpolate_w
 from .oi_adjust_illuminance import oi_adjust_illuminance
 from .oi_extract_waveband import oi_extract_waveband
 from .oi_calculate_irradiance import oi_calculate_irradiance
@@ -46,6 +47,7 @@ __all__ = [
     "oi_spatial_resample",
     "oi_frequency_support",
     "oi_frequency_resample",
+    "oi_interpolate_w",
     "oi_photon_noise",
     "oi_to_file",
     "oi_adjust_illuminance",

--- a/python/isetcam/opticalimage/oi_interpolate_w.py
+++ b/python/isetcam/opticalimage/oi_interpolate_w.py
@@ -1,0 +1,63 @@
+"""Interpolate an :class:`OpticalImage` to a new wavelength sampling."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .oi_class import OpticalImage
+from ..illuminant.illuminant_class import Illuminant
+
+
+def oi_interpolate_w(oi: OpticalImage, wave: Sequence[float]) -> OpticalImage:
+    """Return ``oi`` data interpolated to ``wave``."""
+
+    src_wave = np.asarray(oi.wave, dtype=float).reshape(-1)
+    tgt_wave = np.asarray(wave, dtype=float).reshape(-1)
+
+    photons = np.asarray(oi.photons, dtype=float)
+    if photons.shape[-1] != src_wave.size:
+        raise ValueError("oi.wave length must match photons shape")
+
+    flat = photons.reshape(-1, src_wave.size)
+    interp = np.empty((flat.shape[0], tgt_wave.size), dtype=float)
+    for i, spec in enumerate(flat):
+        interp[i] = np.interp(tgt_wave, src_wave, spec, left=0.0, right=0.0)
+    new_photons = interp.reshape(photons.shape[0], photons.shape[1], tgt_wave.size)
+
+    out = OpticalImage(photons=new_photons, wave=tgt_wave, name=oi.name)
+
+    for attr, val in oi.__dict__.items():
+        if attr in {"photons", "wave", "name", "illuminant"}:
+            continue
+        setattr(out, attr, val)
+
+    illum = getattr(oi, "illuminant", None)
+    if illum is not None:
+        if isinstance(illum, Illuminant):
+            spd = np.asarray(illum.spd, dtype=float)
+            i_wave = np.asarray(illum.wave, dtype=float)
+            new_spd = np.interp(tgt_wave, i_wave, spd, left=0.0, right=0.0)
+            out.illuminant = Illuminant(spd=new_spd, wave=tgt_wave, name=illum.name)
+        else:
+            ill = np.asarray(illum, dtype=float)
+            if ill.ndim == 1:
+                if ill.size != src_wave.size:
+                    raise ValueError("Illuminant vector length must match oi wave")
+                out.illuminant = np.interp(tgt_wave, src_wave, ill, left=0.0, right=0.0)
+            elif ill.ndim == 3:
+                if ill.shape != photons.shape:
+                    raise ValueError("Illuminant cube must match oi photon shape")
+                flat = ill.reshape(-1, src_wave.size)
+                interp_ill = np.empty((flat.shape[0], tgt_wave.size), dtype=float)
+                for i, spec in enumerate(flat):
+                    interp_ill[i] = np.interp(tgt_wave, src_wave, spec, left=0.0, right=0.0)
+                out.illuminant = interp_ill.reshape(ill.shape[0], ill.shape[1], tgt_wave.size)
+            else:
+                raise ValueError("Illuminant must be 1-D or 3-D or Illuminant object")
+
+    return out
+
+
+__all__ = ["oi_interpolate_w"]

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -21,6 +21,7 @@ from .scene_spatial_support import scene_spatial_support
 from .scene_spatial_resample import scene_spatial_resample
 from .scene_frequency_support import scene_frequency_support
 from .scene_frequency_resample import scene_frequency_resample
+from .scene_interpolate_w import scene_interpolate_w
 from .scene_to_file import scene_to_file
 from .scene_extract_waveband import scene_extract_waveband
 from .scene_add_grid import scene_add_grid
@@ -61,6 +62,7 @@ __all__ = [
     "scene_spatial_resample",
     "scene_frequency_support",
     "scene_frequency_resample",
+    "scene_interpolate_w",
     "scene_create",
     "scene_photon_noise",
     "scene_to_file",

--- a/python/isetcam/scene/scene_interpolate_w.py
+++ b/python/isetcam/scene/scene_interpolate_w.py
@@ -1,0 +1,77 @@
+"""Interpolate a :class:`Scene` to a new wavelength sampling."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .scene_class import Scene
+from ..illuminant.illuminant_class import Illuminant
+
+
+def scene_interpolate_w(scene: Scene, wave: Sequence[float]) -> Scene:
+    """Return ``scene`` data interpolated to ``wave``.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene to interpolate.
+    wave : sequence of float
+        Desired wavelength samples in nanometers.
+
+    Returns
+    -------
+    Scene
+        New scene resampled to ``wave``.
+    """
+
+    src_wave = np.asarray(scene.wave, dtype=float).reshape(-1)
+    tgt_wave = np.asarray(wave, dtype=float).reshape(-1)
+
+    photons = np.asarray(scene.photons, dtype=float)
+    if photons.shape[-1] != src_wave.size:
+        raise ValueError("scene.wave length must match photons shape")
+
+    flat = photons.reshape(-1, src_wave.size)
+    interp = np.empty((flat.shape[0], tgt_wave.size), dtype=float)
+    for i, spec in enumerate(flat):
+        interp[i] = np.interp(tgt_wave, src_wave, spec, left=0.0, right=0.0)
+    new_photons = interp.reshape(photons.shape[0], photons.shape[1], tgt_wave.size)
+
+    out = Scene(photons=new_photons, wave=tgt_wave, name=scene.name)
+
+    # Copy other attributes
+    for attr, val in scene.__dict__.items():
+        if attr in {"photons", "wave", "name", "illuminant"}:
+            continue
+        setattr(out, attr, val)
+
+    illum = getattr(scene, "illuminant", None)
+    if illum is not None:
+        if isinstance(illum, Illuminant):
+            spd = np.asarray(illum.spd, dtype=float)
+            i_wave = np.asarray(illum.wave, dtype=float)
+            new_spd = np.interp(tgt_wave, i_wave, spd, left=0.0, right=0.0)
+            out.illuminant = Illuminant(spd=new_spd, wave=tgt_wave, name=illum.name)
+        else:
+            ill = np.asarray(illum, dtype=float)
+            if ill.ndim == 1:
+                if ill.size != src_wave.size:
+                    raise ValueError("Illuminant vector length must match scene wave")
+                out.illuminant = np.interp(tgt_wave, src_wave, ill, left=0.0, right=0.0)
+            elif ill.ndim == 3:
+                if ill.shape != photons.shape:
+                    raise ValueError("Illuminant cube must match scene photon shape")
+                flat = ill.reshape(-1, src_wave.size)
+                interp_ill = np.empty((flat.shape[0], tgt_wave.size), dtype=float)
+                for i, spec in enumerate(flat):
+                    interp_ill[i] = np.interp(tgt_wave, src_wave, spec, left=0.0, right=0.0)
+                out.illuminant = interp_ill.reshape(ill.shape[0], ill.shape[1], tgt_wave.size)
+            else:
+                raise ValueError("Illuminant must be 1-D or 3-D or Illuminant object")
+
+    return out
+
+
+__all__ = ["scene_interpolate_w"]

--- a/python/tests/test_interpolate_w.py
+++ b/python/tests/test_interpolate_w.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_interpolate_w
+from isetcam.opticalimage import OpticalImage, oi_interpolate_w
+from isetcam.illuminant import Illuminant
+
+
+def _scene() -> Scene:
+    wave = np.array([500.0, 600.0])
+    photons = np.arange(8, dtype=float).reshape(2, 2, 2)
+    sc = Scene(photons=photons, wave=wave, name="demo")
+    sc.sample_spacing = 1.0
+    sc.extra = "meta"
+    sc.illuminant = Illuminant(spd=np.array([1.0, 3.0]), wave=wave, name="illum")
+    return sc
+
+
+def _oi() -> OpticalImage:
+    wave = np.array([500.0, 600.0])
+    photons = np.arange(8, dtype=float).reshape(2, 2, 2)
+    oi = OpticalImage(photons=photons, wave=wave, name="demo")
+    oi.sample_spacing = 0.5
+    oi.extra = "meta"
+    oi.illuminant = Illuminant(spd=np.array([2.0, 4.0]), wave=wave, name="illum")
+    return oi
+
+
+def test_scene_interpolate_w():
+    sc = _scene()
+    new_wave = np.array([500.0, 550.0, 600.0])
+    out = scene_interpolate_w(sc, new_wave)
+
+    assert np.array_equal(out.wave, new_wave)
+    assert out.name == sc.name
+    assert getattr(out, "sample_spacing") == sc.sample_spacing
+    assert getattr(out, "extra") == sc.extra
+
+    for i in range(2):
+        for j in range(2):
+            expected = np.interp(new_wave, sc.wave, sc.photons[i, j, :])
+            assert np.allclose(out.photons[i, j, :], expected)
+
+    expected_illum = np.interp(new_wave, sc.illuminant.wave, sc.illuminant.spd)
+    assert isinstance(out.illuminant, Illuminant)
+    assert np.allclose(out.illuminant.spd, expected_illum)
+
+
+def test_oi_interpolate_w():
+    oi = _oi()
+    new_wave = np.array([500.0, 550.0, 600.0])
+    out = oi_interpolate_w(oi, new_wave)
+
+    assert np.array_equal(out.wave, new_wave)
+    assert out.name == oi.name
+    assert getattr(out, "sample_spacing") == oi.sample_spacing
+    assert getattr(out, "extra") == oi.extra
+
+    for i in range(2):
+        for j in range(2):
+            expected = np.interp(new_wave, oi.wave, oi.photons[i, j, :])
+            assert np.allclose(out.photons[i, j, :], expected)
+
+    expected_illum = np.interp(new_wave, oi.illuminant.wave, oi.illuminant.spd)
+    assert isinstance(out.illuminant, Illuminant)
+    assert np.allclose(out.illuminant.spd, expected_illum)


### PR DESCRIPTION
## Summary
- add helpers to interpolate Scene and OpticalImage wavelength data
- export new helpers from package init files
- test interpolation utilities

## Testing
- `pytest python/tests/test_interpolate_w.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683b8a9258b08323b0e0bc5f6cc44b6e