### PR TITLE
Add human cone utilities and Watson models

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -112,6 +112,10 @@ from .human import (
     human_lsf,
     human_cone_contrast,
     human_cone_isolating,
+    human_cones,
+    human_cone_mosaic,
+    watson_impulse_response,
+    watson_rgc_spacing,
 )
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
@@ -240,6 +244,10 @@ __all__ = [
     'human_lsf',
     'human_cone_contrast',
     'human_cone_isolating',
+    'human_cones',
+    'human_cone_mosaic',
+    'watson_impulse_response',
+    'watson_rgc_spacing',
     'iset_root_path',
     'data_path',
     'ie_init',

--- a/python/isetcam/human/__init__.py
+++ b/python/isetcam/human/__init__.py
@@ -10,6 +10,10 @@ from .human_achromatic_otf import human_achromatic_otf
 from .human_lsf import human_lsf
 from .human_cone_contrast import human_cone_contrast
 from .human_cone_isolating import human_cone_isolating
+from .human_cones import human_cones
+from .human_cone_mosaic import human_cone_mosaic
+from .watson_impulse_response import watson_impulse_response
+from .watson_rgc_spacing import watson_rgc_spacing
 
 __all__ = [
     'human_pupil_size',
@@ -22,4 +26,8 @@ __all__ = [
     'human_lsf',
     'human_cone_contrast',
     'human_cone_isolating',
+    'human_cones',
+    'human_cone_mosaic',
+    'watson_impulse_response',
+    'watson_rgc_spacing',
 ]

--- a/python/isetcam/human/human_cone_mosaic.py
+++ b/python/isetcam/human/human_cone_mosaic.py
@@ -1,0 +1,67 @@
+"""Create a spatial arrangement of the human cone mosaic."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+_DEF_DENSITIES = np.array([0.1, 0.55, 0.25, 0.1])
+
+
+def _init_rng(r_seed):
+    rng = np.random.default_rng()
+    if r_seed is None:
+        return rng, rng.bit_generator.state
+    if isinstance(r_seed, (int, np.integer)):
+        rng = np.random.default_rng(int(r_seed))
+        return rng, rng.bit_generator.state
+    rng.bit_generator.state = r_seed
+    return rng, r_seed
+
+
+def human_cone_mosaic(
+    sz: tuple[int, int],
+    densities: np.ndarray | None = None,
+    um_cone_width: float = 2.0,
+    r_seed=None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, object]:
+    """Return cone mosaic positions and types."""
+    if densities is None:
+        densities = _DEF_DENSITIES.copy()
+    else:
+        densities = np.asarray(densities, dtype=float)
+
+    rng, seed_out = _init_rng(r_seed)
+
+    s = densities.sum()
+    if densities.size == 4:
+        densities = densities / s
+    elif densities.size == 3:
+        if s >= 1:
+            densities = np.hstack(([0.0], densities / s))
+        else:
+            densities = np.hstack(([1 - s], densities))
+    n_types = 4
+
+    n_locs = int(np.prod(sz))
+    n_receptors = np.round(densities * n_locs).astype(int)
+    if n_receptors.sum() < n_locs:
+        i = int(np.argmax(n_receptors))
+        n_receptors[i] += n_locs - n_receptors.sum()
+
+    tmp = np.zeros(n_locs, dtype=int)
+    start = 0
+    for ii in range(n_types):
+        tmp[start : start + n_receptors[ii]] = ii + 1
+        start += n_receptors[ii]
+
+    cone_type = rng.permutation(tmp).reshape(sz[0], sz[1])
+
+    x = (np.arange(1, sz[1] + 1) * um_cone_width).astype(float)
+    x -= x.mean()
+    y = (np.arange(1, sz[0] + 1) * um_cone_width).astype(float)
+    y -= y.mean()
+    X, Y = np.meshgrid(x, y)
+    xy = np.column_stack((X.ravel(), Y.ravel()))
+
+    return xy, cone_type, densities, seed_out

--- a/python/isetcam/human/human_cones.py
+++ b/python/isetcam/human/human_cones.py
@@ -1,0 +1,48 @@
+"""Spectral cone fundamentals corrected for macular pigment."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.io import loadmat
+
+from ..ie_read_spectra import ie_read_spectra
+from ..data_path import data_path
+
+
+_DEF_WAVE = np.arange(370, 731)
+
+
+def _macular_unit_density(wave: np.ndarray) -> np.ndarray:
+    """Return unit macular pigment density at ``wave``."""
+    mat = loadmat(data_path("human/macularPigment.mat"))
+    src_wave = mat["wavelength"].ravel()
+    data = mat["data"].ravel()
+    return np.interp(wave, src_wave, data, left=0.0, right=0.0) / 0.3521
+
+
+def human_cones(
+    file_name: str = "stockmanAbs",
+    wave: np.ndarray | None = None,
+    macular_density: float | None = None,
+    included_density: float = 0.35,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return cone spectral sensitivities corrected for macular pigment."""
+    if wave is None:
+        wave = _DEF_WAVE.copy()
+    else:
+        wave = np.asarray(wave, dtype=float)
+
+    fname = file_name
+    if not fname.endswith(".mat"):
+        fname = f"{fname}.mat"
+    path = data_path(f"human/{fname}")
+    cones, wave, _, _ = ie_read_spectra(path, wave)
+
+    if macular_density is None:
+        macular_correction = np.ones(wave.shape)
+        return cones, macular_correction, wave
+
+    unit = _macular_unit_density(wave)
+    macular_correction = 10.0 ** (-(unit * (macular_density - included_density)))
+    cones = cones * macular_correction[:, None]
+    return cones, macular_correction, wave

--- a/python/isetcam/human/watson_impulse_response.py
+++ b/python/isetcam/human/watson_impulse_response.py
@@ -1,0 +1,36 @@
+"""Watson temporal impulse response model."""
+
+from __future__ import annotations
+
+import math
+import numpy as np
+
+
+_DEF_T = np.arange(0.001, 1.001, 0.002)
+
+
+def watson_impulse_response(
+    t: np.ndarray | None = None, transient_factor: float = 0.5
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return impulse response and its temporal MTF."""
+    if t is None:
+        t = _DEF_T.copy()
+    else:
+        t = np.asarray(t, dtype=float)
+    t = t[t > 0]
+
+    tau = 0.00494
+    kappa = 1.33
+    n1 = 9
+    n2 = 10
+
+    h1 = (t / tau) ** (n1 - 1) * np.exp(-t / tau) / (t * math.factorial(n1 - 1))
+    h2 = (t / (kappa * tau)) ** (n2 - 1) * np.exp(-t / (kappa * tau)) / (
+        t * math.factorial(n2 - 1)
+    )
+    imp = h1 - transient_factor * h2
+    imp = imp / imp.sum()
+
+    t_mtf = np.abs(np.fft.fft(imp))
+    freq = (1 / t.max()) * np.arange(1, t.size + 1)
+    return imp, t, t_mtf, freq

--- a/python/isetcam/human/watson_rgc_spacing.py
+++ b/python/isetcam/human/watson_rgc_spacing.py
@@ -1,0 +1,66 @@
+"""Watson retinal ganglion cell spacing model."""
+
+from __future__ import annotations
+
+import math
+import numpy as np
+
+
+_PARAMS = np.array(
+    [
+        [0.9851, 1.058, 22.14],
+        [0.9935, 1.035, 16.35],
+        [0.9729, 1.084, 7.633],
+        [0.9960, 0.9932, 12.13],
+    ]
+)
+_DGF0 = 33163.2
+
+
+def watson_rgc_spacing(
+    fov_cols: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return midget RGC spacing across the field of view."""
+    r = np.arange(0.05, 100.0 + 1e-9, 0.1)
+    dgf = np.zeros((4, r.size))
+    for k in range(4):
+        a, r2, re = _PARAMS[k]
+        dgf[k] = _DGF0 * (a * (1 + r / r2) ** -2 + (1 - a) * np.exp(-r / re))
+
+    fr = (1 / 1.12) * (1 + r / 41.03) ** -1
+    dmf1d = fr * dgf
+    smf1d = np.sqrt(2.0 / (np.sqrt(3.0) * dmf1d))
+
+    deg_start = -fov_cols / 2
+    deg_end = fov_cols / 2
+    degarr = np.linspace(deg_start, deg_end, fov_cols + 1)
+    convert = math.sqrt(2.0)
+    smf0 = np.zeros((degarr.size, degarr.size))
+    for ix, x in enumerate(degarr):
+        for iy, y in enumerate(degarr):
+            rxy = math.hypot(x, y)
+            if rxy == 0:
+                smf0[ix, iy] = 0.0
+                continue
+            if x <= 0 and y >= 0:
+                karr = (0, 1)
+            elif x > 0 and y > 0:
+                karr = (2, 1)
+            elif x > 0 and y < 0:
+                karr = (2, 3)
+            else:
+                karr = (0, 3)
+            smf = []
+            for kk in karr:
+                a, r2, re = _PARAMS[kk]
+                dgf_e = _DGF0 * (a * (1 + rxy / r2) ** -2 + (1 - a) * np.exp(-rxy / re))
+                fr_e = (1 / 1.12) * (1 + rxy / 41.03) ** -1
+                dmf_e = fr_e * dgf_e
+                smf.append(math.sqrt(2.0 / (math.sqrt(3.0) * dmf_e)))
+            smf0[ix, iy] = (
+                convert
+                * (1 / rxy)
+                * math.sqrt(x * x * smf[0] ** 2 + y * y * smf[1] ** 2)
+            )
+
+    return smf0, r, smf1d

--- a/python/tests/test_human_cone_mosaic.py
+++ b/python/tests/test_human_cone_mosaic.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from isetcam.human import human_cone_mosaic
+
+
+def test_human_cone_mosaic_seed():
+    sz = (3, 3)
+    xy, cone_type, dens, seed = human_cone_mosaic(sz, r_seed=42)
+
+    expected_xy = np.array([
+        [-2.0, -2.0],
+        [0.0, -2.0],
+        [2.0, -2.0],
+        [-2.0, 0.0],
+        [0.0, 0.0],
+        [2.0, 0.0],
+        [-2.0, 2.0],
+        [0.0, 2.0],
+        [2.0, 2.0],
+    ])
+    expected_cone_type = np.array([
+        [2, 1, 3],
+        [2, 2, 3],
+        [2, 2, 4],
+    ])
+    assert xy.shape == (9, 2)
+    assert np.allclose(xy, expected_xy)
+    assert np.array_equal(cone_type, expected_cone_type)
+    assert np.isclose(dens.sum(), 1.0)
+    # seed is a dict containing RNG state
+    assert isinstance(seed, dict)

--- a/python/tests/test_human_cones.py
+++ b/python/tests/test_human_cones.py
@@ -1,0 +1,28 @@
+import numpy as np
+from scipy.io import loadmat
+
+from isetcam.human import human_cones
+from isetcam import ie_read_spectra, data_path
+
+
+def test_human_cones_no_macular():
+    wave = np.arange(370, 731)
+    cones, mac, out_wave = human_cones('stockmanAbs', wave)
+    data, _, _, _ = ie_read_spectra(data_path('human/stockmanAbs.mat'), wave)
+    assert np.array_equal(out_wave, wave)
+    assert np.allclose(mac, 1.0)
+    assert np.allclose(cones, data)
+
+
+def test_human_cones_with_macular():
+    wave = np.arange(370, 731)
+    cones, mac, _ = human_cones('stockmanAbs', wave, macular_density=0.6, included_density=0.35)
+    cone_data, _, _, _ = ie_read_spectra(data_path('human/stockmanAbs.mat'), wave)
+    mat = loadmat(data_path('human/macularPigment.mat'))
+    unit = np.interp(
+        wave, mat['wavelength'].ravel(), mat['data'].ravel(), left=0.0, right=0.0
+    ) / 0.3521
+    expected_mac = 10 ** (-(unit * (0.6 - 0.35)))
+    expected_cones = cone_data * expected_mac[:, None]
+    assert np.allclose(mac, expected_mac)
+    assert np.allclose(cones, expected_cones)

--- a/python/tests/test_watson_models.py
+++ b/python/tests/test_watson_models.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from isetcam.human import watson_impulse_response, watson_rgc_spacing
+
+
+def test_watson_impulse_response_default():
+    imp, t, mtf, freq = watson_impulse_response()
+    assert t.size == 500
+    assert np.isclose(imp.sum(), 1.0)
+    assert np.allclose(imp[:5], [
+        1.64341760e-09,
+        2.39250786e-06,
+        5.68669063e-05,
+        3.98655496e-04,
+        1.53883323e-03,
+    ])
+    assert np.allclose(mtf[:3], [1.0, 1.00990868, 1.03712801])
+    assert np.allclose(freq[:3], [1.001001, 2.002002, 3.003003])
+
+
+def test_watson_rgc_spacing_basic():
+    smf0, r, smf1d = watson_rgc_spacing(5)
+    assert r.size == 1000
+    assert smf1d.shape == (4, r.size)
+    assert np.allclose(smf1d[:, 0], [
+        0.00653927,
+        0.00654839,
+        0.00652906,
+        0.00656183,
+    ])
+    assert np.isclose(smf0[3, 3], 0.014671495492619382)
+    assert smf0.shape == (6, 6)


### PR DESCRIPTION
## Summary
- port humanCones.m and humanConeMosaic.m
- implement watson temporal impulse response and RGC spacing
- expose new helpers through `isetcam.human`
- test cones, cone mosaic and Watson models

## Testing
- `pytest python/tests/test_human_cones.py python/tests/test_human_cone_mosaic.py python/tests/test_watson_models.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683bdccb46748323ae2929f8e756b3d0