### PR TITLE
Add camera_clear_data utility

### DIFF
--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -14,6 +14,7 @@ from .camera_vsnr import camera_vsnr
 from .camera_acutance import camera_acutance
 from .camera_color_accuracy import camera_color_accuracy
 from .camera_compute_sequence import camera_compute_sequence
+from .camera_clear_data import camera_clear_data
 
 __all__ = [
     "Camera",
@@ -30,4 +31,5 @@ __all__ = [
     "camera_acutance",
     "camera_color_accuracy",
     "camera_compute_sequence",
+    "camera_clear_data",
 ]

--- a/python/isetcam/camera/camera_clear_data.py
+++ b/python/isetcam/camera/camera_clear_data.py
@@ -1,0 +1,25 @@
+"""Utility to remove optional attributes from a Camera and its components."""
+
+from __future__ import annotations
+
+from .camera_class import Camera
+from ..opticalimage import oi_clear_data
+from ..sensor import sensor_clear_data
+from ..ip import ip_clear_data
+
+
+def camera_clear_data(camera: Camera) -> Camera:
+    """Remove cached or optional attributes from ``camera``.
+
+    This invokes :func:`oi_clear_data`, :func:`sensor_clear_data` and
+    :func:`ip_clear_data` on the optical image, sensor and image
+    processor objects of ``camera`` respectively.
+    """
+    camera.optical_image = oi_clear_data(camera.optical_image)
+    camera.sensor = sensor_clear_data(camera.sensor)
+    if hasattr(camera, "ip"):
+        camera.ip = ip_clear_data(camera.ip)
+    return camera
+
+
+__all__ = ["camera_clear_data"]

--- a/python/tests/test_camera_clear_data.py
+++ b/python/tests/test_camera_clear_data.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from isetcam.camera import Camera, camera_clear_data
+from isetcam.sensor import Sensor
+from isetcam.opticalimage import OpticalImage
+from isetcam.ip import VCImage
+
+
+def _simple_camera() -> Camera:
+    sensor = Sensor(volts=np.ones((2, 2)), exposure_time=0.01, wave=np.array([500, 510]))
+    oi = OpticalImage(photons=np.ones((2, 2, 2)), wave=np.array([500, 510]))
+    cam = Camera(sensor=sensor, optical_image=oi)
+    cam.ip = VCImage(rgb=np.ones((2, 2, 3)), wave=np.array([500, 510]))
+    return cam
+
+
+def test_camera_clear_data_removes_nested_fields():
+    cam = _simple_camera()
+    cam.sensor.offset_fpn_image = np.ones((2, 2))
+    cam.optical_image.depth_map = np.ones((2, 2))
+    cam.ip.processed_rgb = np.zeros((2, 2, 3))
+    cam.ip.custom_attr = 42
+
+    out = camera_clear_data(cam)
+    assert out is cam
+    assert not hasattr(cam.sensor, "offset_fpn_image")
+    assert not hasattr(cam.optical_image, "depth_map")
+    assert not hasattr(cam.ip, "processed_rgb")
+    assert not hasattr(cam.ip, "custom_attr")
+
+
+def test_camera_clear_data_no_fields():
+    cam = _simple_camera()
+    out = camera_clear_data(cam)
+    assert out is cam
+    assert np.allclose(cam.sensor.volts, np.ones((2, 2)))
+    assert np.allclose(cam.optical_image.photons, np.ones((2, 2, 2)))
+    assert np.allclose(cam.ip.rgb, np.ones((2, 2, 3)))


### PR DESCRIPTION
## Summary
- add camera_clear_data for cleaning Camera instances
- export camera_clear_data
- test clearing nested objects

## Testing
- `pytest -q python/tests/test_camera_clear_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683baa9948f483238efdbfb539b29495