### PR TITLE
Add sensor filter editing utilities

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -29,6 +29,9 @@ from .sensor_resample_wave import sensor_resample_wave
 from .sensor_rescale import sensor_rescale
 from .sensor_gain_offset import sensor_gain_offset
 from .sensor_dr import sensor_dr
+from .sensor_add_filter import sensor_add_filter
+from .sensor_delete_filter import sensor_delete_filter
+from .sensor_replace_filter import sensor_replace_filter
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -87,4 +90,7 @@ __all__ = [
     "sensor_rescale",
     "sensor_gain_offset",
     "sensor_dr",
+    "sensor_add_filter",
+    "sensor_delete_filter",
+    "sensor_replace_filter",
 ]

--- a/python/isetcam/sensor/sensor_add_filter.py
+++ b/python/isetcam/sensor/sensor_add_filter.py
@@ -1,0 +1,49 @@
+"""Append a color filter to a :class:`Sensor`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+from scipy.io import loadmat
+
+from .sensor_class import Sensor
+
+
+def sensor_add_filter(sensor: Sensor, filter_path: str | Path) -> Sensor:
+    """Load ``filter_path`` and append its data to ``sensor``.
+
+    The filter spectrum is interpolated to ``sensor.wave`` and appended to
+    ``sensor.filter_spectra``. The corresponding filter name from the file is
+    appended to ``sensor.filter_names``.
+    """
+    mat = loadmat(str(Path(filter_path)), squeeze_me=True, struct_as_record=False)
+    data = np.asarray(mat["data"], dtype=float)
+    src_wave = np.asarray(mat["wavelength"], dtype=float).reshape(-1)
+    names = mat.get("filterNames")
+    if names is None:
+        name = Path(filter_path).stem
+    else:
+        name = str(np.atleast_1d(names)[0])
+
+    column = data[:, 0] if data.ndim > 1 else data.reshape(-1)
+    wave = np.asarray(sensor.wave, dtype=float)
+    column = np.interp(wave, src_wave, column, left=0.0, right=0.0)
+    column = column.reshape(-1, 1)
+
+    if hasattr(sensor, "filter_spectra"):
+        fs = np.asarray(sensor.filter_spectra, dtype=float)
+        if fs.shape[0] != column.shape[0]:
+            raise ValueError("filter length mismatch with sensor.wave")
+        sensor.filter_spectra = np.column_stack((fs, column))
+    else:
+        sensor.filter_spectra = column
+
+    if hasattr(sensor, "filter_names"):
+        sensor.filter_names = list(sensor.filter_names) + [name]
+    else:
+        sensor.filter_names = [name]
+
+    return sensor
+
+
+__all__ = ["sensor_add_filter"]

--- a/python/isetcam/sensor/sensor_delete_filter.py
+++ b/python/isetcam/sensor/sensor_delete_filter.py
@@ -1,0 +1,34 @@
+"""Remove a color filter from a :class:`Sensor`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .sensor_class import Sensor
+
+
+def sensor_delete_filter(sensor: Sensor, which_filter: int) -> Sensor:
+    """Delete filter ``which_filter`` from ``sensor``.
+
+    Parameters
+    ----------
+    sensor : Sensor
+        Sensor instance containing ``filter_spectra`` and ``filter_names``.
+    which_filter : int
+        Index of the filter to remove (0-based).
+    """
+    if not hasattr(sensor, "filter_spectra"):
+        raise AttributeError("sensor has no 'filter_spectra'")
+    fs = np.asarray(sensor.filter_spectra, dtype=float)
+    if which_filter < 0 or which_filter >= fs.shape[1]:
+        raise IndexError("which_filter out of range")
+    sensor.filter_spectra = np.delete(fs, which_filter, axis=1)
+
+    names = list(getattr(sensor, "filter_names", []))
+    if names and which_filter < len(names):
+        del names[which_filter]
+    sensor.filter_names = names
+    return sensor
+
+
+__all__ = ["sensor_delete_filter"]

