### PR TITLE
Add HDR scene utilities

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -33,6 +33,10 @@ from .scene_thumbnail import scene_thumbnail
 from .scene_illuminant_pattern import scene_illuminant_pattern
 from .scene_illuminant_ss import scene_illuminant_ss
 from .scene_illuminant_scale import scene_illuminant_scale
+from .scene_hdr_image import scene_hdr_image
+from .scene_hdr_chart import scene_hdr_chart
+from .scene_hdr_lights import scene_hdr_lights
+from .scene_create_hdr import scene_create_hdr
 from .scene_depth_overlay import scene_depth_overlay
 from .scene_depth_range import scene_depth_range
 from .scene_list import scene_list
@@ -84,4 +88,8 @@ __all__ = [
     "scene_wb_create",
     "scene_description",
     "scene_clear_data",
+    "scene_hdr_image",
+    "scene_hdr_chart",
+    "scene_hdr_lights",
+    "scene_create_hdr",
 ]

--- a/python/isetcam/scene/scene_create_hdr.py
+++ b/python/isetcam/scene/scene_create_hdr.py
@@ -1,0 +1,27 @@
+"""Factory for basic HDR :class:`Scene` types."""
+
+from __future__ import annotations
+
+from .scene_class import Scene
+from .scene_hdr_image import scene_hdr_image
+from .scene_hdr_chart import scene_hdr_chart
+from .scene_hdr_lights import scene_hdr_lights
+
+
+_VALID = {
+    "hdrimage": scene_hdr_image,
+    "hdrchart": scene_hdr_chart,
+    "hdrlights": scene_hdr_lights,
+}
+
+
+def scene_create_hdr(name: str, **kwargs) -> Scene:
+    """Create a high dynamic range :class:`Scene` by name."""
+
+    key = name.lower().replace(" ", "")
+    if key not in _VALID:
+        raise ValueError(f"Unknown HDR scene type '{name}'")
+    return _VALID[key](**kwargs)
+
+
+__all__ = ["scene_create_hdr"]

