### PR TITLE
Add ip_hdr_white

### DIFF
--- a/python/isetcam/ip/__init__.py
+++ b/python/isetcam/ip/__init__.py
@@ -9,6 +9,7 @@ from .ip_to_file import ip_to_file
 from .ip_from_file import ip_from_file
 from .ip_plot import ip_plot
 from .ip_clear_data import ip_clear_data
+from .ip_hdr_white import ip_hdr_white
 
 __all__ = [
     "VCImage",
@@ -20,4 +21,5 @@ __all__ = [
     "ip_from_file",
     "ip_plot",
     "ip_clear_data",
+    "ip_hdr_white",
 ]

--- a/python/isetcam/ip/ip_hdr_white.py
+++ b/python/isetcam/ip/ip_hdr_white.py
@@ -1,0 +1,67 @@
+"""Whiten near-saturated pixels in a VCImage."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import gaussian_filter
+
+from .vcimage_class import VCImage
+
+
+def ip_hdr_white(
+    ip: VCImage,
+    *,
+    saturation: float | None = None,
+    hdr_level: float = 0.95,
+    wgt_blur: float = 1.0,
+    white_level: float = 1.0,
+) -> tuple[VCImage, np.ndarray]:
+    """Return ``ip`` with bright regions shifted toward white.
+
+    Parameters
+    ----------
+    ip : VCImage
+        Image to modify in-place.
+    saturation : float, optional
+        Level at which input values are considered saturated. Defaults to
+        the maximum value of ``ip.rgb`` when ``None``.
+    hdr_level : float, optional
+        Fraction of ``saturation`` from which the whitening begins. Pixels
+        below this fraction are unaffected. Defaults to ``0.95``.
+    wgt_blur : float, optional
+        Standard deviation of the Gaussian filter used to blur the weight
+        map. Defaults to ``1.0``.
+    white_level : float, optional
+        Desired output level for the brightest region. Defaults to ``1.0``.
+
+    Returns
+    -------
+    tuple
+        ``(ip, weights)`` where ``ip`` is the same instance with modified
+        ``rgb`` data and ``weights`` is the 2-D map of whitening weights.
+    """
+
+    rgb = np.asarray(ip.rgb, dtype=float)
+    if rgb.ndim != 3 or rgb.shape[2] != 3:
+        raise ValueError("ip.rgb must have shape (H, W, 3)")
+
+    if saturation is None:
+        saturation = float(rgb.max())
+
+    luminance = rgb.mean(axis=2)
+    wgts = (luminance / saturation - hdr_level) / (1.0 - hdr_level)
+    wgts = np.clip(wgts, 0.0, 1.0)
+    if wgt_blur > 0:
+        wgts = gaussian_filter(wgts, sigma=float(wgt_blur), mode="nearest")
+
+    new_rgb = rgb * (1.0 - wgts[..., None]) + white_level * wgts[..., None]
+
+    lum_max = new_rgb.mean(axis=2).max()
+    if lum_max > 0:
+        new_rgb *= white_level / lum_max
+
+    ip.rgb = new_rgb
+    return ip, wgts
+
+
+__all__ = ["ip_hdr_white"]

--- a/python/tests/test_ip_hdr_white.py
+++ b/python/tests/test_ip_hdr_white.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from isetcam.ip import VCImage, ip_hdr_white
+
+
+def _simple_ip() -> VCImage:
+    rgb = np.array(
+        [
+            [[0.5, 0.5, 0.5], [0.9, 0.9, 0.9]],
+            [[1.0, 1.0, 1.0], [0.2, 0.2, 0.2]],
+        ],
+        dtype=float,
+    )
+    wave = np.array([500, 510, 520])
+    return VCImage(rgb=rgb, wave=wave)
+
+
+def test_ip_hdr_white_default():
+    ip = _simple_ip()
+    out, w = ip_hdr_white(ip, saturation=1.0, hdr_level=0.8, wgt_blur=0)
+    assert out is ip
+    lum = out.rgb.mean(axis=2)
+    assert np.isclose(lum.max(), 1.0)
+    assert w.shape == lum.shape
+    assert np.isclose(w[1, 0], 1.0)
+
+
+def test_ip_hdr_white_scaled():
+    ip = _simple_ip()
+    out, _ = ip_hdr_white(ip, saturation=1.0, hdr_level=0.8, wgt_blur=0, white_level=0.5)
+    lum = out.rgb.mean(axis=2)
+    assert np.isclose(lum.max(), 0.5)


### PR DESCRIPTION
## Summary
- port `ipHDRWhite.m` to Python as `ip_hdr_white`
- export helper in `isetcam.ip`
- test whitening/white-level scaling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683bf32ad7308323b9874a49446c8d93