### PR TITLE
Add ie_scp helper

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -151,6 +151,7 @@ from .illuminant import (
 )
 from .ip import ip_to_file, ip_from_file, ip_plot
 from .io import openexr_read, openexr_write, pfm_read, pfm_write, dng_read, dng_write
+from .ie_scp import ie_scp
 
 __all__ = [
     '__version__',
@@ -299,6 +300,7 @@ __all__ = [
     'pfm_write',
     'dng_read',
     'dng_write',
+    'ie_scp',
     'vc_add_and_select_object',
     'vc_get_object',
     'vc_replace_object',

--- a/python/isetcam/ie_scp.py
+++ b/python/isetcam/ie_scp.py
@@ -1,0 +1,36 @@
+"""Lightweight wrapper around the :command:`scp` utility."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def ie_scp(user: str, host: str, src: str, dest: str, quiet: bool = True) -> tuple[str, int]:
+    """Copy ``src`` to ``dest`` on ``host`` via ``scp``.
+
+    Parameters
+    ----------
+    user, host : str
+        Remote login information used as ``user@host``.
+    src : str
+        Path to the local file to copy.
+    dest : str
+        Destination path on the remote host.
+    quiet : bool, optional
+        Add the ``-q`` flag to suppress progress information.
+
+    Returns
+    -------
+    tuple[str, int]
+        Command string executed and the subprocess return code.
+    """
+    cmd = ["scp"]
+    if quiet:
+        cmd.append("-q")
+    cmd.extend([src, f"{user}@{host}:{dest}"])
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE if quiet else None,
+        stderr=subprocess.PIPE if quiet else None,
+    )
+    return " ".join(cmd), result.returncode

--- a/python/tests/test_ie_scp.py
+++ b/python/tests/test_ie_scp.py
@@ -1,0 +1,47 @@
+import subprocess
+
+from isetcam import ie_scp
+
+
+def test_ie_scp_quiet(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, stdout=None, stderr=None):
+        called['cmd'] = cmd
+        called['stdout'] = stdout
+        called['stderr'] = stderr
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    cmd, rc = ie_scp('user', 'host', 'local.txt', 'remote.txt')
+    assert called['cmd'] == ['scp', '-q', 'local.txt', 'user@host:remote.txt']
+    assert cmd == 'scp -q local.txt user@host:remote.txt'
+    assert rc == 0
+    assert called['stdout'] is subprocess.PIPE
+    assert called['stderr'] is subprocess.PIPE
+
+
+def test_ie_scp_not_quiet(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, stdout=None, stderr=None):
+        called['cmd'] = cmd
+        called['stdout'] = stdout
+        called['stderr'] = stderr
+
+        class Result:
+            returncode = 1
+
+        return Result()
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    cmd, rc = ie_scp('u', 'h', 'src', 'dest', quiet=False)
+    assert called['cmd'] == ['scp', 'src', 'u@h:dest']
+    assert cmd == 'scp src u@h:dest'
+    assert rc == 1
+    assert called['stdout'] is None
+    assert called['stderr'] is None


### PR DESCRIPTION
## Summary
- wrap system `scp` command with `ie_scp`
- expose the helper in the package API
- test command creation via mocking

## Testing
- `PYTHONPATH=$PWD/python pytest -q python/tests/test_ie_scp.py`
- `PYTHONPATH=$PWD/python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bfb2bc354832388a3cce656a4935f