### PR TITLE
Add sensor ISO speed calculation

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -24,6 +24,7 @@ from .sensor_rotate import sensor_rotate
 from .sensor_show_cfa import sensor_show_cfa
 from .sensor_stats import sensor_stats
 from .sensor_clear_data import sensor_clear_data
+from .sensor_iso_speed import sensor_iso_speed
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -77,4 +78,5 @@ __all__ = [
     "sensor_rotate",
     "sensor_stats",
     "sensor_clear_data",
+    "sensor_iso_speed",
 ]

--- a/python/isetcam/sensor/sensor_iso_speed.py
+++ b/python/isetcam/sensor/sensor_iso_speed.py
@@ -1,0 +1,41 @@
+"""Compute ISO speed from sensor noise parameters using SNR=10 criterion."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .sensor_class import Sensor
+from .sensor_get import sensor_get
+
+
+def sensor_iso_speed(sensor: Sensor) -> float:
+    """Return the ISO speed for ``sensor`` using the SNR=10 method."""
+    conv_gain = sensor_get(sensor, "conversion_gain")
+    read_noise = sensor_get(sensor, "read_noise_electrons")
+    gain_sd = sensor_get(sensor, "gain_sd") / 100.0
+    offset_sd = sensor_get(sensor, "offset_sd")
+
+    dsnu = offset_sd / conv_gain
+
+    a = 100.0 * gain_sd ** 2 - 1.0
+    b = 100.0
+    c = 100.0 * (read_noise ** 2 + dsnu ** 2)
+
+    if a >= 0:
+        return float("inf")
+
+    disc = b ** 2 - 4.0 * a * c
+    if disc < 0:
+        return float("inf")
+
+    sqrt_disc = float(np.sqrt(disc))
+    e1 = (-b + sqrt_disc) / (2.0 * a)
+    e2 = (-b - sqrt_disc) / (2.0 * a)
+    electrons = e1 if e1 > 0 else e2
+    if electrons <= 0:
+        return float("inf")
+
+    v_per_ls = getattr(sensor, "volts_per_lux_sec", 1.0)
+    luxsec = electrons / (conv_gain * v_per_ls)
+
+    return 10.0 / luxsec

--- a/python/tests/test_sensor_iso_speed.py
+++ b/python/tests/test_sensor_iso_speed.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from isetcam.sensor import Sensor, sensor_set, sensor_iso_speed
+
+
+def _expected_iso(cg, read_noise, gain_sd, offset_sd, vpls):
+    gain_sd = gain_sd / 100.0
+    dsnu = offset_sd / cg
+    a = 100.0 * gain_sd ** 2 - 1.0
+    b = 100.0
+    c = 100.0 * (read_noise ** 2 + dsnu ** 2)
+    if a >= 0:
+        return float("inf")
+    disc = b ** 2 - 4.0 * a * c
+    e1 = (-b + np.sqrt(disc)) / (2.0 * a)
+    e2 = (-b - np.sqrt(disc)) / (2.0 * a)
+    e = e1 if e1 > 0 else e2
+    luxsec = e / (cg * vpls)
+    return 10.0 / luxsec
+
+
+def test_iso_speed_shot_noise_only():
+    s = Sensor(volts=np.zeros((1,)), wave=np.array([550]), exposure_time=0.01)
+    sensor_set(s, "conversion_gain", 1.0)
+    sensor_set(s, "read_noise_electrons", 0.0)
+    sensor_set(s, "gain_sd", 0.0)
+    sensor_set(s, "offset_sd", 0.0)
+    s.volts_per_lux_sec = 1000.0
+
+    iso = sensor_iso_speed(s)
+    exp_iso = _expected_iso(1.0, 0.0, 0.0, 0.0, 1000.0)
+    assert np.isclose(iso, exp_iso)
+
+
+def test_iso_speed_with_read_noise():
+    s = Sensor(volts=np.zeros((1,)), wave=np.array([550]), exposure_time=0.01)
+    sensor_set(s, "conversion_gain", 1.0)
+    sensor_set(s, "read_noise_electrons", 20.0)
+    sensor_set(s, "gain_sd", 0.0)
+    sensor_set(s, "offset_sd", 0.0)
+    s.volts_per_lux_sec = 1000.0
+
+    iso = sensor_iso_speed(s)
+    exp_iso = _expected_iso(1.0, 20.0, 0.0, 0.0, 1000.0)
+    assert np.isclose(iso, exp_iso)


### PR DESCRIPTION
## Summary
- add function `sensor_iso_speed` to compute ISO speed by solving for SNR=10
- expose `sensor_iso_speed` from sensor package
- test ISO speed calculations with simple examples

## Testing
- `PYTHONPATH=python pytest python/tests/test_sensor_iso_speed.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683bd28114948323ba087113a4ecc04b