### PR TITLE
Add sensor wave resampling and scaling utilities

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -25,6 +25,9 @@ from .sensor_show_cfa import sensor_show_cfa
 from .sensor_stats import sensor_stats
 from .sensor_clear_data import sensor_clear_data
 from .sensor_iso_speed import sensor_iso_speed
+from .sensor_resample_wave import sensor_resample_wave
+from .sensor_rescale import sensor_rescale
+from .sensor_gain_offset import sensor_gain_offset
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -79,4 +82,7 @@ __all__ = [
     "sensor_stats",
     "sensor_clear_data",
     "sensor_iso_speed",
+    "sensor_resample_wave",
+    "sensor_rescale",
+    "sensor_gain_offset",
 ]

--- a/python/isetcam/sensor/sensor_gain_offset.py
+++ b/python/isetcam/sensor/sensor_gain_offset.py
@@ -1,0 +1,15 @@
+"""Apply analog gain and offset to sensor voltages."""
+
+from __future__ import annotations
+
+from .sensor_class import Sensor
+
+
+def sensor_gain_offset(sensor: Sensor, gain: float = 1.0, offset: float = 0.0) -> Sensor:
+    """Apply multiplicative ``gain`` and additive ``offset`` to ``sensor.volts``."""
+
+    sensor.volts = sensor.volts * float(gain) + float(offset)
+    return sensor
+
+
+__all__ = ["sensor_gain_offset"]

--- a/python/isetcam/sensor/sensor_resample_wave.py
+++ b/python/isetcam/sensor/sensor_resample_wave.py
@@ -1,0 +1,59 @@
+"""Resample sensor spectral data to a new wavelength support."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .sensor_class import Sensor
+
+
+def _interp_matrix(data: np.ndarray, src_wave: np.ndarray, tgt_wave: np.ndarray) -> np.ndarray:
+    """Helper to interpolate columns of ``data`` to ``tgt_wave``."""
+    out = np.empty((tgt_wave.size, data.shape[1]), dtype=float)
+    for i in range(data.shape[1]):
+        out[:, i] = np.interp(tgt_wave, src_wave, data[:, i], left=0.0, right=0.0)
+    return out
+
+
+def sensor_resample_wave(sensor: Sensor, wave: Sequence[float]) -> Sensor:
+    """Return ``sensor`` resampled to ``wave``.
+
+    The voltage data are left unchanged but spectral properties such as quantum
+    efficiency and color filter spectra are interpolated to the desired
+    wavelengths.
+    """
+    src_wave = np.asarray(sensor.wave, dtype=float).reshape(-1)
+    tgt_wave = np.asarray(wave, dtype=float).reshape(-1)
+
+    out = Sensor(
+        volts=np.asarray(sensor.volts),
+        wave=tgt_wave,
+        exposure_time=sensor.exposure_time,
+        name=sensor.name,
+    )
+
+    qe = getattr(sensor, "qe", None)
+    if qe is not None:
+        qe = np.asarray(qe, dtype=float).reshape(-1)
+        if qe.size != src_wave.size:
+            raise ValueError("sensor.qe length must match sensor.wave")
+        out.qe = np.interp(tgt_wave, src_wave, qe, left=0.0, right=0.0)
+
+    if hasattr(sensor, "filter_spectra"):
+        filt = np.asarray(sensor.filter_spectra, dtype=float)
+        if filt.shape[0] != src_wave.size:
+            raise ValueError("filter_spectra first dimension must match sensor.wave")
+        out.filter_spectra = _interp_matrix(filt, src_wave, tgt_wave)
+
+    if hasattr(sensor, "ir_filter"):
+        ir = np.asarray(sensor.ir_filter, dtype=float).reshape(-1)
+        if ir.size != src_wave.size:
+            raise ValueError("ir_filter length must match sensor.wave")
+        out.ir_filter = np.interp(tgt_wave, src_wave, ir, left=0.0, right=0.0)
+
+    return out
+
+
+__all__ = ["sensor_resample_wave"]

--- a/python/isetcam/sensor/sensor_rescale.py
+++ b/python/isetcam/sensor/sensor_rescale.py
@@ -1,0 +1,53 @@
+"""Resize sensor voltage data and adjust pixel size metadata."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+from scipy.ndimage import zoom as nd_zoom
+
+from .sensor_class import Sensor
+
+
+def sensor_rescale(sensor: Sensor, row_col: Sequence[int], sensor_size: Sequence[float]) -> Sensor:
+    """Return ``sensor`` resized to ``row_col`` pixels.
+
+    Parameters
+    ----------
+    sensor : Sensor
+        Input sensor to rescale.
+    row_col : sequence of int
+        Desired ``(rows, cols)`` for the output voltage image.
+    sensor_size : sequence of float
+        Physical size of the sensor in meters as ``(height, width)``.
+    """
+
+    rows, cols = [int(v) for v in row_col]
+    if rows <= 0 or cols <= 0:
+        raise ValueError("row_col must contain positive integers")
+
+    volts = np.asarray(sensor.volts, dtype=float)
+    zoom_factors = (rows / volts.shape[0], cols / volts.shape[1])
+    resized = nd_zoom(volts, zoom_factors, order=1)
+
+    out = Sensor(
+        volts=resized,
+        wave=sensor.wave,
+        exposure_time=sensor.exposure_time,
+        name=sensor.name,
+    )
+
+    if isinstance(sensor_size, Sequence):
+        if len(sensor_size) == 2:
+            height, width = float(sensor_size[0]), float(sensor_size[1])
+        else:
+            height = width = float(sensor_size[0])
+    else:
+        height = width = float(sensor_size)
+
+    out.pixel_size = (height / rows + width / cols) / 2.0
+    return out
+
+
+__all__ = ["sensor_rescale"]

