### PR TITLE
Add scene vector utility functions

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -49,6 +49,10 @@ from .scene_description import scene_description
 from .scene_clear_data import scene_clear_data
 from .scene_init_geometry import scene_init_geometry
 from .scene_init_spatial import scene_init_spatial
+from .scene_vector_utils import (
+    scene_photons_from_vector,
+    scene_energy_from_vector,
+)
 
 __all__ = [
     "Scene",
@@ -102,4 +106,6 @@ __all__ = [
     "scene_make_video",
     "scene_init_geometry",
     "scene_init_spatial",
+    "scene_photons_from_vector",
+    "scene_energy_from_vector",
 ]

--- a/python/isetcam/scene/scene_vector_utils.py
+++ b/python/isetcam/scene/scene_vector_utils.py
@@ -1,0 +1,29 @@
+"""Utilities for extracting pixel spectra from a :class:`Scene`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+from ..quanta2energy import quanta_to_energy
+
+
+def scene_photons_from_vector(scene: Scene, row: int, col: int) -> np.ndarray:
+    """Return photons at ``(row, col)`` as a 1-D vector."""
+    photons = np.asarray(scene.photons)
+    if photons.ndim != 3:
+        raise ValueError("scene.photons must be a 3-D array")
+    h, w, _ = photons.shape
+    if row < 0 or row >= h or col < 0 or col >= w:
+        raise ValueError("row/col index out of bounds")
+    return photons[row, col, :].reshape(-1)
+
+
+def scene_energy_from_vector(scene: Scene, row: int, col: int) -> np.ndarray:
+    """Return spectral energy at ``(row, col)`` as a 1-D vector."""
+    photons_vec = scene_photons_from_vector(scene, row, col)
+    energy = quanta_to_energy(scene.wave, photons_vec)
+    return energy.reshape(-1)
+
+
+__all__ = ["scene_photons_from_vector", "scene_energy_from_vector"]

--- a/python/tests/test_scene_vector_utils.py
+++ b/python/tests/test_scene_vector_utils.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from isetcam.scene import (
+    Scene,
+    scene_photons_from_vector,
+    scene_energy_from_vector,
+)
+from isetcam.quanta2energy import quanta_to_energy
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([500, 510, 520])
+    photons = np.arange(24).reshape(2, 2, 6)[:, :, :3]  # just ensure shape
+    return Scene(photons=photons, wave=wave)
+
+
+def test_scene_photons_from_vector():
+    sc = _simple_scene()
+    vec = scene_photons_from_vector(sc, 1, 0)
+    expected = sc.photons[1, 0, :].reshape(-1)
+    assert np.array_equal(vec, expected)
+
+
+def test_scene_energy_from_vector():
+    sc = _simple_scene()
+    vec = scene_energy_from_vector(sc, 0, 1)
+    expected = quanta_to_energy(sc.wave, sc.photons[0, 1, :])
+    assert np.allclose(vec, expected.reshape(-1))


### PR DESCRIPTION
## Summary
- add utilities to extract pixel spectra as vectors from `Scene`
- export new utilities in `scene.__init__`
- unit tests for `scene_photons_from_vector` and `scene_energy_from_vector`

## Testing
- `PYTHONPATH=python pytest python/tests/test_scene_vector_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683c15cf8fb88323940c763a685cc44b