### PR TITLE
Normalize integer images in scene_from_file

### DIFF
--- a/python/isetcam/scene/scene_from_file.py
+++ b/python/isetcam/scene/scene_from_file.py
@@ -19,6 +19,10 @@ def scene_from_file(
 ) -> Scene:
     """Read ``path`` and return a :class:`Scene`.
 
+    Integer-valued images are normalized to the [0, 1] range using the
+    maximum value representable by their data type.  Floating-point images
+    are left unchanged.
+
     Parameters
     ----------
     path : str or Path
@@ -36,7 +40,12 @@ def scene_from_file(
         Scene containing the image data.
     """
     img = imageio.imread(Path(path))
-    data = np.asarray(img, dtype=float)
+    # Scale integer images to the [0, 1] range by dividing by the maximum
+    # representable value.  Floating point images are left as-is.
+    if np.issubdtype(img.dtype, np.integer):
+        data = np.asarray(img, dtype=float) / np.iinfo(img.dtype).max
+    else:
+        data = np.asarray(img, dtype=float)
     if data.ndim == 2:
         data = data[:, :, np.newaxis]
 

--- a/python/tests/test_scene_from_file.py
+++ b/python/tests/test_scene_from_file.py
@@ -30,3 +30,11 @@ def test_scene_from_file_gray():
     sc = scene_from_file(fpath, wave=wave)
     assert sc.photons.ndim == 3 and sc.photons.shape[2] == 1
     assert np.array_equal(sc.wave, wave)
+
+
+def test_scene_from_file_uint8_scaling():
+    fpath = data_path('images/rgb/adelson.png')
+    sc = scene_from_file(fpath)
+    assert sc.photons.dtype == float
+    assert sc.photons.min() >= 0.0
+    assert sc.photons.max() <= 1.0


### PR DESCRIPTION
## Summary
- normalize integer images when creating scenes from files
- clarify docstring for `scene_from_file`
- test scaling of uint8 PNG files

## Testing
- `pytest -q python/tests/test_scene_from_file.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bb27068c48323a40a394c870a4747