--- a/python/tests/test_sensor_gain_offset.py
+++ b/python/tests/test_sensor_gain_offset.py
@@ -1,0 +1,10 @@
+import numpy as np
+from isetcam.sensor import Sensor, sensor_gain_offset
+
+
+def test_sensor_gain_offset_basic():
+    volts = np.array([[1.0, 2.0], [3.0, 4.0]])
+    s = Sensor(volts=volts.copy(), wave=np.array([550]), exposure_time=0.01)
+    sensor_gain_offset(s, gain=2.0, offset=-1.0)
+    expected = volts * 2.0 - 1.0
+    assert np.allclose(s.volts, expected)

--- a/python/tests/test_sensor_resample_wave.py
+++ b/python/tests/test_sensor_resample_wave.py
@@ -1,0 +1,27 @@
+import numpy as np
+from isetcam.sensor import Sensor, sensor_resample_wave
+
+
+def test_sensor_resample_wave_basic():
+    wave = np.array([400, 500, 600, 700], dtype=float)
+    volts = np.zeros((2, 2), dtype=float)
+    s = Sensor(volts=volts, wave=wave, exposure_time=0.01)
+    s.qe = wave * 0.01
+    s.filter_spectra = np.vstack((wave, wave ** 2)).T
+    s.ir_filter = wave * 0.001
+
+    new_wave = np.array([450, 550, 650], dtype=float)
+    out = sensor_resample_wave(s, new_wave)
+
+    assert np.array_equal(out.wave, new_wave)
+    assert np.allclose(out.volts, volts)
+
+    expected_qe = np.interp(new_wave, wave, s.qe)
+    assert np.allclose(out.qe, expected_qe)
+
+    for i in range(s.filter_spectra.shape[1]):
+        expected = np.interp(new_wave, wave, s.filter_spectra[:, i])
+        assert np.allclose(out.filter_spectra[:, i], expected)
+
+    expected_ir = np.interp(new_wave, wave, s.ir_filter)
+    assert np.allclose(out.ir_filter, expected_ir)

--- a/python/tests/test_sensor_rescale.py
+++ b/python/tests/test_sensor_rescale.py
@@ -1,0 +1,18 @@
+import numpy as np
+from scipy.ndimage import zoom as nd_zoom
+
+from isetcam.sensor import Sensor, sensor_rescale
+
+
+def test_sensor_rescale_basic():
+    volts = np.arange(4, dtype=float).reshape(2, 2)
+    s = Sensor(volts=volts, wave=np.array([550]), exposure_time=0.01)
+    out = sensor_rescale(s, (4, 4), (4e-6, 4e-6))
+
+    expected = nd_zoom(volts, (2, 2), order=1)
+    assert np.allclose(out.volts, expected)
+    assert out.volts.shape == (4, 4)
+    assert np.array_equal(out.wave, s.wave)
+
+    expected_px = (4e-6 / 4 + 4e-6 / 4) / 2.0
+    assert np.isclose(out.pixel_size, expected_px)


### PR DESCRIPTION
## Summary
- implement `sensor_resample_wave`, `sensor_rescale`, and `sensor_gain_offset`
- export the new helpers from `isetcam.sensor`
- test sensor spectral interpolation, resizing, and gain/offset operations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bfdaf11688323adefc385762cb364