--- a/python/isetcam/scene/scene_hdr_chart.py
+++ b/python/isetcam/scene/scene_hdr_chart.py
@@ -1,0 +1,50 @@
+"""Create an HDR chart with luminance steps."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .scene_class import Scene
+from .scene_adjust_luminance import scene_adjust_luminance
+from ..illuminant import illuminant_create
+
+_DEF_WAVE = np.arange(400, 701, 10, dtype=float)
+
+
+def scene_hdr_chart(
+    dynamic_range: float = 1e4,
+    n_levels: int = 12,
+    cols_per_level: int = 8,
+    *,
+    max_luminance: Optional[float] = None,
+    wave: np.ndarray | None = None,
+) -> Scene:
+    """Return a chart of horizontal strips spanning ``dynamic_range``."""
+
+    if wave is None:
+        wave = _DEF_WAVE
+    else:
+        wave = np.asarray(wave, dtype=float).reshape(-1)
+
+    ill = illuminant_create("D65", wave)
+    ill_photons = ill.spd.astype(float)
+
+    cols = n_levels * cols_per_level
+    rows = cols
+
+    reflectances = np.logspace(0, np.log10(1.0 / dynamic_range), n_levels)
+    photons = ill_photons[:, None] * reflectances
+
+    img = np.zeros((rows, cols, wave.size), dtype=float)
+    for i in range(n_levels):
+        start = i * cols_per_level
+        end = start + cols_per_level
+        patch = photons[:, i]
+        img[:, start:end, :] = patch
+
+    sc = Scene(photons=img, wave=wave, name="HDR chart")
+    if max_luminance is not None:
+        sc = scene_adjust_luminance(sc, "peak", float(max_luminance))
+    return sc

--- a/python/isetcam/scene/scene_hdr_image.py
+++ b/python/isetcam/scene/scene_hdr_image.py
@@ -1,0 +1,95 @@
+"""Create an HDR scene of bright patches on a background image."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from skimage.transform import resize
+
+from .scene_class import Scene
+from .scene_adjust_luminance import scene_adjust_luminance
+from .scene_from_file import scene_from_file
+
+
+_DEF_WAVE = np.arange(400, 701, 10, dtype=float)
+
+
+def _background(image: str | None, size: int, wave: np.ndarray) -> Scene:
+    if not image:
+        photons = np.zeros((size, size, wave.size), dtype=float)
+        return Scene(photons=photons, wave=wave, name="Background")
+
+    img = scene_from_file(Path(image), wave=wave)
+    if img.photons.shape[0] != size or img.photons.shape[1] != size:
+        data = resize(
+            img.photons,
+            (size, size, wave.size),
+            order=1,
+            mode="reflect",
+            anti_aliasing=True,
+            preserve_range=True,
+        )
+        img = Scene(photons=data.astype(float), wave=wave, name=img.name)
+    img = scene_adjust_luminance(img, "mean", 1.0)
+    return img
+
+
+def scene_hdr_image(
+    n_patches: int,
+    *,
+    background: str | None = None,
+    image_size: int = 512,
+    dynamic_range: float = 3.0,
+    patch_shape: str = "square",
+    patch_size: Optional[int] = None,
+    row: Optional[int] = None,
+    wave: np.ndarray | None = None,
+) -> Scene:
+    """Return a scene with bright patches spanning ``dynamic_range`` log units."""
+
+    if wave is None:
+        wave = _DEF_WAVE
+    else:
+        wave = np.asarray(wave, dtype=float).reshape(-1)
+
+    bg = _background(background, image_size, wave)
+    photons = bg.photons.copy()
+    rows, cols = photons.shape[:2]
+
+    if patch_shape not in {"square", "circle"}:
+        raise ValueError("patch_shape must be 'square' or 'circle'")
+
+    levels = np.logspace(0, dynamic_range, n_patches)[::-1]
+
+    if patch_shape == "square":
+        if patch_size is None:
+            patch_w = cols // (2 * n_patches)
+        else:
+            patch_w = int(patch_size)
+        patch_h = patch_w
+        spacing = cols / (n_patches + 1)
+        centers = np.round(np.arange(1, n_patches + 1) * spacing).astype(int)
+        r0 = int(row) if row is not None else (rows - patch_h) // 2
+        for i, c in enumerate(centers):
+            c0 = int(c) - patch_w // 2
+            r_slice = slice(r0, r0 + patch_h)
+            c_slice = slice(c0, c0 + patch_w)
+            patch = np.full((patch_h, patch_w, wave.size), levels[i], dtype=float)
+            photons[r_slice, c_slice, :] = photons[r_slice, c_slice, :] + patch
+    else:  # circle
+        if patch_size is None:
+            radius = cols // (4 * n_patches)
+        else:
+            radius = int(patch_size)
+        spacing = cols / (n_patches + 1)
+        centers = np.round(np.arange(1, n_patches + 1) * spacing).astype(int)
+        r_center = int(row) if row is not None else rows // 2
+        yy, xx = np.ogrid[:rows, :cols]
+        for i, c in enumerate(centers):
+            mask = (xx - c) ** 2 + (yy - r_center) ** 2 <= radius ** 2
+            photons[mask, :] = photons[mask, :] + levels[i]
+
+    out = Scene(photons=photons, wave=wave, name="HDR image")
+    return out

