### PR TITLE
Add sensor_clear_data helper and tests

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -23,6 +23,7 @@ from .sensor_show_image import sensor_show_image
 from .sensor_rotate import sensor_rotate
 from .sensor_show_cfa import sensor_show_cfa
 from .sensor_stats import sensor_stats
+from .sensor_clear_data import sensor_clear_data
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -75,4 +76,5 @@ __all__ = [
     "sensor_show_cfa",
     "sensor_rotate",
     "sensor_stats",
+    "sensor_clear_data",
 ]

--- a/python/isetcam/sensor/sensor_clear_data.py
+++ b/python/isetcam/sensor/sensor_clear_data.py
@@ -1,0 +1,37 @@
+"""Utility to remove optional attributes from a Sensor."""
+
+from __future__ import annotations
+
+from .sensor_class import Sensor
+
+# Attributes that may be attached to Sensor instances by various helpers
+# or user interfaces. These are removed by :func:`sensor_clear_data`.
+_OPTIONAL_ATTRS = [
+    "offset_fpn_image",
+    "gain_fpn_image",
+    "data",
+    "crop_rect",
+    "full_size",
+]
+
+
+def sensor_clear_data(sensor: Sensor) -> Sensor:
+    """Remove cached or optional attributes from ``sensor``.
+
+    Parameters
+    ----------
+    sensor : Sensor
+        Sensor object to clean.
+
+    Returns
+    -------
+    Sensor
+        The same ``sensor`` instance with extraneous attributes removed.
+    """
+    for attr in _OPTIONAL_ATTRS:
+        if hasattr(sensor, attr):
+            delattr(sensor, attr)
+    return sensor
+
+
+__all__ = ["sensor_clear_data"]

--- a/python/tests/test_sensor_clear_data.py
+++ b/python/tests/test_sensor_clear_data.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from isetcam.sensor import Sensor, sensor_clear_data
+
+
+def _simple_sensor() -> Sensor:
+    volts = np.ones((2, 2), dtype=float)
+    wave = np.array([500, 510])
+    return Sensor(volts=volts, wave=wave, exposure_time=0.01)
+
+
+def test_sensor_clear_data_removes_fields():
+    s = _simple_sensor()
+    s.offset_fpn_image = np.ones((2, 2))
+    s.gain_fpn_image = np.ones((2, 2))
+    s.data = object()
+    s.crop_rect = (0, 0, 1, 1)
+    s.full_size = (2, 2)
+
+    out = sensor_clear_data(s)
+    assert out is s
+    for fld in [
+        "offset_fpn_image",
+        "gain_fpn_image",
+        "data",
+        "crop_rect",
+        "full_size",
+    ]:
+        assert not hasattr(out, fld)
+
+
+def test_sensor_clear_data_no_fields():
+    s = _simple_sensor()
+    out = sensor_clear_data(s)
+    assert out is s
+    assert np.array_equal(out.volts, s.volts)
+    assert np.array_equal(out.wave, s.wave)


### PR DESCRIPTION
## Summary
- implement `sensor_clear_data` helper
- export helper in `sensor.__init__`
- add tests for clearing optional sensor fields

## Testing
- `PYTHONPATH=. pytest -q tests/test_sensor_clear_data.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ba33e63408323abaef6e6cbeeb407