--- a/python/isetcam/sensor/sensor_replace_filter.py
+++ b/python/isetcam/sensor/sensor_replace_filter.py
@@ -1,0 +1,47 @@
+"""Replace an existing color filter in a :class:`Sensor`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+from scipy.io import loadmat
+
+from .sensor_class import Sensor
+
+
+def sensor_replace_filter(sensor: Sensor, which_filter: int, new_filter_file: str | Path) -> Sensor:
+    """Replace filter ``which_filter`` with data from ``new_filter_file``."""
+    if not hasattr(sensor, "filter_spectra"):
+        raise AttributeError("sensor has no 'filter_spectra'")
+    fs = np.asarray(sensor.filter_spectra, dtype=float)
+    if which_filter < 0 or which_filter >= fs.shape[1]:
+        raise IndexError("which_filter out of range")
+
+    mat = loadmat(str(Path(new_filter_file)), squeeze_me=True, struct_as_record=False)
+    data = np.asarray(mat["data"], dtype=float)
+    src_wave = np.asarray(mat["wavelength"], dtype=float).reshape(-1)
+    names = mat.get("filterNames")
+    if names is None:
+        name = Path(new_filter_file).stem
+    else:
+        name = str(np.atleast_1d(names)[0])
+
+    column = data[:, 0] if data.ndim > 1 else data.reshape(-1)
+    wave = np.asarray(sensor.wave, dtype=float)
+    column = np.interp(wave, src_wave, column, left=0.0, right=0.0)
+
+    if column.size != fs.shape[0]:
+        raise ValueError("filter length mismatch with sensor.wave")
+    fs[:, which_filter] = column
+    sensor.filter_spectra = fs
+
+    names_list = list(getattr(sensor, "filter_names", []))
+    while len(names_list) < fs.shape[1]:
+        names_list.append("")
+    names_list[which_filter] = name
+    sensor.filter_names = names_list
+
+    return sensor
+
+
+__all__ = ["sensor_replace_filter"]

--- a/python/tests/test_sensor_filter_edit.py
+++ b/python/tests/test_sensor_filter_edit.py
@@ -1,0 +1,55 @@
+import numpy as np
+from scipy.io import loadmat
+
+from isetcam.sensor import (
+    Sensor,
+    sensor_add_filter,
+    sensor_delete_filter,
+    sensor_replace_filter,
+)
+from isetcam import data_path
+
+
+def _expected(path, wave):
+    mat = loadmat(data_path(path), squeeze_me=True, struct_as_record=False)
+    data = np.asarray(mat["data"], dtype=float).reshape(-1)
+    src_wave = np.asarray(mat["wavelength"], dtype=float).reshape(-1)
+    values = np.interp(wave, src_wave, data, left=0.0, right=0.0)
+    name = str(np.atleast_1d(mat["filterNames"])[0])
+    return values, name
+
+
+def test_sensor_add_filter():
+    wave = np.arange(370, 731, dtype=float)
+    s = Sensor(volts=np.zeros((1, 1)), wave=wave, exposure_time=0.01)
+    sensor_add_filter(s, data_path("sensor/colorfilters/B.mat"))
+    expected, name = _expected("sensor/colorfilters/B.mat", wave)
+    assert s.filter_spectra.shape == (wave.size, 1)
+    assert np.allclose(s.filter_spectra[:, 0], expected)
+    assert s.filter_names == [name]
+
+
+def test_sensor_delete_filter():
+    wave = np.arange(370, 731, dtype=float)
+    s = Sensor(volts=np.zeros((1, 1)), wave=wave, exposure_time=0.01)
+    sensor_add_filter(s, data_path("sensor/colorfilters/B.mat"))
+    sensor_add_filter(s, data_path("sensor/colorfilters/G.mat"))
+    sensor_delete_filter(s, 0)
+    expected, name = _expected("sensor/colorfilters/G.mat", wave)
+    assert s.filter_spectra.shape == (wave.size, 1)
+    assert np.allclose(s.filter_spectra[:, 0], expected)
+    assert s.filter_names == [name]
+
+
+def test_sensor_replace_filter():
+    wave = np.arange(370, 731, dtype=float)
+    s = Sensor(volts=np.zeros((1, 1)), wave=wave, exposure_time=0.01)
+    sensor_add_filter(s, data_path("sensor/colorfilters/B.mat"))
+    sensor_add_filter(s, data_path("sensor/colorfilters/G.mat"))
+    sensor_replace_filter(s, 1, data_path("sensor/colorfilters/R.mat"))
+    expected_b, name_b = _expected("sensor/colorfilters/B.mat", wave)
+    expected_r, name_r = _expected("sensor/colorfilters/R.mat", wave)
+    assert s.filter_spectra.shape == (wave.size, 2)
+    assert np.allclose(s.filter_spectra[:, 0], expected_b)
+    assert np.allclose(s.filter_spectra[:, 1], expected_r)
+    assert s.filter_names == [name_b, name_r]


### PR DESCRIPTION
## Summary
- implement sensor filter editing: add/delete/replace
- expose utilities in sensor package
- test adding, deleting and replacing sensor filters

## Testing
- `PYTHONPATH=$PWD/python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c492de5d083238dbd5580d6dfcafc