### PR TITLE
Add sensor dynamic range calculation

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -28,6 +28,7 @@ from .sensor_iso_speed import sensor_iso_speed
 from .sensor_resample_wave import sensor_resample_wave
 from .sensor_rescale import sensor_rescale
 from .sensor_gain_offset import sensor_gain_offset
+from .sensor_dr import sensor_dr
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -85,4 +86,5 @@ __all__ = [
     "sensor_resample_wave",
     "sensor_rescale",
     "sensor_gain_offset",
+    "sensor_dr",
 ]

--- a/python/isetcam/sensor/sensor_dr.py
+++ b/python/isetcam/sensor/sensor_dr.py
@@ -1,0 +1,71 @@
+"""Estimate sensor dynamic range in dB."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from .sensor_class import Sensor
+from .sensor_get import sensor_get
+
+
+def sensor_dr(sensor: Sensor, integration_time: float | None = None) -> Tuple[float, float, float]:
+    """Return dynamic range of ``sensor`` in dB.
+
+    Parameters
+    ----------
+    sensor:
+        Sensor object containing noise related attributes. Optional
+        attributes ``dark_voltage`` (in volts/second), ``conversion_gain``
+        (volts/electron), ``read_noise_electrons`` (electrons), ``gain_sd``
+        (PRNU in percent), ``offset_sd`` (DSNU in volts) and ``voltage_swing``
+        (maximum voltage) are used. When not present they default to zero for
+        noise and unity for conversion gain and voltage swing.
+    integration_time:
+        Exposure time in seconds.  Defaults to ``sensor.exposure_time``.
+
+    Returns
+    -------
+    tuple of float
+        ``(dr_db, max_voltage, min_voltage)`` where ``dr_db`` is the dynamic
+        range in decibels, ``max_voltage`` is the voltage swing minus the dark
+        signal, and ``min_voltage`` is the standard deviation of the combined
+        noise sources (dark current shot noise, read noise, DSNU and PRNU at
+        ``max_voltage``).
+    """
+
+    if integration_time is None:
+        integration_time = sensor_get(sensor, "exposure_time")
+    integration_time = float(integration_time)
+    if integration_time == 0:
+        return float("nan"), float("nan"), float("nan")
+
+    conv_gain = sensor_get(sensor, "conversion_gain")
+    read_noise_e = sensor_get(sensor, "read_noise_electrons")
+    gain_sd = sensor_get(sensor, "gain_sd") / 100.0
+    offset_sd = sensor_get(sensor, "offset_sd")
+    voltage_swing = sensor_get(sensor, "voltage_swing")
+
+    dark_voltage = getattr(sensor, "dark_voltage", 0.0)
+    dark_volts = dark_voltage * integration_time
+
+    max_voltage = voltage_swing - dark_volts
+
+    dark_electrons = dark_volts / conv_gain
+    dk_var = dark_electrons * (conv_gain ** 2)
+    rn_var = (read_noise_e * conv_gain) ** 2
+    dsnu_var = offset_sd ** 2
+    prnu_var = (gain_sd * max_voltage) ** 2
+
+    min_voltage = float(np.sqrt(dk_var + rn_var + dsnu_var + prnu_var))
+
+    if min_voltage == 0 or max_voltage <= 0:
+        dr_db = float("inf")
+    else:
+        dr_db = float(10.0 * np.log10(max_voltage / min_voltage))
+
+    return dr_db, float(max_voltage), min_voltage
+
+
+__all__ = ["sensor_dr"]

--- a/python/tests/test_sensor_dr.py
+++ b/python/tests/test_sensor_dr.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from isetcam.sensor import Sensor, sensor_set, sensor_dr
+
+
+def _expected(cg, read_noise, gain_sd, offset_sd, dark_v, v_swing, t):
+    dark_volts = dark_v * t
+    vmax = v_swing - dark_volts
+    dk_e = dark_volts / cg
+    dk_var = dk_e * (cg ** 2)
+    rn_var = (read_noise * cg) ** 2
+    dsnu_var = offset_sd ** 2
+    prnu_var = (gain_sd / 100.0 * vmax) ** 2
+    vmin = np.sqrt(dk_var + rn_var + dsnu_var + prnu_var)
+    if vmin == 0 or vmax <= 0:
+        dr = np.inf
+    else:
+        dr = 10 * np.log10(vmax / vmin)
+    return dr, vmax, vmin
+
+
+def test_sensor_dr_basic():
+    s = Sensor(volts=np.zeros((1,)), wave=np.array([550]), exposure_time=0.1)
+    sensor_set(s, "conversion_gain", 2.0)
+    sensor_set(s, "read_noise_electrons", 1.0)
+    sensor_set(s, "gain_sd", 10.0)
+    sensor_set(s, "offset_sd", 0.5)
+    sensor_set(s, "voltage_swing", 5.0)
+    s.dark_voltage = 0.05
+
+    dr, vmax, vmin = sensor_dr(s)
+    exp_dr, exp_vmax, exp_vmin = _expected(2.0, 1.0, 10.0, 0.5, 0.05, 5.0, 0.1)
+
+    assert np.isclose(dr, exp_dr)
+    assert np.isclose(vmax, exp_vmax)
+    assert np.isclose(vmin, exp_vmin)
+
+
+def test_sensor_dr_infinite():
+    s = Sensor(volts=np.zeros((1,)), wave=np.array([550]), exposure_time=0.01)
+    sensor_set(s, "conversion_gain", 1.0)
+    sensor_set(s, "read_noise_electrons", 0.0)
+    sensor_set(s, "gain_sd", 0.0)
+    sensor_set(s, "offset_sd", 0.0)
+    sensor_set(s, "voltage_swing", 1.0)
+    s.dark_voltage = 0.0
+
+    dr, vmax, vmin = sensor_dr(s)
+    assert np.isinf(dr)
+    assert vmax == 1.0
+    assert vmin == 0.0


### PR DESCRIPTION
## Summary
- port `sensorDR.m` to Python as `sensor_dr`
- expose new function in `isetcam.sensor`
- test dynamic range computation on synthetic sensors

## Testing
- `pytest python/tests/test_sensor_dr.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c0033efbc8323a8969527c9d7380a