### PR TITLE
Add oi_clear_data utility and tests

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -27,6 +27,7 @@ from .oi_save_image import oi_save_image
 from .oi_thumbnail import oi_thumbnail
 from .oi_illuminant_pattern import oi_illuminant_pattern
 from .oi_illuminant_ss import oi_illuminant_ss
+from .oi_clear_data import oi_clear_data
 from .oi_plot import oi_plot
 
 __all__ = [
@@ -60,4 +61,5 @@ __all__ = [
     "oi_thumbnail",
     "oi_illuminant_pattern",
     "oi_illuminant_ss",
+    "oi_clear_data",
 ]

--- a/python/isetcam/opticalimage/oi_clear_data.py
+++ b/python/isetcam/opticalimage/oi_clear_data.py
@@ -1,0 +1,42 @@
+"""Utility to remove optional attributes from an OpticalImage."""
+
+from __future__ import annotations
+
+from .oi_class import OpticalImage
+
+# Attributes that may be attached to OpticalImage instances by various helpers
+# or user interfaces. These are removed by :func:`oi_clear_data`.
+_OPTIONAL_ATTRS = [
+    "depth_map",
+    "wangular",
+    "crop_rect",
+    "full_size",
+    "sample_spacing",
+    "pad_size",
+    "psf",
+    "otf",
+    "optics_psf",
+    "optics_otf",
+]
+
+
+def oi_clear_data(oi: OpticalImage) -> OpticalImage:
+    """Remove cached or optional attributes from ``oi``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Optical image object to clean.
+
+    Returns
+    -------
+    OpticalImage
+        The same ``oi`` instance with extraneous attributes removed.
+    """
+    for attr in _OPTIONAL_ATTRS:
+        if hasattr(oi, attr):
+            delattr(oi, attr)
+    return oi
+
+
+__all__ = ["oi_clear_data"]

--- a/python/tests/test_oi_clear_data.py
+++ b/python/tests/test_oi_clear_data.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from isetcam.opticalimage import OpticalImage, oi_clear_data
+
+
+def _simple_oi() -> OpticalImage:
+    wave = np.array([500, 510])
+    photons = np.ones((2, 2, 2), dtype=float)
+    return OpticalImage(photons=photons, wave=wave)
+
+
+def test_oi_clear_data_removes_fields():
+    oi = _simple_oi()
+    oi.depth_map = np.ones((2, 2))
+    oi.wangular = 1.0
+    oi.optics_psf = np.ones((3, 3))
+    oi.crop_rect = (0, 0, 1, 1)
+    oi.full_size = (2, 2)
+    oi.sample_spacing = 0.5
+
+    out = oi_clear_data(oi)
+    assert out is oi
+    for fld in [
+        "depth_map",
+        "wangular",
+        "optics_psf",
+        "crop_rect",
+        "full_size",
+        "sample_spacing",
+    ]:
+        assert not hasattr(out, fld)
+
+
+def test_oi_clear_data_no_fields():
+    oi = _simple_oi()
+    out = oi_clear_data(oi)
+    assert out is oi
+    assert np.array_equal(out.photons, oi.photons)
+    assert np.array_equal(out.wave, oi.wave)


### PR DESCRIPTION
## Summary
- add `oi_clear_data` to remove optional OpticalImage attributes
- export `oi_clear_data` from the opticalimage package
- test that `oi_clear_data` removes extraneous fields while keeping data intact

## Testing
- `export PYTHONPATH=$PWD/python && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ba0df055883238125319bdb0d2ad3