### PR TITLE
Update CI Python matrix

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,11 +13,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: |
             python/pyproject.toml


### PR DESCRIPTION
## Summary
- test against multiple Python versions in CI

## Testing
- `pip install -e python flake8` *(fails: could not download build dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'isetcam')*

------
https://chatgpt.com/codex/tasks/task_e_683c429fed9c83238b7991aa62ef233c