### PR TITLE
Implement CP camera utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -120,7 +120,7 @@ from .human import (
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip  # noqa: E501
+from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip, cp  # noqa: E501
 from .opticalimage import oi_to_file, oi_plot
 from .sensor import sensor_to_file
 from .display import (
@@ -264,6 +264,7 @@ __all__ = [
     'metrics',
     'human',
     'ip',
+    'cp',
     'oi_to_file',
     'sensor_to_file',
     'display_to_file',

--- a/python/isetcam/cp/__init__.py
+++ b/python/isetcam/cp/__init__.py
@@ -1,0 +1,15 @@
+"""Lightweight computational photography tools."""
+
+from .cp_scene import CPScene
+from .cp_cmodule import CPCModule
+from .cp_camera import CPCamera
+from .cp_burst_camera import cp_burst_camera
+from .cp_burst_ip import cp_burst_ip
+
+__all__ = [
+    "CPScene",
+    "CPCModule",
+    "CPCamera",
+    "cp_burst_camera",
+    "cp_burst_ip",
+]

--- a/python/isetcam/cp/cp_burst_camera.py
+++ b/python/isetcam/cp/cp_burst_camera.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import List
+
+
+def cp_burst_camera(n_frames: int, base_exposure: float, mode: str = "burst") -> List[float]:
+    """Return exposure times for a burst or HDR capture."""
+    mode = mode.lower()
+    if n_frames < 1:
+        raise ValueError("n_frames must be positive")
+    if mode == "hdr":
+        if n_frames > 1 and n_frames % 2 == 0:
+            n_frames += 1
+        offset = (n_frames - 1) / 2
+        exp = [base_exposure * (2 ** (i - offset)) for i in range(n_frames)]
+    else:  # burst
+        exp = [base_exposure / n_frames for _ in range(n_frames)]
+    return exp

--- a/python/isetcam/cp/cp_burst_ip.py
+++ b/python/isetcam/cp/cp_burst_ip.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from ..sensor import Sensor
+
+
+def cp_burst_ip(sensors: Sequence[Sensor], mode: str = "sum") -> np.ndarray:
+    """Combine a sequence of sensor frames."""
+    if not sensors:
+        raise ValueError("sensors list is empty")
+    stack = np.stack([s.volts for s in sensors], axis=0)
+    mode = mode.lower()
+    if mode == "sum":
+        return stack.sum(axis=0)
+    if mode == "longest":
+        return stack[-1]
+    raise ValueError("Unknown mode")

--- a/python/isetcam/cp/cp_camera.py
+++ b/python/isetcam/cp/cp_camera.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Sequence
+
+from .cp_scene import CPScene
+from .cp_cmodule import CPCModule
+
+
+@dataclass
+class CPCamera:
+    """Simplified computational camera composed of one or more modules."""
+
+    modules: List[CPCModule] = field(default_factory=list)
+
+    def take_picture(
+        self,
+        scene: CPScene,
+        *,
+        exposure_times: Sequence[float] | float = 1.0,
+    ) -> List:
+        """Capture ``scene`` using ``exposure_times`` for each frame."""
+        if isinstance(exposure_times, Sequence) and not isinstance(exposure_times, (str, bytes)):
+            exp_list = list(exposure_times)
+        else:
+            exp_list = [float(exposure_times)]
+        scenes = scene.render(exp_list)
+        all_images: List = []
+        for module in self.modules:
+            all_images.extend(module.compute(scenes, exp_list))
+        return all_images

--- a/python/isetcam/cp/cp_cmodule.py
+++ b/python/isetcam/cp/cp_cmodule.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import List
+
+import numpy as np
+
+from ..sensor import Sensor, sensor_compute
+from ..optics import Optics
+from ..opticalimage import OpticalImage, oi_compute
+from ..scene import Scene
+
+
+@dataclass
+class CPCModule:
+    """Simple camera module holding :class:`Sensor` and :class:`Optics`."""
+
+    sensor: Sensor
+    optics: Optics
+
+    def compute(self, scenes: List[Scene], exp_times: List[float]) -> List[Sensor]:
+        """Return sensor captures for each scene and exposure time."""
+        outputs: List[Sensor] = []
+        for sc, t in zip(scenes, exp_times):
+            oi = oi_compute(sc, self.optics)
+            s = replace(self.sensor)
+            s.exposure_time = float(t)
+            s = sensor_compute(s, oi)
+            outputs.append(s)
+        return outputs

--- a/python/isetcam/cp/cp_scene.py
+++ b/python/isetcam/cp/cp_scene.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+
+from ..scene import Scene
+
+
+@dataclass
+class CPScene:
+    """Container for a sequence of :class:`Scene` objects."""
+
+    scenes: List[Scene]
+
+    def preview(self) -> Scene:
+        """Return the first scene in the sequence."""
+        return self.scenes[0]
+
+    def render(self, exp_times: List[float]) -> List[Scene]:
+        """Return scenes corresponding to ``exp_times``.
+
+        If only a single scene is stored, it is replicated to match the
+        number of exposure times.
+        """
+        if len(self.scenes) == len(exp_times):
+            return list(self.scenes)
+        if len(self.scenes) == 1:
+            return [self.scenes[0] for _ in exp_times]
+        raise ValueError("Number of scenes does not match exposure times")

--- a/python/tests/test_cp_camera.py
+++ b/python/tests/test_cp_camera.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from isetcam.scene import Scene
+from isetcam.sensor import sensor_create
+from isetcam.optics import optics_create
+from isetcam.cp import CPScene, CPCModule, CPCamera, cp_burst_camera, cp_burst_ip
+
+
+def _simple_scene() -> Scene:
+    photons = np.ones((1, 1, 1), dtype=float)
+    return Scene(photons=photons, wave=np.array([550.0]))
+
+
+def test_cpscene_render_repeat():
+    sc = CPScene([_simple_scene()])
+    exp = [0.1, 0.1, 0.1]
+    out = sc.render(exp)
+    assert len(out) == 3
+    for s in out:
+        assert np.allclose(s.photons, 1.0)
+
+
+def test_burst_capture_sum():
+    scene = CPScene([_simple_scene()])
+    sensor = sensor_create()
+    optics = optics_create()
+    module = CPCModule(sensor=sensor, optics=optics)
+    camera = CPCamera([module])
+
+    exp_times = cp_burst_camera(3, 0.03, mode="burst")
+    sensors = camera.take_picture(scene, exposure_times=exp_times)
+    assert len(sensors) == 3
+
+    combined = cp_burst_ip(sensors, mode="sum")
+    expected = sensors[0].volts * 3
+    assert np.allclose(combined, expected)


### PR DESCRIPTION
## Summary
- implement dataclasses `CPScene`, `CPCModule`, `CPCamera`
- add burst/HDR helper functions `cp_burst_camera` and `cp_burst_ip`
- expose new cp package and re-export in `isetcam.__init__`
- test cp camera burst functionality

## Testing
- `pytest -q python/tests/test_cp_camera.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bf0b3be288323acf6ec302c1caf10