### PR TITLE
Add sensor_stats ROI statistics

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -22,6 +22,7 @@ from .sensor_dng_read import sensor_dng_read
 from .sensor_show_image import sensor_show_image
 from .sensor_rotate import sensor_rotate
 from .sensor_show_cfa import sensor_show_cfa
+from .sensor_stats import sensor_stats
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -73,4 +74,5 @@ __all__ = [
     "sensor_show_image",
     "sensor_show_cfa",
     "sensor_rotate",
+    "sensor_stats",
 ]

--- a/python/isetcam/sensor/sensor_stats.py
+++ b/python/isetcam/sensor/sensor_stats.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import numpy as np
+
+from .sensor_class import Sensor
+from .sensor_photon_noise import sensor_photon_noise
+
+
+def sensor_stats(
+    sensor: Sensor,
+    roi: Sequence[int],
+    *,
+    use_photon_noise: bool = False,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return mean signal, noise SD and SNR for a sensor ROI.
+
+    Parameters
+    ----------
+    sensor : Sensor
+        Sensor object containing voltage data.
+    roi : sequence of int
+        ROI specified as ``(x, y, width, height)`` using 0-based indexing.
+    use_photon_noise : bool, optional
+        When ``True`` photon noise is generated using
+        :func:`sensor_photon_noise` before computing the statistics.  The
+        ``sensor`` object is updated with the noisy volts and noise is
+        measured from the added noise.  When ``False`` noise is estimated
+        from the standard deviation of the ROI data.
+
+    Returns
+    -------
+    tuple of np.ndarray
+        ``(mean_signal, noise_sd, snr)`` for each color channel present in
+        ``sensor.volts``.
+    """
+
+    if len(roi) != 4:
+        raise ValueError("roi must be (x, y, width, height)")
+    x, y, w, h = [int(v) for v in roi]
+    if w <= 0 or h <= 0:
+        raise ValueError("width and height must be positive")
+
+    volts = np.asarray(sensor.volts, dtype=float)
+    if x < 0 or y < 0 or x + w > volts.shape[1] or y + h > volts.shape[0]:
+        raise ValueError("roi is outside the sensor bounds")
+
+    if use_photon_noise:
+        noisy_volts, noise_full = sensor_photon_noise(sensor)
+        roi_volts = noisy_volts[y : y + h, x : x + w, ...]
+        roi_noise = noise_full[y : y + h, x : x + w, ...]
+    else:
+        roi_volts = volts[y : y + h, x : x + w, ...]
+        roi_noise = roi_volts - np.nanmean(roi_volts, axis=(0, 1), keepdims=True)
+
+    if roi_volts.ndim == 2:
+        roi_volts = roi_volts[..., np.newaxis]
+        roi_noise = roi_noise[..., np.newaxis]
+
+    flat_volts = roi_volts.reshape(-1, roi_volts.shape[2])
+    flat_noise = roi_noise.reshape(-1, roi_noise.shape[2])
+
+    mean_signal = np.nanmean(flat_volts, axis=0)
+    noise_sd = np.nanstd(flat_noise, axis=0)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        snr = np.where(noise_sd == 0, np.inf, mean_signal / noise_sd)
+    return mean_signal, noise_sd, snr
+
+
+__all__ = ["sensor_stats"]

--- a/python/tests/test_sensor_stats.py
+++ b/python/tests/test_sensor_stats.py
@@ -1,0 +1,36 @@
+import numpy as np
+from isetcam.sensor import Sensor, sensor_stats, sensor_photon_noise
+
+
+def test_sensor_stats_basic():
+    volts = np.array([[1.0, 2.0], [3.0, 4.0]])
+    s = Sensor(volts=volts.copy(), wave=np.array([550]), exposure_time=0.01)
+
+    mean_signal, noise_sd, snr = sensor_stats(s, (0, 0, 2, 2))
+
+    expected_mean = volts.mean()
+    expected_sd = volts.std()
+    expected_snr = expected_mean / expected_sd
+
+    assert np.allclose(mean_signal, expected_mean)
+    assert np.allclose(noise_sd, expected_sd)
+    assert np.allclose(snr, expected_snr)
+
+
+def test_sensor_stats_with_photon_noise():
+    np.random.seed(0)
+    volts = np.full((10, 10), 20.0, dtype=float)
+    s = Sensor(volts=volts.copy(), wave=np.array([550]), exposure_time=0.01)
+
+    mean_signal, noise_sd, snr = sensor_stats(s, (0, 0, 10, 10), use_photon_noise=True)
+
+    np.random.seed(0)
+    s2 = Sensor(volts=volts.copy(), wave=np.array([550]), exposure_time=0.01)
+    noisy, noise = sensor_photon_noise(s2)
+    exp_mean = noisy.mean()
+    exp_sd = noise.std()
+    exp_snr = exp_mean / exp_sd
+
+    assert np.allclose(mean_signal, exp_mean)
+    assert np.allclose(noise_sd, exp_sd)
+    assert np.allclose(snr, exp_snr)


### PR DESCRIPTION
## Summary
- port MATLAB `sensorStats` into Python as `sensor_stats`
- export it from the sensor package
- test statistics computation with and without photon noise

## Testing
- `pytest -q python/tests/test_sensor_stats.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b8ee630e883238f05c084c1eb1414