### PR TITLE
Add scene_from_ddf_file utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -4,6 +4,7 @@ from .scene_class import Scene
 from .scene_add import scene_add
 from .scene_utils import get_photons, set_photons, get_n_wave
 from .scene_from_file import scene_from_file
+from .scene_from_ddf_file import scene_from_ddf_file
 from .scene_get import scene_get
 from .scene_set import scene_set
 from .scene_adjust_luminance import scene_adjust_luminance
@@ -53,6 +54,7 @@ __all__ = [
     "set_photons",
     "get_n_wave",
     "scene_from_file",
+    "scene_from_ddf_file",
     "scene_get",
     "scene_set",
     "scene_adjust_luminance",

--- a/python/isetcam/scene/scene_from_ddf_file.py
+++ b/python/isetcam/scene/scene_from_ddf_file.py
@@ -1,0 +1,40 @@
+"""Read a DDF file and return a :class:`Scene`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import io
+from zipfile import ZipFile
+
+import numpy as np
+
+from .scene_class import Scene
+
+
+def scene_from_ddf_file(path: str | Path) -> Scene:
+    """Load ``path`` and return a :class:`Scene`.
+
+    The ``.ddf`` file is expected to be a zip archive containing the files
+    ``metadata.json``, ``photons.npy`` and ``wave.npy``. The metadata file is
+    ignored except for verifying the cube dimensions.
+    """
+    path = Path(path)
+    with ZipFile(path, 'r') as z:
+        with z.open('metadata.json') as f:
+            meta = json.load(f)
+        with z.open('photons.npy') as f:
+            photons = np.load(io.BytesIO(f.read()))
+        with z.open('wave.npy') as f:
+            wave = np.load(io.BytesIO(f.read()))
+
+    photons = np.asarray(photons, dtype=float)
+    wave = np.asarray(wave).reshape(-1)
+
+    if photons.shape[2] != meta.get('nwave'):
+        raise ValueError('metadata mismatch')
+    if photons.shape[0] != meta.get('height') or photons.shape[1] != meta.get('width'):
+        raise ValueError('metadata mismatch')
+
+    return Scene(photons=photons, wave=wave)
+

--- a/python/tests/test_scene_from_ddf_file.py
+++ b/python/tests/test_scene_from_ddf_file.py
@@ -1,0 +1,31 @@
+import json
+import io
+from zipfile import ZipFile
+
+import numpy as np
+
+from isetcam.scene import scene_from_ddf_file, Scene
+
+
+def _write_sample_ddf(path):
+    photons = np.arange(12, dtype=float).reshape(2, 2, 3)
+    wave = np.array([450.0, 550.0, 650.0], dtype=float)
+    meta = {"width": 2, "height": 2, "nwave": 3}
+
+    with ZipFile(path, "w") as z:
+        z.writestr("metadata.json", json.dumps(meta))
+        buf = io.BytesIO(); np.save(buf, photons); z.writestr("photons.npy", buf.getvalue())
+        buf = io.BytesIO(); np.save(buf, wave); z.writestr("wave.npy", buf.getvalue())
+
+    return photons, wave
+
+
+def test_scene_from_ddf_file(tmp_path):
+    ddf_path = tmp_path / "sample.ddf"
+    photons, wave = _write_sample_ddf(ddf_path)
+
+    sc = scene_from_ddf_file(ddf_path)
+    assert isinstance(sc, Scene)
+    assert np.allclose(sc.photons, photons)
+    assert np.array_equal(sc.wave, wave)
+


### PR DESCRIPTION
## Summary
- implement `scene_from_ddf_file` for loading a simple DDF archive
- expose the new function in `scene.__init__`
- create sample DDF data during tests instead of storing it in the repo

## Testing
- `PYTHONPATH=python pytest python/tests/test_scene_from_ddf_file.py -q`
- `PYTHONPATH=python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c0bf7285483238af0133317feda1a