### PR TITLE
Add ip_clear_data utility and tests

### DIFF
--- a/python/isetcam/ip/__init__.py
+++ b/python/isetcam/ip/__init__.py
@@ -8,6 +8,7 @@ from .ip_set import ip_set
 from .ip_to_file import ip_to_file
 from .ip_from_file import ip_from_file
 from .ip_plot import ip_plot
+from .ip_clear_data import ip_clear_data
 
 __all__ = [
     "VCImage",
@@ -18,4 +19,5 @@ __all__ = [
     "ip_to_file",
     "ip_from_file",
     "ip_plot",
+    "ip_clear_data",
 ]

--- a/python/isetcam/ip/ip_clear_data.py
+++ b/python/isetcam/ip/ip_clear_data.py
@@ -1,0 +1,37 @@
+"""Utility to remove optional attributes from a VCImage."""
+
+from __future__ import annotations
+
+from .vcimage_class import VCImage
+
+# Attributes that may be attached to VCImage instances by helpers or
+# user interfaces. These are removed by :func:`ip_clear_data`.
+_OPTIONAL_ATTRS = [
+    "processed_rgb",
+]
+
+
+def ip_clear_data(ip: VCImage) -> VCImage:
+    """Remove cached or optional attributes from ``ip``.
+
+    Parameters
+    ----------
+    ip : VCImage
+        Image processing object to clean.
+
+    Returns
+    -------
+    VCImage
+        The same ``ip`` instance with extraneous attributes removed.
+    """
+    for attr in _OPTIONAL_ATTRS:
+        if hasattr(ip, attr):
+            delattr(ip, attr)
+    # Remove any arbitrary attributes not part of VCImage dataclass
+    for key in list(vars(ip).keys()):
+        if key not in {"rgb", "wave", "name"}:
+            delattr(ip, key)
+    return ip
+
+
+__all__ = ["ip_clear_data"]

--- a/python/tests/test_ip_clear_data.py
+++ b/python/tests/test_ip_clear_data.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from isetcam.ip import VCImage, ip_clear_data
+
+
+def _simple_ip() -> VCImage:
+    rgb = np.ones((2, 2, 3), dtype=float)
+    wave = np.array([500, 510, 520])
+    return VCImage(rgb=rgb, wave=wave)
+
+
+def test_ip_clear_data_removes_fields():
+    ip = _simple_ip()
+    ip.processed_rgb = np.zeros_like(ip.rgb)
+    ip.custom_attr = 42
+
+    out = ip_clear_data(ip)
+    assert out is ip
+    for fld in ["processed_rgb", "custom_attr"]:
+        assert not hasattr(out, fld)
+
+
+def test_ip_clear_data_no_fields():
+    ip = _simple_ip()
+    out = ip_clear_data(ip)
+    assert out is ip
+    assert np.allclose(out.rgb, ip.rgb)
+    assert np.array_equal(out.wave, ip.wave)


### PR DESCRIPTION
## Summary
- add `ip_clear_data` to purge optional VCImage attributes
- export `ip_clear_data` in the `ip` package
- test that `ip_clear_data` removes stray fields

## Testing
- `python -m pytest tests/test_ip_clear_data.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683ba6b28744832390f5cc3bacd7086e