### PR TITLE
Add sensor_roi function and tests

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -16,6 +16,7 @@ from .sensor_create import sensor_create
 from .sensor_snr import sensor_snr
 from .sensor_snr_luxsec import sensor_snr_luxsec
 from .sensor_crop import sensor_crop
+from .sensor_roi import sensor_roi
 from .sensor_plot import sensor_plot
 from .sensor_ccm import sensor_ccm
 from .sensor_dng_read import sensor_dng_read
@@ -75,6 +76,7 @@ __all__ = [
     "sensor_to_file",
     "sensor_create",
     "sensor_crop",
+    "sensor_roi",
     "sensor_snr",
     "sensor_snr_luxsec",
     "sensor_plot",

--- a/python/isetcam/sensor/sensor_roi.py
+++ b/python/isetcam/sensor/sensor_roi.py
@@ -1,0 +1,51 @@
+"""Extract a rectangular ROI from a :class:`Sensor`."""
+
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import numpy as np
+
+from .sensor_class import Sensor
+from ..ie_clip import ie_clip
+
+
+def sensor_roi(sensor: Sensor, rect: Sequence[int]) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ROI volts and indices from ``sensor``.
+
+    Parameters
+    ----------
+    sensor : Sensor
+        Sensor object containing voltage data.
+    rect : sequence of int
+        ``(x, y, width, height)`` rectangle using 0-based indexing. Values
+        outside the sensor bounds are clipped similar to MATLAB.
+
+    Returns
+    -------
+    tuple of np.ndarray
+        ``(roi_volts, rows, cols)`` where ``rows`` and ``cols`` are the
+        index arrays for the selected region.
+    """
+
+    if len(rect) != 4:
+        raise ValueError("rect must have four elements (x, y, width, height)")
+
+    x, y, w, h = [int(v) for v in rect]
+    if w <= 0 or h <= 0:
+        raise ValueError("width and height must be positive")
+
+    volts = np.asarray(sensor.volts)
+    nrows, ncols = volts.shape[:2]
+
+    row_idx = np.arange(y, y + h, dtype=int)
+    col_idx = np.arange(x, x + w, dtype=int)
+
+    row_idx = ie_clip(row_idx, 0, nrows - 1).astype(int)
+    col_idx = ie_clip(col_idx, 0, ncols - 1).astype(int)
+
+    roi_volts = volts[np.ix_(row_idx, col_idx)]
+    return roi_volts, row_idx, col_idx
+
+
+__all__ = ["sensor_roi"]

--- a/python/tests/test_sensor_roi.py
+++ b/python/tests/test_sensor_roi.py
@@ -1,0 +1,34 @@
+import numpy as np
+from isetcam.sensor import Sensor, sensor_roi
+
+
+def _simple_sensor(width: int = 4, height: int = 4) -> Sensor:
+    pattern = np.fromfunction(lambda y, x: (y % 2) * 2 + (x % 2), (height, width), dtype=int)
+    return Sensor(volts=pattern.astype(float), wave=np.array([500]), exposure_time=0.01)
+
+
+def test_sensor_roi_basic():
+    s = _simple_sensor(4, 4)
+    roi, rows, cols = sensor_roi(s, (1, 1, 2, 2))
+    expected = s.volts[1:3, 1:3]
+    assert np.array_equal(roi, expected)
+    assert np.array_equal(rows, np.array([1, 2]))
+    assert np.array_equal(cols, np.array([1, 2]))
+
+
+def test_sensor_roi_clip_bounds():
+    s = _simple_sensor(4, 4)
+    roi, rows, cols = sensor_roi(s, (-1, -1, 3, 3))
+    exp_rows = np.array([0, 0, 1])
+    exp_cols = np.array([0, 0, 1])
+    assert np.array_equal(rows, exp_rows)
+    assert np.array_equal(cols, exp_cols)
+    assert np.array_equal(roi, s.volts[np.ix_(exp_rows, exp_cols)])
+
+
+def test_sensor_roi_bad_size():
+    s = _simple_sensor(2, 2)
+    with np.testing.assert_raises(ValueError):
+        sensor_roi(s, (0, 0, 0, 1))
+    with np.testing.assert_raises(ValueError):
+        sensor_roi(s, (0, 0, 1, 0))


### PR DESCRIPTION
## Summary
- implement `sensor_roi` to read a rectangular ROI from a Sensor
- export it from the sensor package
- test ROI extraction and bounds clipping

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_sensor_roi.py`

------
https://chatgpt.com/codex/tasks/task_e_683c4c2dc23c8323bc0b6e7612b1ae8f