### PR TITLE
Add scene_illuminant_scale and tests

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -32,6 +32,7 @@ from .scene_save_image import scene_save_image
 from .scene_thumbnail import scene_thumbnail
 from .scene_illuminant_pattern import scene_illuminant_pattern
 from .scene_illuminant_ss import scene_illuminant_ss
+from .scene_illuminant_scale import scene_illuminant_scale
 from .scene_depth_overlay import scene_depth_overlay
 from .scene_depth_range import scene_depth_range
 from .scene_list import scene_list
@@ -76,6 +77,7 @@ __all__ = [
     "scene_thumbnail",
     "scene_illuminant_pattern",
     "scene_illuminant_ss",
+    "scene_illuminant_scale",
     "scene_depth_overlay",
     "scene_depth_range",
     "scene_list",

--- a/python/isetcam/scene/scene_illuminant_scale.py
+++ b/python/isetcam/scene/scene_illuminant_scale.py
@@ -1,0 +1,57 @@
+"""Scale scene illuminant so average reflectance is unity."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def _expand_illuminant(illum: np.ndarray, shape: tuple[int, int, int]) -> np.ndarray:
+    """Return ``illum`` expanded to ``shape``."""
+    if illum.ndim == 1:
+        if illum.size != shape[2]:
+            raise ValueError("Illuminant vector length must match scene wave")
+        return np.tile(illum.reshape(1, 1, -1), (shape[0], shape[1], 1))
+    if illum.ndim == 3:
+        if illum.shape != shape:
+            raise ValueError("Illuminant cube must match scene photon shape")
+        return illum
+    raise ValueError("Illuminant must be 1-D or 3-D")
+
+
+def scene_illuminant_scale(scene: Scene) -> Scene:
+    """Adjust illuminant intensity to yield mean reflectance of one.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene containing an ``illuminant`` attribute.
+
+    Returns
+    -------
+    Scene
+        New scene with scaled illuminant. Photon data are not modified.
+    """
+
+    illum = getattr(scene, "illuminant", None)
+    if illum is None:
+        raise AttributeError("scene has no illuminant attribute")
+
+    photons = np.asarray(scene.photons, dtype=float)
+    ill = np.asarray(illum, dtype=float)
+    ill_cube = _expand_illuminant(ill, photons.shape)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        refl = np.divide(photons, ill_cube, out=np.zeros_like(photons), where=ill_cube!=0)
+    avg_refl = float(refl.mean())
+
+    scale = avg_refl if avg_refl > 0 else 1.0
+    new_illum = ill * scale
+
+    out = Scene(photons=photons, wave=scene.wave, name=scene.name)
+    if ill.ndim == 1:
+        out.illuminant = new_illum
+    else:
+        out.illuminant = new_illum
+    return out

--- a/python/tests/test_scene_illuminant_scale.py
+++ b/python/tests/test_scene_illuminant_scale.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_illuminant_scale
+from isetcam.luminance_from_photons import luminance_from_photons
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([500, 510], dtype=float)
+    photons = np.array(
+        [[[0.2, 0.4], [0.6, 0.8]], [[0.5, 0.2], [0.3, 0.4]]], dtype=float
+    )
+    sc = Scene(photons=photons, wave=wave)
+    sc.illuminant = np.array([1.0, 1.0])
+    return sc
+
+
+def test_scene_illuminant_scale_vector():
+    sc = _simple_scene()
+    out = scene_illuminant_scale(sc)
+    refl = out.photons / out.illuminant.reshape(1, 1, -1)
+    assert np.isclose(refl.mean(), 1.0)
+    assert np.allclose(out.photons, sc.photons)
+    lum_before = luminance_from_photons(sc.photons, sc.wave).mean()
+    lum_after = luminance_from_photons(out.photons, out.wave).mean()
+    assert np.isclose(lum_after, lum_before)
+
+
+def test_scene_illuminant_scale_cube():
+    sc = _simple_scene()
+    sc.illuminant = np.ones_like(sc.photons)
+    sc.illuminant[0, 0, :] = 2.0
+    out = scene_illuminant_scale(sc)
+    refl = out.photons / out.illuminant
+    assert np.isclose(refl.mean(), 1.0)
+


### PR DESCRIPTION
## Summary
- implement `scene_illuminant_scale` to scale illuminant so that the mean reflectance equals one
- export the function via `isetcam.scene`
- add unit tests for luminance normalization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'isetcam')*

------
https://chatgpt.com/codex/tasks/task_e_683b9491c5c88323849cbf06b4195503