### PR TITLE
Add ie_clip utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -33,6 +33,7 @@ from .cct import cct
 from .cct_to_sun import cct_to_sun
 from .daylight import daylight
 from .circle_points import circle_points
+from .ie_clip import ie_clip
 from .ie_param_format import ie_param_format
 from .ie_session_get import ie_session_get
 from .ie_session_set import ie_session_set
@@ -175,6 +176,7 @@ __all__ = [
     'cct_to_sun',
     'daylight',
     'circle_points',
+    'ie_clip',
     'ie_param_format',
     'ie_session_get',
     'ie_session_set',

--- a/python/isetcam/ie_clip.py
+++ b/python/isetcam/ie_clip.py
@@ -1,0 +1,54 @@
+"""Clip values to a specified range."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Any
+
+
+_SENTINEL = object()
+
+
+def ie_clip(data: np.ndarray, lower: Any = _SENTINEL, upper: Any = _SENTINEL) -> np.ndarray:
+    """Clip ``data`` to the provided bounds.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Array of values to be clipped.
+    lower : float or None, optional
+        Lower clipping bound. When not provided and ``upper`` is also not
+        provided, the default range ``[0, 1]`` is used. If a single numeric
+        bound is provided (``lower`` or ``upper``), the data are clipped
+        symmetrically to ``[-abs(b), abs(b)]``. ``None`` disables the lower
+        bound.
+    upper : float or None, optional
+        Upper clipping bound. ``None`` disables the upper bound.
+
+    Returns
+    -------
+    np.ndarray
+        The clipped array.
+    """
+    arr = np.asarray(data)
+
+    # Determine clipping bounds following MATLAB semantics
+    if lower is _SENTINEL and upper is _SENTINEL:
+        lower, upper = 0.0, 1.0
+    elif lower is not _SENTINEL and upper is _SENTINEL:
+        if lower is None:
+            return arr
+        bound = float(abs(lower))
+        lower, upper = -bound, bound
+    elif lower is _SENTINEL and upper is not _SENTINEL:
+        if upper is None:
+            return arr
+        bound = float(abs(upper))
+        lower, upper = -bound, bound
+
+    # Both bounds provided (may include None)
+    if lower is not None:
+        arr = np.maximum(arr, float(lower))
+    if upper is not None:
+        arr = np.minimum(arr, float(upper))
+    return arr

--- a/python/tests/test_ie_clip.py
+++ b/python/tests/test_ie_clip.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from isetcam import ie_clip
+
+
+def test_ie_clip_default():
+    data = np.array([-1.0, 0.5, 2.0])
+    out = ie_clip(data)
+    assert np.allclose(out, [0.0, 0.5, 1.0])
+
+
+def test_ie_clip_single_bound():
+    data = np.array([-2.0, -0.3, 0.3, 1.2])
+    out = ie_clip(data, 0.5)
+    assert np.allclose(out, [-0.5, -0.3, 0.3, 0.5])
+
+
+def test_ie_clip_two_bounds():
+    data = np.array([-2.0, -0.5, 0.5, 2.0])
+    out = ie_clip(data, -0.5, 1.5)
+    assert np.allclose(out, [-0.5, -0.5, 0.5, 1.5])
+
+
+def test_ie_clip_none_bound():
+    data = np.array([-2.0, 1.0, 3.0])
+    out = ie_clip(data, None, 2.0)
+    assert np.allclose(out, [-2.0, 1.0, 2.0])


### PR DESCRIPTION
## Summary
- add `ie_clip` for MATLAB-compatible clipping
- export `ie_clip` in package init
- test default behavior, single-bound, and two-bound cases

## Testing
- `PYTHONPATH=python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bf8b68fdc8323bad6bd9baf1685e7