### PR TITLE
Add human ocular image and UV safety utilities

### DIFF
--- a/python/isetcam/human/__init__.py
+++ b/python/isetcam/human/__init__.py
@@ -12,6 +12,8 @@ from .human_cone_contrast import human_cone_contrast
 from .human_cone_isolating import human_cone_isolating
 from .human_cones import human_cones
 from .human_cone_mosaic import human_cone_mosaic
+from .human_oi import human_oi
+from .human_uv_safety import human_uv_safety
 from .watson_impulse_response import watson_impulse_response
 from .watson_rgc_spacing import watson_rgc_spacing
 
@@ -28,6 +30,8 @@ __all__ = [
     'human_cone_isolating',
     'human_cones',
     'human_cone_mosaic',
+    'human_oi',
+    'human_uv_safety',
     'watson_impulse_response',
     'watson_rgc_spacing',
 ]

--- a/python/isetcam/human/human_oi.py
+++ b/python/isetcam/human/human_oi.py
@@ -1,0 +1,56 @@
+"""Simplified human optical image computation."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import fftconvolve
+
+from ..scene import Scene
+from ..optics import Optics, optics_cos4th, optics_otf
+from ..opticalimage import (
+    OpticalImage,
+    oi_spatial_support,
+    oi_calculate_irradiance,
+    oi_calculate_illuminance,
+)
+from .human_otf import human_otf
+
+
+_DEF_FNUMBER = 4.0
+_DEF_FLENGTH = 0.017  # meters
+
+
+def human_oi(scene: Scene, oi: OpticalImage | None = None) -> OpticalImage:
+    """Return a human optical image computed from ``scene``."""
+    if scene is None:
+        raise ValueError("scene is required")
+
+    if oi is None:
+        photons = np.asarray(scene.photons, dtype=float).copy()
+        oi = OpticalImage(photons=photons, wave=np.asarray(scene.wave, dtype=float))
+    else:
+        oi.photons = np.asarray(scene.photons, dtype=float).copy()
+        oi.wave = np.asarray(scene.wave, dtype=float).copy()
+
+    if hasattr(scene, "fov"):
+        oi.wangular = scene.fov
+
+    spacing = getattr(scene, "sample_spacing", 1.0)
+    oi.sample_spacing = spacing
+
+    sup = oi_spatial_support(oi, units="meters")
+    X, Y = np.meshgrid(sup["x"], sup["y"])
+    diag = np.sqrt(np.ptp(sup["x"]) ** 2 + np.ptp(sup["y"]) ** 2)
+    fall = optics_cos4th(X, Y, _DEF_FLENGTH, diag, _DEF_FNUMBER, magnification=0)
+    oi.photons *= fall[..., np.newaxis]
+
+    otf, _, wave = human_otf(wave=oi.wave)
+    psf = optics_otf(otf)
+    for i in range(wave.size):
+        oi.photons[:, :, i] = fftconvolve(
+            oi.photons[:, :, i], psf[:, :, i], mode="same"
+        )
+
+    oi.irradiance = oi_calculate_irradiance(oi)
+    oi.illuminance = oi_calculate_illuminance(oi)
+    return oi

--- a/python/isetcam/human/human_uv_safety.py
+++ b/python/isetcam/human/human_uv_safety.py
@@ -1,0 +1,106 @@
+"""Evaluate photobiological safety of ultraviolet and blue light."""
+
+from __future__ import annotations
+
+from typing import Tuple
+import numpy as np
+
+from ..data_path import data_path
+from ..ie_read_spectra import ie_read_spectra
+
+
+_DEF_METHOD = "eye"
+
+
+def human_uv_safety(
+    energy: np.ndarray,
+    wave: np.ndarray,
+    method: str = _DEF_METHOD,
+    duration: float = 1.0,
+) -> Tuple[float, float, bool | None]:
+    """Return safety metrics for spectral ``energy``.
+
+    Parameters
+    ----------
+    energy : np.ndarray
+        Spectral irradiance or radiance in watts/(nm m^2).
+    wave : np.ndarray
+        Wavelength samples in nanometers.
+    method : str, optional
+        One of ``'skineye'``, ``'eye'``, ``'bluehazard'``,
+        ``'thermalskin'``, or ``'skinthermalthreshold'``.
+        Defaults to ``'eye'``.
+    duration : float, optional
+        Exposure duration in seconds. Defaults to 1.0.
+
+    Returns
+    -------
+    tuple
+        ``(val, level, safety)`` as defined by the IEC 62471 standard.
+    """
+    energy = np.asarray(energy, dtype=float).reshape(-1)
+    wave = np.asarray(wave, dtype=float).reshape(-1)
+    if energy.size != wave.size:
+        raise ValueError("energy and wave must have the same length")
+
+    if wave.size > 1:
+        d_lambda = float(wave[1] - wave[0])
+    else:
+        d_lambda = 10.0
+
+    m = method.lower()
+    val: float | bool
+    level: float
+    safety: bool | None = None
+
+    if m == "skineye":
+        actinic, _, _, _ = ie_read_spectra(
+            data_path("safetyStandards/Actinic.mat"), wave
+        )
+        mask = wave <= 400
+        level = float(np.dot(actinic[mask], energy[mask]) * d_lambda)
+        val = (30.0 / level) / 60.0
+    elif m == "eye":
+        mask = wave <= 400
+        level = float(np.sum(energy[mask]) * d_lambda)
+        if duration <= 1000:
+            safety = level * duration < 10000
+        else:
+            safety = level < 10
+        val = safety
+    elif m == "bluehazard":
+        blue, _, _, _ = ie_read_spectra(
+            data_path("safetyStandards/blueLightHazard.mat"), wave
+        )
+        level = float(np.dot(blue, energy) * d_lambda)
+        if duration <= 1e4 and level * duration < 1e6:
+            safety = True
+        elif duration > 1e4 and level < 100:
+            safety = True
+        else:
+            safety = False
+        if level > 100:
+            if duration <= 1e4:
+                val = 1e6 / level / 60.0
+            else:
+                val = 0.0
+            # when level <= 100 the standard does not specify a limit
+        else:
+            val = float("inf")
+    elif m == "thermalskin":
+        level = float(duration ** 0.25 * np.sum(energy) * d_lambda)
+        val = level
+        safety = duration <= 10 and level < 20000 * duration ** 0.25
+    elif m == "skinthermalthreshold":
+        if wave.size > 1:
+            d = float(wave[1] - wave[0])
+        else:
+            d = 10.0
+        val = float(np.sum(energy) * d * duration)
+        level = val
+        h = 2 * duration ** 0.25 * 1e4
+        safety = val < h
+    else:
+        raise ValueError(f"Unknown method '{method}'")
+
+    return val, level, safety

--- a/python/tests/test_human_oi.py
+++ b/python/tests/test_human_oi.py
@@ -1,0 +1,14 @@
+import numpy as np
+from isetcam.scene import Scene
+from isetcam.human import human_oi
+
+
+def test_human_oi_basic():
+    wave = np.array([550], dtype=float)
+    photons = np.ones((8, 8, 1), dtype=float)
+    sc = Scene(photons=photons, wave=wave)
+    sc.sample_spacing = 1e-3
+    oi = human_oi(sc)
+    assert oi.photons.shape == photons.shape
+    assert hasattr(oi, "illuminance")
+    assert oi.illuminance.shape == photons.shape[:2]

--- a/python/tests/test_human_uv_safety.py
+++ b/python/tests/test_human_uv_safety.py
@@ -1,0 +1,11 @@
+import numpy as np
+from isetcam.human import human_uv_safety
+
+
+def test_human_uv_safety_eye():
+    wave = np.arange(300, 401, 10, dtype=float)
+    energy = np.ones_like(wave) * 0.01
+    val, level, safe = human_uv_safety(energy, wave, method="eye", duration=100)
+    assert isinstance(val, (bool, np.bool_))
+    assert level > 0
+    assert isinstance(safe, (bool, np.bool_))


### PR DESCRIPTION
## Summary
- implement `human_oi` for a simplified human optical image calculation
- implement `human_uv_safety` to assess UV/blue light exposure
- export new utilities in `isetcam.human`
- test human optical image creation
- test UV safety calculations

## Testing
- `pytest -q python/tests/test_human_oi.py python/tests/test_human_uv_safety.py`

------
https://chatgpt.com/codex/tasks/task_e_683c2329c1508323a9d9e9e5c86fb3b7