--- a/python/isetcam/scene/scene_hdr_lights.py
+++ b/python/isetcam/scene/scene_hdr_lights.py
@@ -1,0 +1,65 @@
+"""Create an HDR scene with simple geometric lights."""
+
+from __future__ import annotations
+
+import numpy as np
+from skimage.draw import disk, rectangle
+
+from .scene_class import Scene
+
+_DEF_WAVE = np.arange(400, 701, 10, dtype=float)
+
+
+def _draw_lights(size: int) -> np.ndarray:
+    img = np.zeros((size, size), dtype=float)
+
+    # Circles across the top quarter
+    centers = np.linspace(0.2, 0.8, 4) * size
+    radii = np.array([0.01, 0.035, 0.07, 0.1]) * size
+    row = int(round(size * 0.25))
+    for c, r in zip(centers, radii):
+        rr, cc = disk((row, c), r, shape=img.shape)
+        img[rr, cc] = 1
+
+    # Lines in the middle
+    centers = np.linspace(0.1, 0.8, 4) * size
+    row = int(round(size * 0.5))
+    lengths = np.array([7, 3, 1, 1]) * (0.02 * size)
+    widths = np.array([1, 1, 3, 8]) * (0.02 * size)
+    for c, l, w in zip(centers, lengths, widths):
+        start = (int(row - w / 2), int(c))
+        end = (int(row + w / 2), int(c + l))
+        rr, cc = rectangle(start, end, shape=img.shape)
+        img[rr, cc] = 1
+
+    # Squares near the bottom
+    centers = np.linspace(0.1, 0.7, 3) * size
+    row = int(round(size * 0.75))
+    sizes = np.array([2, 5, 9]) * (size / 64)
+    for c, s in zip(centers, sizes):
+        start = (int(row - s / 2), int(c - s / 2))
+        end = (int(row + s / 2), int(c + s / 2))
+        rr, cc = rectangle(start, end, shape=img.shape)
+        img[rr, cc] = 1
+
+    return img
+
+
+def scene_hdr_lights(
+    *,
+    image_size: int = 384,
+    dynamic_range: float = 1e7,
+    wave: np.ndarray | None = None,
+) -> Scene:
+    """Return a simple HDR lights scene."""
+
+    if wave is None:
+        wave = _DEF_WAVE
+    else:
+        wave = np.asarray(wave, dtype=float).reshape(-1)
+
+    pattern = _draw_lights(image_size)
+    photons = np.ones((image_size, image_size, wave.size), dtype=float)
+    photons[pattern > 0] = dynamic_range
+
+    return Scene(photons=photons, wave=wave, name="HDR lights")

--- a/python/tests/test_scene_hdr.py
+++ b/python/tests/test_scene_hdr.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from isetcam.scene import (
+    scene_hdr_image,
+    scene_hdr_chart,
+    scene_hdr_lights,
+)
+
+
+def test_scene_hdr_image_patches():
+    wave = np.array([550.0])
+    sc = scene_hdr_image(
+        3,
+        image_size=8,
+        dynamic_range=1,
+        patch_size=2,
+        background=None,
+        patch_shape="square",
+        wave=wave,
+    )
+    levels = np.logspace(0, 1, 3)[::-1]
+    row = (8 - 2) // 2
+    assert np.allclose(sc.photons[row:row+2, 1:3, 0], levels[0])
+    assert np.allclose(sc.photons[row:row+2, 3:5, 0], levels[1])
+    assert np.allclose(sc.photons[row:row+2, 5:7, 0], levels[2])
+    ratio = sc.photons[row, 1, 0] / sc.photons[row, 5, 0]
+    assert np.isclose(ratio, 10)
+
+
+def test_scene_hdr_chart_levels():
+    wave = np.array([550.0])
+    sc = scene_hdr_chart(dynamic_range=100, n_levels=3, cols_per_level=2, wave=wave)
+    first = sc.photons[0, 0, 0]
+    last = sc.photons[0, -1, 0]
+    assert np.isclose(first / last, 100)
+    assert np.allclose(sc.photons[:, 0:2, 0], first)
+    assert np.allclose(sc.photons[:, 4:6, 0], last)
+
+
+def test_scene_hdr_lights_dynamic_range():
+    wave = np.array([550.0])
+    sc = scene_hdr_lights(image_size=16, dynamic_range=1000, wave=wave)
+    assert np.isclose(sc.photons.max(), 1000)
+    assert np.isclose(sc.photons.min(), 1)


### PR DESCRIPTION
## Summary
- implement HDR scene creation functions
- expose new HDR helpers in scene package
- test HDR scene creation utilities

## Testing
- `flake8 python/isetcam/scene/scene_hdr_image.py python/isetcam/scene/scene_hdr_chart.py python/isetcam/scene/scene_hdr_lights.py python/isetcam/scene/scene_create_hdr.py python/tests/test_scene_hdr.py`
- `pytest -q python/tests/test_scene_hdr.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bed839db0832384bf6cc9da5adb78