### PR TITLE
Add illuminant correction and Esser transform

### DIFF
--- a/python/isetcam/imgproc/__init__.py
+++ b/python/isetcam/imgproc/__init__.py
@@ -2,6 +2,8 @@
 
 from .image_distort import image_distort
 from .ie_internal_to_display import ie_internal_to_display
+from .image_illuminant_correction import image_illuminant_correction
+from .image_esser_transform import image_esser_transform
 from .demosaic import (
     ie_nearest_neighbor,
     ie_bilinear,
@@ -24,4 +26,6 @@ __all__ = [
     "faulty_insert",
     "faulty_list",
     "faulty_pixel_correction",
+    "image_illuminant_correction",
+    "image_esser_transform",
 ]

--- a/python/isetcam/imgproc/image_esser_transform.py
+++ b/python/isetcam/imgproc/image_esser_transform.py
@@ -1,0 +1,56 @@
+"""Calculate sensor-to-target transform using the Esser chart."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from ..ie_read_spectra import ie_read_spectra
+from ..illuminant import illuminant_create
+from ..energy_to_quanta import energy_to_quanta
+from ..data_path import data_path
+
+
+def image_esser_transform(
+    sensor_qe: np.ndarray,
+    target_qe: np.ndarray,
+    wave: Sequence[float],
+    illuminant: str | Sequence[float] = "D65",
+    *,
+    surfaces: np.ndarray | None = None,
+) -> np.ndarray:
+    """Return linear transform from sensor space to target space."""
+    sensor_qe = np.asarray(sensor_qe, dtype=float)
+    target_qe = np.asarray(target_qe, dtype=float)
+    wave = np.asarray(wave, dtype=float)
+
+    if sensor_qe.shape[0] != wave.size or target_qe.shape[0] != wave.size:
+        raise ValueError("sensor_qe and target_qe must match wave length")
+
+    if surfaces is None:
+        path = data_path("surfaces/charts/esser/reflectance/esserChart.mat")
+        surfaces, _, _, _ = ie_read_spectra(path, wave)
+    else:
+        surfaces = np.asarray(surfaces, dtype=float)
+        if surfaces.shape[0] != wave.size:
+            raise ValueError("surfaces rows must match wave length")
+
+    if isinstance(illuminant, str):
+        illum = illuminant_create(illuminant, wave)
+        ill_energy = illum.spd
+    else:
+        ill_energy = np.asarray(illuminant, dtype=float)
+        if ill_energy.size != wave.size:
+            raise ValueError("Illuminant length must match wave")
+
+    ill_quanta = energy_to_quanta(wave, ill_energy).reshape(-1)
+
+    sensor_esser = (sensor_qe.T @ np.diag(ill_quanta) @ surfaces).T
+    target_esser = (target_qe.T @ np.diag(ill_quanta) @ surfaces).T
+
+    T, _, _, _ = np.linalg.lstsq(sensor_esser, target_esser, rcond=None)
+    return T
+
+__all__ = ["image_esser_transform"]

--- a/python/isetcam/imgproc/image_illuminant_correction.py
+++ b/python/isetcam/imgproc/image_illuminant_correction.py
@@ -1,0 +1,116 @@
+"""Simple illuminant correction routines."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Sequence
+
+from ..ie_param_format import ie_param_format
+from ..illuminant import illuminant_create
+from ..rgb_to_xw_format import rgb_to_xw_format
+from ..xw_to_rgb_format import xw_to_rgb_format
+
+
+def _replace_nan(data: np.ndarray, value: float = 0.0) -> np.ndarray:
+    """Return ``data`` with ``NaN`` values replaced by ``value``."""
+    out = np.asarray(data, dtype=float).copy()
+    out[np.isnan(out)] = value
+    return out
+
+
+def _image_linear_transform(im: np.ndarray, T: np.ndarray) -> np.ndarray:
+    if im.ndim == 3:
+        xw, r, c = rgb_to_xw_format(im)
+        out = xw @ T
+        return xw_to_rgb_format(out, r, c)
+    if im.ndim == 2:
+        if im.shape[1] != T.shape[0]:
+            raise ValueError("Matrix dimensions do not align")
+        return im @ T
+    raise ValueError("Image must be RGB or XW format")
+
+
+def _calc_wp_scaling(
+    internal_cmf: np.ndarray | None,
+    wave: Sequence[float] | None,
+    target: str | Sequence[float] = "D65",
+) -> np.ndarray:
+    """Return scaling of an equal energy white in ``internal_cmf`` space."""
+    if internal_cmf is None:
+        return np.ones(1)
+
+    if isinstance(target, str):
+        if wave is None:
+            raise ValueError("wave must be provided when target is a name")
+        illum = illuminant_create(target, np.asarray(wave))
+        t_data = illum.spd
+    else:
+        t_data = np.asarray(target, dtype=float)
+    white = internal_cmf.T @ t_data
+    white = white / np.max(white)
+    return white
+
+
+def _gray_world(img: np.ndarray, internal_cmf, wave, target) -> np.ndarray:
+    img = _replace_nan(img, 0)
+    N = img.shape[2]
+    white_ratio = _calc_wp_scaling(internal_cmf, wave, target)
+    if white_ratio.size == 1:
+        white_ratio = np.ones(N)
+    white_ratio = white_ratio / white_ratio[0]
+    avg = img.mean(axis=(0, 1))
+    D = [white_ratio[i] * (avg[0] / avg[i]) if avg[i] != 0 else 0 for i in range(N)]
+    return np.diag(D)
+
+
+def _white_world(img: np.ndarray, internal_cmf, wave, target) -> np.ndarray:
+    img = _replace_nan(img, 0)
+    N = img.shape[2]
+    mx = [img[:, :, i].max() for i in range(N)]
+    white_ratio = _calc_wp_scaling(internal_cmf, wave, target)
+    if white_ratio.size == 1:
+        white_ratio = np.ones(N)
+    bright_plane_index = int(np.argmax(mx))
+    bright_plane = img[:, :, bright_plane_index]
+    criterion = 0.7
+    brt = []
+    thresh = criterion * mx[bright_plane_index]
+    mask = bright_plane >= thresh
+    for i in range(N):
+        vals = img[:, :, i][mask]
+        brt.append(vals.mean() if vals.size > 0 else 0)
+    white_ratio = white_ratio / white_ratio[0]
+    D = [white_ratio[i] * (brt[0] / brt[i]) if brt[i] != 0 else 0 for i in range(N)]
+    return np.diag(D)
+
+
+def image_illuminant_correction(
+    img: np.ndarray,
+    method: str = "none",
+    *,
+    internal_cmf: np.ndarray | None = None,
+    wave: Sequence[float] | None = None,
+    target_white: str | Sequence[float] = "D65",
+    transform: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Apply simple illuminant correction to ``img``."""
+    method = ie_param_format(method)
+    if img.size == 0:
+        return img, np.eye(img.shape[2])
+    if method == "none":
+        T = np.eye(img.shape[2])
+        return img, T
+    if method == "grayworld":
+        T = _gray_world(img, internal_cmf, wave, target_white)
+    elif method == "whiteworld":
+        T = _white_world(img, internal_cmf, wave, target_white)
+    elif method in {"manualmatrixentry", "manual"}:
+        if transform is None:
+            raise ValueError("Manual correction requires 'transform'")
+        T = np.asarray(transform, dtype=float)
+    else:
+        raise ValueError(f"Unknown illuminant correction method {method}")
+    corrected = _image_linear_transform(img, T)
+    return corrected, T
+
+__all__ = ["image_illuminant_correction"]

--- a/python/tests/test_image_esser_transform.py
+++ b/python/tests/test_image_esser_transform.py
@@ -1,0 +1,18 @@
+import numpy as np
+from isetcam.imgproc import image_esser_transform
+
+
+def test_simple_transform():
+    wave = np.array([1.0, 2.0, 3.0])
+    sensor_qe = np.array([[1, 0], [0, 1], [0, 0]], dtype=float)
+    target_qe = np.array([[0, 1], [1, 0], [0, 0]], dtype=float)
+    surfaces = np.eye(3)
+    T = image_esser_transform(
+        sensor_qe,
+        target_qe,
+        wave,
+        illuminant=np.ones_like(wave),
+        surfaces=surfaces,
+    )
+    expected = np.array([[0, 1], [1, 0]], dtype=float)
+    assert np.allclose(T, expected)

--- a/python/tests/test_image_illuminant_correction.py
+++ b/python/tests/test_image_illuminant_correction.py
@@ -1,0 +1,23 @@
+import numpy as np
+from isetcam.imgproc import image_illuminant_correction
+
+
+def test_gray_world_means_equalized():
+    img = np.array(
+        [
+            [[1.0, 2.0, 4.0], [1.0, 2.0, 4.0]],
+            [[1.0, 2.0, 4.0], [1.0, 2.0, 4.0]],
+        ]
+    )
+    corrected, T = image_illuminant_correction(img, "gray world")
+    expected_T = np.diag([1.0, 0.5, 0.25])
+    assert np.allclose(T, expected_T)
+    avg = corrected.mean(axis=(0, 1))
+    assert np.allclose(avg, [1.0, 1.0, 1.0])
+
+
+def test_none_returns_identity():
+    img = np.random.rand(2, 2, 3)
+    corrected, T = image_illuminant_correction(img, "none")
+    assert np.allclose(corrected, img)
+    assert np.allclose(T, np.eye(3))


### PR DESCRIPTION
## Summary
- implement `image_illuminant_correction` and helper methods
- implement `image_esser_transform`
- integrate new utilities into `imgproc.__init__`
- test illuminant correction and Esser transform

## Testing
- `pytest python/tests/test_image_illuminant_correction.py python/tests/test_image_esser_transform.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683be67e72dc8323be3da413e43e15a1