### PR TITLE
Add sRGB/Lab conversions

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -57,6 +57,8 @@ from .lms_to_xyz import lms_to_xyz
 from .xyz_to_lms import xyz_to_lms
 from .lms_to_srgb import lms_to_srgb
 from .srgb_to_lms import srgb_to_lms
+from .srgb_to_lab import srgb_to_lab
+from .lab_to_srgb import lab_to_srgb
 from .srgb_to_lrgb import srgb_to_lrgb
 from .lrgb_to_srgb import lrgb_to_srgb
 from .srgb_xyz import (
@@ -185,6 +187,8 @@ __all__ = [
     'xyz_to_lms',
     'lms_to_srgb',
     'srgb_to_lms',
+    'srgb_to_lab',
+    'lab_to_srgb',
     'srgb_to_lrgb',
     'lrgb_to_srgb',
     'srgb_to_linear',

--- a/python/isetcam/lab_to_srgb.py
+++ b/python/isetcam/lab_to_srgb.py
@@ -1,0 +1,29 @@
+"""Convert CIE L*a*b* values to nonlinear sRGB."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .lab_to_xyz import lab_to_xyz
+from .srgb_xyz import xyz_to_srgb
+
+
+def lab_to_srgb(lab: np.ndarray, whitepoint: np.ndarray) -> np.ndarray:
+    """Convert L*a*b* values to sRGB.
+
+    Parameters
+    ----------
+    lab : np.ndarray
+        L*a*b* values in either ``(n, 3)`` XW format or ``(rows, cols, 3)`` RGB
+        format.
+    whitepoint : array-like
+        Reference white point as ``(Xn, Yn, Zn)``.
+
+    Returns
+    -------
+    np.ndarray
+        sRGB values in the same spatial format as ``lab``.
+    """
+    xyz = lab_to_xyz(lab, whitepoint)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    return srgb

--- a/python/isetcam/srgb_to_lab.py
+++ b/python/isetcam/srgb_to_lab.py
@@ -1,0 +1,28 @@
+"""Convert nonlinear sRGB values to CIE L*a*b*."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .srgb_xyz import srgb_to_xyz
+from .xyz_to_lab import xyz_to_lab
+
+
+def srgb_to_lab(srgb: np.ndarray, whitepoint: np.ndarray) -> np.ndarray:
+    """Convert sRGB values to L*a*b*.
+
+    Parameters
+    ----------
+    srgb : np.ndarray
+        sRGB values in either ``(n, 3)`` XW format or ``(rows, cols, 3)`` RGB
+        format.
+    whitepoint : array-like
+        Reference white point as ``(Xn, Yn, Zn)``.
+
+    Returns
+    -------
+    np.ndarray
+        L*a*b* values in the same spatial format as ``srgb``.
+    """
+    xyz = srgb_to_xyz(srgb)
+    return xyz_to_lab(xyz, whitepoint)

--- a/python/tests/test_srgb_lab.py
+++ b/python/tests/test_srgb_lab.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from isetcam import srgb_to_lab, lab_to_srgb
+
+WHITEPOINT = np.array([0.95047, 1.0, 1.08883])
+
+
+def test_srgb_lab_round_trip_xw():
+    srgb = np.random.rand(10, 3)
+    lab = srgb_to_lab(srgb, WHITEPOINT)
+    srgb2 = lab_to_srgb(lab, WHITEPOINT)
+    assert np.allclose(srgb2, srgb, atol=1e-6)
+
+
+def test_srgb_lab_round_trip_rgb():
+    srgb = np.random.rand(4, 5, 3)
+    lab = srgb_to_lab(srgb, WHITEPOINT)
+    srgb2 = lab_to_srgb(lab, WHITEPOINT)
+    assert np.allclose(srgb2, srgb, atol=1e-6)


### PR DESCRIPTION
## Summary
- convert between sRGB and Lab
- expose conversion helpers
- test round trip between sRGB and Lab

## Testing
- `pytest -q python/tests/test_srgb_lab.py`

------
https://chatgpt.com/codex/tasks/task_e_683bc95515e88323aa139e0cf3f858ee