### PR TITLE
Add scene video export utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -41,6 +41,7 @@ from .scene_create_hdr import scene_create_hdr
 from .scene_depth_overlay import scene_depth_overlay
 from .scene_depth_range import scene_depth_range
 from .scene_list import scene_list
+from .scene_make_video import scene_make_video
 from .scene_wb_create import scene_wb_create
 from .scene_plot import scene_plot
 from .scene_description import scene_description
@@ -94,4 +95,5 @@ __all__ = [
     "scene_hdr_chart",
     "scene_hdr_lights",
     "scene_create_hdr",
+    "scene_make_video",
 ]

--- a/python/isetcam/scene/scene_make_video.py
+++ b/python/isetcam/scene/scene_make_video.py
@@ -1,0 +1,41 @@
+"""Export a list of scenes as a video."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import imageio.v2 as imageio
+
+from .scene_class import Scene
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def scene_make_video(
+    scene_list: Sequence[Scene],
+    output_path: str | Path,
+    fps: int = 30,
+) -> None:
+    """Encode ``scene_list`` into a video at ``output_path``.
+
+    Parameters
+    ----------
+    scene_list : Sequence[Scene]
+        Scenes to render as video frames.
+    output_path : str or Path
+        Destination file path for the video.
+    fps : int, optional
+        Frames per second of the encoded video. Defaults to ``30``.
+    """
+    writer = imageio.get_writer(str(Path(output_path)), fps=int(fps))
+    try:
+        for sc in scene_list:
+            xyz = ie_xyz_from_photons(sc.photons, sc.wave)
+            srgb, _, _ = xyz_to_srgb(xyz)
+            img = np.clip(srgb, 0.0, 1.0)
+            arr = (img * 255).round().astype(np.uint8)
+            writer.append_data(arr)
+    finally:
+        writer.close()

--- a/python/tests/test_scene_make_video.py
+++ b/python/tests/test_scene_make_video.py
@@ -1,0 +1,29 @@
+import io
+import numpy as np
+import pytest
+import imageio.v2 as imageio
+
+from isetcam.scene import Scene, scene_make_video
+
+
+def _ffmpeg_available() -> bool:
+    try:
+        with imageio.get_writer(io.BytesIO(), format="ffmpeg", fps=1):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _ffmpeg_available(), reason="ffmpeg not available")
+def test_scene_make_video(tmp_path):
+    wave = np.array([500, 600, 700])
+    sc1 = Scene(photons=np.ones((2, 2, 3)), wave=wave)
+    sc2 = Scene(photons=np.zeros((2, 2, 3)), wave=wave)
+    path = tmp_path / "movie.mp4"
+    scene_make_video([sc1, sc2], path, fps=2)
+    reader = imageio.get_reader(path)
+    frames = [frame for frame in reader]
+    reader.close()
+    assert len(frames) == 2
+    assert frames[0].shape == (2, 2, 3)


### PR DESCRIPTION
## Summary
- implement `scene_make_video` to encode a list of scenes to a video
- export `scene_make_video` from the scene package
- test video export using `imageio` writer

## Testing
- `PYTHONPATH=python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c100003b083239ee2e34e04980547