### PR TITLE
Add camera_full_reference metric

### DIFF
--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -15,6 +15,7 @@ from .camera_acutance import camera_acutance
 from .camera_color_accuracy import camera_color_accuracy
 from .camera_compute_sequence import camera_compute_sequence
 from .camera_clear_data import camera_clear_data
+from .camera_full_reference import camera_full_reference
 
 __all__ = [
     "Camera",
@@ -32,4 +33,5 @@ __all__ = [
     "camera_color_accuracy",
     "camera_compute_sequence",
     "camera_clear_data",
+    "camera_full_reference",
 ]

--- a/python/isetcam/camera/camera_full_reference.py
+++ b/python/isetcam/camera/camera_full_reference.py
@@ -1,0 +1,70 @@
+"""Compute basic full-reference metrics for a camera scene pair."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import numpy as np
+
+from .camera_class import Camera
+from .camera_compute import camera_compute
+from .camera_mtf import camera_mtf
+from .camera_vsnr import camera_vsnr
+from ..scene import Scene
+from ..quanta2energy import quanta_to_energy
+from ..ie_xyz_from_energy import ie_xyz_from_energy
+from ..srgb_xyz import xyz_to_srgb
+from ..srgb_to_lab import srgb_to_lab
+from ..metrics import delta_e_ab
+
+
+_WHITEPOINT = np.array([0.95047, 1.0, 1.08883])
+
+
+def camera_full_reference(camera: Camera, scene: Scene) -> Dict[str, Any]:
+    """Return simple full-reference metrics for ``camera`` imaging ``scene``.
+
+    This function runs the camera pipeline on ``scene`` and compares the
+    rendered result to an ideal image using several existing quality metrics.
+    The returned dictionary contains the following entries:
+
+    ``"mtf"``
+        Tuple ``(freqs, mtf)`` from :func:`camera_mtf`.
+    ``"deltaE"``
+        CIELAB color difference image between the ideal rendering and the
+        camera result using :func:`~isetcam.metrics.delta_e_ab`.
+    ``"vsnr"``
+        Visible SNR value computed by :func:`camera_vsnr`.
+    """
+
+    # Compute the camera result for the scene
+    camera = camera_compute(camera, scene)
+
+    # Ideal XYZ image from the scene photon data
+    energy = quanta_to_energy(scene.wave, scene.photons)
+    xyz_ideal = ie_xyz_from_energy(energy, scene.wave)
+    srgb_ideal, _, _ = xyz_to_srgb(xyz_ideal)
+    lab_ideal = srgb_to_lab(srgb_ideal, _WHITEPOINT)
+
+    # Approximate display rendering by normalizing the sensor response and
+    # replicating it across RGB channels
+    volts = camera.sensor.volts.astype(float)
+    if volts.size == 0:
+        raise ValueError("camera.sensor.volts is empty")
+    scaled = volts / volts.max() if volts.max() > 0 else volts
+    srgb_result = np.repeat(scaled[:, :, None], 3, axis=2)
+    lab_result = srgb_to_lab(srgb_result, _WHITEPOINT)
+
+    delta_e = delta_e_ab(lab_ideal, lab_result)
+
+    freqs, mtf = camera_mtf(camera)
+    vsnr_val = camera_vsnr(camera, scene)
+
+    return {
+        "mtf": (freqs, mtf),
+        "deltaE": delta_e,
+        "vsnr": vsnr_val,
+    }
+
+
+__all__ = ["camera_full_reference"]

--- a/python/tests/test_camera_full_reference.py
+++ b/python/tests/test_camera_full_reference.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from isetcam.camera import camera_create, camera_full_reference
+from isetcam.scene import Scene
+
+
+def _gray_scene(w: int = 4, h: int = 4, n_wave: int = 3) -> Scene:
+    wave = np.arange(500, 500 + 10 * n_wave, 10)
+    photons = np.ones((h, w, n_wave), dtype=float)
+    return Scene(photons=photons, wave=wave)
+
+
+def test_camera_full_reference_basic():
+    cam = camera_create()
+    sc = _gray_scene()
+    res = camera_full_reference(cam, sc)
+    assert set(res.keys()) == {"mtf", "deltaE", "vsnr"}
+
+    freqs, mtf = res["mtf"]
+    assert freqs.shape == mtf.shape
+    assert res["deltaE"].shape == (sc.photons.shape[0], sc.photons.shape[1])
+    assert np.isfinite(res["vsnr"])


### PR DESCRIPTION
## Summary
- implement `camera_full_reference` to compute MTF, ΔE and VSNR for a scene
- export new function in camera package
- add regression test

## Testing
- `pytest -q python/tests/test_camera_full_reference.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683be2fa97808323b2a19577bb6078df