### PR TITLE
Implement oi_translate and add tests

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -12,6 +12,7 @@ from .oi_photon_noise import oi_photon_noise
 from .oi_to_file import oi_to_file
 from .oi_crop import oi_crop
 from .oi_pad import oi_pad
+from .oi_translate import oi_translate
 from .oi_rotate import oi_rotate
 from .oi_spatial_support import oi_spatial_support
 from .oi_spatial_resample import oi_spatial_resample
@@ -43,6 +44,7 @@ __all__ = [
     "oi_compute",
     "oi_crop",
     "oi_pad",
+    "oi_translate",
     "oi_rotate",
     "oi_spatial_support",
     "oi_spatial_resample",

--- a/python/isetcam/opticalimage/oi_translate.py
+++ b/python/isetcam/opticalimage/oi_translate.py
@@ -1,0 +1,51 @@
+"""Translate the photon data of an OpticalImage."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+def oi_translate(oi: OpticalImage, dx: int, dy: int, fill: float = 0) -> OpticalImage:
+    """Shift ``oi`` by ``dx`` and ``dy`` pixels.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image to translate.
+    dx, dy : int
+        Horizontal and vertical shift in pixels. Positive values move the
+        image to the right and down respectively.
+    fill : float, optional
+        Value used to fill areas exposed by the shift. Defaults to 0.
+
+    Returns
+    -------
+    OpticalImage
+        New optical image containing the shifted photon data with the same
+        wavelength samples and name.
+    """
+
+    photons = oi.photons
+    h, w = photons.shape[:2]
+    shifted = np.full_like(photons, fill, dtype=photons.dtype)
+
+    if abs(dx) < w and abs(dy) < h:
+        if dx >= 0:
+            src_x = slice(0, w - dx)
+            dst_x = slice(dx, dx + (w - dx))
+        else:
+            src_x = slice(-dx, w)
+            dst_x = slice(0, w + dx)
+
+        if dy >= 0:
+            src_y = slice(0, h - dy)
+            dst_y = slice(dy, dy + (h - dy))
+        else:
+            src_y = slice(-dy, h)
+            dst_y = slice(0, h + dy)
+
+        shifted[dst_y, dst_x, :] = photons[src_y, src_x, :]
+
+    return OpticalImage(photons=shifted, wave=oi.wave, name=oi.name)

--- a/python/tests/test_oi_translate.py
+++ b/python/tests/test_oi_translate.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from isetcam.opticalimage import OpticalImage, oi_translate
+
+
+def _simple_oi(width: int = 3, height: int = 3, n_wave: int = 1) -> OpticalImage:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    return OpticalImage(photons=photons, wave=wave)
+
+
+def test_oi_translate_positive():
+    oi = _simple_oi(3, 3, 1)
+    out = oi_translate(oi, 1, 1, fill=-1)
+    expected = np.full_like(oi.photons, -1)
+    expected[1:, 1:, :] = oi.photons[:-1, :-1, :]
+    assert np.array_equal(out.photons, expected)
+    assert np.array_equal(out.wave, oi.wave)
+    assert out.name == oi.name
+
+
+def test_oi_translate_negative():
+    oi = _simple_oi(3, 3, 1)
+    out = oi_translate(oi, -1, -1, fill=0)
+    expected = np.zeros_like(oi.photons)
+    expected[:-1, :-1, :] = oi.photons[1:, 1:, :]
+    assert np.array_equal(out.photons, expected)
+
+
+def test_oi_translate_outside():
+    oi = _simple_oi(2, 2, 1)
+    out = oi_translate(oi, 5, 0, fill=2)
+    expected = np.full_like(oi.photons, 2)
+    assert np.array_equal(out.photons, expected)
+


### PR DESCRIPTION
## Summary
- implement `oi_translate` for shifting optical images
- export the new function
- test translation and fill handling

## Testing
- `pytest -q python/tests/test_oi_translate.py`

------
https://chatgpt.com/codex/tasks/task_e_683bcd76fdcc8323b28568a3de97913c