### PR TITLE
Port cos4th and defocused MTF

### DIFF
--- a/python/isetcam/human/human_otf.py
+++ b/python/isetcam/human/human_otf.py
@@ -47,7 +47,7 @@ def human_otf(
     max_f = min(max_f1, max_f2)
     sample_sf = np.linspace(0, max_f, 40)
 
-    otf = _human_core(wave, sample_sf, p_radius, d0)
+    otf = _human_core(sample_sf, p_radius, d0, wave)
 
     r, c = f_support.shape[:2]
     otf2d = np.zeros((r, c, wave.size))

--- a/python/isetcam/optics/__init__.py
+++ b/python/isetcam/optics/__init__.py
@@ -8,6 +8,8 @@ from .optics_to_file import optics_to_file
 from .optics_from_file import optics_from_file
 from .optics_psf import optics_psf
 from .optics_otf import optics_otf
+from .optics_cos4th import optics_cos4th
+from .optics_defocused_mtf import optics_defocused_mtf, optics_defocus_core
 
 __all__ = [
     "Optics",
@@ -18,4 +20,7 @@ __all__ = [
     "optics_from_file",
     "optics_psf",
     "optics_otf",
+    "optics_cos4th",
+    "optics_defocused_mtf",
+    "optics_defocus_core",
 ]

--- a/python/isetcam/optics/optics_cos4th.py
+++ b/python/isetcam/optics/optics_cos4th.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def optics_cos4th(
+    x: np.ndarray,
+    y: np.ndarray,
+    image_distance: float,
+    image_diagonal: float,
+    f_number: float,
+    magnification: float = 1.0,
+) -> np.ndarray:
+    """Calculate cos4th off-axis falloff.
+
+    Parameters
+    ----------
+    x, y : array-like
+        Spatial support coordinates in meters.
+    image_distance : float
+        Distance from lens to image plane in meters.
+    image_diagonal : float
+        Diagonal size of the image in meters.
+    f_number : float
+        Lens f-number.
+    magnification : float, optional
+        Magnification factor used for the near-field case. Defaults to 1.0.
+
+    Returns
+    -------
+    np.ndarray
+        Relative illumination falloff for each ``(x, y)`` position.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    s_factor = np.sqrt(image_distance ** 2 + (x ** 2 + y ** 2))
+    if image_distance > 10 * image_diagonal:
+        spatial_fall = (image_distance / s_factor) ** 4
+    else:
+        cos_phi = image_distance / s_factor
+        sin_phi = np.sqrt(1.0 - cos_phi ** 2)
+        tan_phi = sin_phi / cos_phi
+        sin_theta = 1.0 / (1.0 + 4.0 * (f_number * (1.0 - magnification)) ** 2)
+        cos_theta = np.sqrt(1.0 - sin_theta ** 2)
+        tan_theta = sin_theta / cos_theta
+        spatial_fall = (
+            (np.pi / 2.0)
+            * (
+                1.0
+                - (1.0 - tan_theta ** 2 + tan_phi ** 2)
+                / np.sqrt(
+                    tan_phi ** 4
+                    + 2 * tan_phi ** 2 * (1.0 - tan_theta ** 2)
+                    + 1.0 / cos_theta ** 4
+                )
+            )
+        )
+        spatial_fall /= np.pi * sin_theta ** 2
+    return spatial_fall

--- a/python/isetcam/optics/optics_defocused_mtf.py
+++ b/python/isetcam/optics/optics_defocused_mtf.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import numpy as np
+from scipy.special import jn
+
+from .optics_class import Optics
+
+
+def optics_defocused_mtf(s: np.ndarray, alpha: np.ndarray) -> np.ndarray:
+    """Diffraction-limited MTF with defocus.
+
+    Parameters
+    ----------
+    s : array-like
+        Reduced spatial frequency in the range ``0`` to ``2``.
+    alpha : array-like
+        Defocus parameter ``w20`` scaled by frequency.
+
+    Returns
+    -------
+    np.ndarray
+        Modulation transfer values for each spatial frequency.
+    """
+    s = np.asarray(s, dtype=float)
+    alpha = np.asarray(alpha, dtype=float)
+    nf = np.abs(s) / 2.0
+    beta = np.sqrt(1.0 - nf ** 2)
+    otf = np.zeros_like(nf)
+    ii = alpha == 0
+    if np.any(ii):
+        otf[ii] = (2.0 / np.pi) * (np.arccos(nf[ii]) - nf[ii] * beta[ii])
+    jj = ~ii
+    if np.any(jj):
+        H1 = (
+            beta[jj] * jn(1, alpha[jj])
+            + 0.5 * np.sin(2 * beta[jj]) * (jn(1, alpha[jj]) - jn(3, alpha[jj]))
+            - 0.25 * np.sin(4 * beta[jj]) * (jn(3, alpha[jj]) - jn(5, alpha[jj]))
+        )
+        H2 = (
+            np.sin(beta[jj]) * (jn(0, alpha[jj]) - jn(2, alpha[jj]))
+            + (1.0 / 3.0)
+            * np.sin(3 * beta[jj])
+            * (jn(2, alpha[jj]) - jn(4, alpha[jj]))
+            - (1.0 / 5.0)
+            * np.sin(5 * beta[jj])
+            * (jn(4, alpha[jj]) - jn(6, alpha[jj]))
+        )
+        otf[jj] = (
+            (4.0 / (np.pi * alpha[jj])) * np.cos(alpha[jj] * nf[jj]) * H1
+            - (4.0 / (np.pi * alpha[jj])) * np.sin(alpha[jj] * nf[jj]) * H2
+        )
+    if otf.size > 0 and otf.flat[0] != 0:
+        otf = otf / otf.flat[0]
+    return otf
+
+
+def optics_defocus_core(
+    optics: Optics,
+    sample_sf: np.ndarray,
+    D: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute defocused OTF for ``optics``.
+
+    Parameters
+    ----------
+    optics : Optics
+        Optics description.
+    sample_sf : array-like
+        Spatial frequencies in cycles/degree.
+    D : array-like
+        Defocus in diopters for each wavelength.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        ``(otf, sample_sf_mm)`` where ``otf`` has shape ``(n_wave, n_sf)`` and
+        ``sample_sf_mm`` are the frequencies in cycles/mm.
+    """
+    if optics is None:
+        raise ValueError("optics is required")
+
+    sample_sf = np.asarray(sample_sf, dtype=float).reshape(-1)
+    D = np.asarray(D, dtype=float).reshape(-1)
+    p = optics.f_length / (2.0 * optics.f_number)
+    D0 = 1.0 / optics.f_length
+
+    w20 = (p ** 2 / 2.0) * (D0 * D) / (D0 + D)
+    c = D0 / np.tan(np.deg2rad(1.0))
+
+    cSF = sample_sf * c
+    ii = cSF == 0
+    if np.any(ii):
+        nonzero = cSF[~ii]
+        if nonzero.size == 0:
+            cSF[ii] = 1e-12
+        else:
+            cSF[ii] = np.min(nonzero) * 1e-12
+
+    wave = np.asarray(optics.wave, dtype=float) * 1e-9
+    s = np.zeros((wave.size, sample_sf.size))
+    alpha = np.zeros_like(s)
+    otf = np.zeros_like(s)
+
+    for i in range(wave.size):
+        s[i, :] = (wave[i] / (D0 * p)) * cSF
+        alpha[i, :] = (4.0 * np.pi / wave[i]) * w20[i] * np.abs(s[i, :])
+        otf[i, :] = optics_defocused_mtf(s[i, :], np.abs(alpha[i, :]))
+
+    l = np.angle(otf) != 0
+    otf[l] = 0
+    otf = np.real(otf)
+
+    deg_per_mm = 1.0 / (np.tan(np.deg2rad(1.0)) * (1.0 / D0) * 1000.0)
+    sample_sf_mm = sample_sf * deg_per_mm
+
+    return otf, sample_sf_mm

--- a/python/tests/test_optics_cos4th.py
+++ b/python/tests/test_optics_cos4th.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from isetcam.optics import optics_cos4th
+
+
+def test_cos4th_far_field():
+    x = np.array([[-1e-3, 0.0, 1e-3]])
+    y = np.zeros_like(x)
+    img_dist = 0.02
+    img_diag = 0.001
+    fnum = 4.0
+    expected = (img_dist / np.sqrt(img_dist**2 + x**2 + y**2)) ** 4
+    out = optics_cos4th(x, y, img_dist, img_diag, fnum)
+    assert np.allclose(out, expected)
+
+
+def test_cos4th_near_field():
+    x = np.array([0.0])
+    y = np.array([0.001])
+    img_dist = 0.01
+    img_diag = 0.02
+    fnum = 5.6
+    magnification = 0.5
+    cos_phi = img_dist / np.sqrt(img_dist**2 + x**2 + y**2)
+    sin_phi = np.sqrt(1.0 - cos_phi**2)
+    tan_phi = sin_phi / cos_phi
+    sin_theta = 1.0 / (1.0 + 4.0 * (fnum * (1.0 - magnification)) ** 2)
+    cos_theta = np.sqrt(1.0 - sin_theta**2)
+    tan_theta = sin_theta / cos_theta
+    expected = (
+        (np.pi / 2.0)
+        * (
+            1.0
+            - (1.0 - tan_theta**2 + tan_phi**2)
+            / np.sqrt(tan_phi**4 + 2 * tan_phi**2 * (1.0 - tan_theta**2) + 1.0 / cos_theta**4)
+        )
+    )
+    expected /= np.pi * sin_theta**2
+    out = optics_cos4th(x, y, img_dist, img_diag, fnum, magnification)
+    assert np.allclose(out, expected)

--- a/python/tests/test_optics_defocused_mtf.py
+++ b/python/tests/test_optics_defocused_mtf.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from isetcam.optics import (
+    Optics,
+    optics_defocused_mtf,
+    optics_defocus_core,
+)
+
+
+def test_optics_defocused_mtf_basic():
+    s = np.linspace(0, 2, 5)
+    alpha = np.zeros_like(s)
+    out = optics_defocused_mtf(s, alpha)
+    nf = np.abs(s) / 2.0
+    beta = np.sqrt(1.0 - nf ** 2)
+    expected = (2.0 / np.pi) * (np.arccos(nf) - nf * beta)
+    expected /= expected[0]
+    assert np.allclose(out, expected)
+
+
+def test_optics_defocus_core_simple():
+    optics = Optics(f_number=4.0, f_length=0.005, wave=np.array([500]))
+    sample_sf = np.array([0.0, 10.0, 20.0])
+    D = np.array([0.5])
+
+    otf, sfmm = optics_defocus_core(optics, sample_sf, D)
+
+    p = optics.f_length / (2.0 * optics.f_number)
+    D0 = 1.0 / optics.f_length
+    w20 = (p ** 2 / 2.0) * (D0 * D) / (D0 + D)
+    c = D0 / np.tan(np.deg2rad(1.0))
+    cSF = sample_sf * c
+    cSF[0] = np.min(cSF[1:]) * 1e-12
+    lam = optics.wave[0] * 1e-9
+    s = (lam / (D0 * p)) * cSF
+    alpha = (4.0 * np.pi / lam) * w20[0] * np.abs(s)
+    expected_otf = optics_defocused_mtf(s, np.abs(alpha))
+
+    deg_per_mm = 1.0 / (np.tan(np.deg2rad(1.0)) * (1.0 / D0) * 1000.0)
+    expected_sfmm = sample_sf * deg_per_mm
+
+    assert np.allclose(otf[0], expected_otf)
+    assert np.allclose(sfmm, expected_sfmm)


### PR DESCRIPTION
## Summary
- port MATLAB `cos4th` falloff to Python as `optics_cos4th`
- port `opticsDefocusedMTF` and helper `opticsDefocusCore`
- expose new functions in optics package and fix human OTF helper
- add unit tests for the new routines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683be0203d208323829a1a8188ef6b07