### PR TITLE
Add scene geometry initialization helpers

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -47,6 +47,8 @@ from .scene_wb_create import scene_wb_create
 from .scene_plot import scene_plot
 from .scene_description import scene_description
 from .scene_clear_data import scene_clear_data
+from .scene_init_geometry import scene_init_geometry
+from .scene_init_spatial import scene_init_spatial
 
 __all__ = [
     "Scene",
@@ -98,4 +100,6 @@ __all__ = [
     "scene_hdr_lights",
     "scene_create_hdr",
     "scene_make_video",
+    "scene_init_geometry",
+    "scene_init_spatial",
 ]

--- a/python/isetcam/scene/scene_init_geometry.py
+++ b/python/isetcam/scene/scene_init_geometry.py
@@ -1,0 +1,17 @@
+"""Initialize geometric properties of a :class:`Scene`."""
+
+from __future__ import annotations
+
+from .scene_class import Scene
+
+_DEFAULT_DISTANCE = 1.2  # meters
+
+
+def scene_init_geometry(scene: Scene) -> Scene:
+    """Assign default ``distance`` to ``scene`` if missing."""
+    if getattr(scene, "distance", None) is None:
+        scene.distance = _DEFAULT_DISTANCE
+    return scene
+
+
+__all__ = ["scene_init_geometry"]

--- a/python/isetcam/scene/scene_init_spatial.py
+++ b/python/isetcam/scene/scene_init_spatial.py
@@ -1,0 +1,17 @@
+"""Initialize spatial properties of a :class:`Scene`."""
+
+from __future__ import annotations
+
+from .scene_class import Scene
+
+_DEFAULT_FOV = 10.0  # degrees
+
+
+def scene_init_spatial(scene: Scene) -> Scene:
+    """Assign default ``fov`` to ``scene`` if missing."""
+    if getattr(scene, "fov", None) is None:
+        scene.fov = _DEFAULT_FOV
+    return scene
+
+
+__all__ = ["scene_init_spatial"]

--- a/python/tests/test_scene_init_defaults.py
+++ b/python/tests/test_scene_init_defaults.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_init_geometry, scene_init_spatial
+
+
+def _simple_scene():
+    wave = np.array([550], dtype=float)
+    photons = np.ones((1, 1, 1), dtype=float)
+    return Scene(photons=photons, wave=wave)
+
+
+def test_defaults_assigned_when_missing():
+    sc = _simple_scene()
+    scene_init_geometry(sc)
+    scene_init_spatial(sc)
+    assert sc.distance == 1.2
+    assert sc.fov == 10.0
+
+
+def test_existing_values_preserved():
+    sc = _simple_scene()
+    sc.distance = 2.0
+    sc.fov = 20.0
+    scene_init_geometry(sc)
+    scene_init_spatial(sc)
+    assert sc.distance == 2.0
+    assert sc.fov == 20.0


### PR DESCRIPTION
## Summary
- add `scene_init_geometry` and `scene_init_spatial` helper functions for default
  `Scene` parameters
- export them from the scene package
- test defaults for distance and FOV

## Testing
- `pytest python/tests/test_scene_init_defaults.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c13e3b30c8323b223862ef095520f