### PR TITLE
Add scene_radiance_from_vector utility

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -53,6 +53,7 @@ from .scene_vector_utils import (
     scene_photons_from_vector,
     scene_energy_from_vector,
 )
+from .scene_radiance_from_vector import scene_radiance_from_vector
 
 __all__ = [
     "Scene",
@@ -108,4 +109,5 @@ __all__ = [
     "scene_init_spatial",
     "scene_photons_from_vector",
     "scene_energy_from_vector",
+    "scene_radiance_from_vector",
 ]

--- a/python/isetcam/scene/scene_radiance_from_vector.py
+++ b/python/isetcam/scene/scene_radiance_from_vector.py
@@ -1,0 +1,32 @@
+"""Retrieve spectral radiance at a pixel of a :class:`Scene`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+from .scene_vector_utils import scene_photons_from_vector
+from ..quanta2energy import quanta_to_energy
+
+
+def scene_radiance_from_vector(scene: Scene, row: int, col: int) -> np.ndarray:
+    """Return radiance at ``(row, col)`` as a 1-D vector.
+
+    Parameters
+    ----------
+    scene : Scene
+        Input scene containing photon data.
+    row, col : int
+        Pixel coordinates.
+
+    Returns
+    -------
+    np.ndarray
+        Radiance values in watts/sr/nm/m^2 for the given pixel.
+    """
+    photons_vec = scene_photons_from_vector(scene, row, col)
+    energy = quanta_to_energy(scene.wave, photons_vec)
+    return energy.reshape(-1)
+
+
+__all__ = ["scene_radiance_from_vector"]

--- a/python/tests/test_scene_radiance_vector.py
+++ b/python/tests/test_scene_radiance_vector.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from isetcam.scene import Scene, scene_radiance_from_vector
+from isetcam.quanta2energy import quanta_to_energy
+
+
+def _simple_scene() -> Scene:
+    wave = np.array([500, 510, 520])
+    photons = np.arange(24).reshape(2, 2, 6)[:, :, :3]
+    return Scene(photons=photons, wave=wave)
+
+
+def test_scene_radiance_from_vector():
+    sc = _simple_scene()
+    vec = scene_radiance_from_vector(sc, 1, 1)
+    expected = quanta_to_energy(sc.wave, sc.photons[1, 1, :])
+    assert vec.shape == (3,)
+    assert np.allclose(vec, expected.reshape(-1))
+


### PR DESCRIPTION
## Summary
- implement `scene_radiance_from_vector` to get radiance vector at a pixel
- expose new helper from `scene.__init__`
- unit test for the new helper

## Testing
- `pytest python/tests/test_scene_radiance_vector.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683c2aabc7148323ba543217de7d7dfc