### PR TITLE
Add Poirson color model for human_space_time

### DIFF
--- a/python/isetcam/human/__init__.py
+++ b/python/isetcam/human/__init__.py
@@ -19,6 +19,7 @@ from .human_oi import human_oi
 from .human_uv_safety import human_uv_safety
 from .watson_impulse_response import watson_impulse_response
 from .watson_rgc_spacing import watson_rgc_spacing
+from .poirson_spatio_chromatic import poirson_spatio_chromatic
 
 __all__ = [
     'human_pupil_size',
@@ -40,4 +41,5 @@ __all__ = [
     'human_uv_safety',
     'watson_impulse_response',
     'watson_rgc_spacing',
+    'poirson_spatio_chromatic',
 ]

--- a/python/isetcam/human/human_space_time.py
+++ b/python/isetcam/human/human_space_time.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from .kelly_space_time import kelly_space_time, _DEF_FS, _DEF_FT
 from .watson_impulse_response import watson_impulse_response
+from .poirson_spatio_chromatic import poirson_spatio_chromatic
 
 
 def human_space_time(
@@ -37,7 +38,9 @@ def human_space_time(
         sens = np.interp(ft, all_ft, t_mtf)
         fs = None
     elif flag in {"poirsoncolor", "wandellpoirsoncolorspace"}:
-        raise NotImplementedError("Poirson/Wandell color model not implemented")
+        lum, rg, by, positions = poirson_spatio_chromatic()
+        sens = {"lum": lum, "rg": rg, "by": by}
+        fs = positions
     else:
         raise ValueError("Unknown model")
 

--- a/python/isetcam/human/poirson_spatio_chromatic.py
+++ b/python/isetcam/human/poirson_spatio_chromatic.py
@@ -1,0 +1,88 @@
+"""Poirson & Wandell spatial chromatic filters."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _ie_hwhm2sd(hwhm: float, gdim: int = 2) -> float:
+    if gdim == 1:
+        return hwhm / (2 * np.sqrt(np.log(2)))
+    elif gdim == 2:
+        return hwhm / np.sqrt(2 * np.log(2))
+    raise ValueError("gdim must be 1 or 2")
+
+
+def _gauss(hwhm: float, support: int) -> np.ndarray:
+    x = np.arange(support) - round(support / 2)
+    sd = _ie_hwhm2sd(hwhm, 1)
+    g = np.exp(-((x / (2 * sd)) ** 2))
+    return g / g.sum()
+
+
+def _gauss2(hwhm_y: float, support_y: int, hwhm_x: float, support_x: int) -> np.ndarray:
+    x = np.arange(support_x) - round(support_x / 2)
+    y = np.arange(support_y) - round(support_y / 2)
+    X, Y = np.meshgrid(x, y)
+    sd_x = _ie_hwhm2sd(hwhm_x)
+    sd_y = _ie_hwhm2sd(hwhm_y)
+    g = np.exp(-0.5 * ((X / sd_x) ** 2 + (Y / sd_y) ** 2))
+    return g / g.sum()
+
+
+def _sum_gauss(params: list[float], dimension: int) -> np.ndarray:
+    width = int(round(params[0]))
+    n_gauss = (len(params) - 1) // 2
+    if dimension == 2:
+        g = np.zeros((width, width), dtype=float)
+    else:
+        g = np.zeros(width, dtype=float)
+    for i in range(n_gauss):
+        h = params[2 * i + 1]
+        w = params[2 * i + 2]
+        if dimension == 2:
+            g0 = _gauss2(h, width, h, width)
+        else:
+            g0 = _gauss(h, width)
+        g += w * g0
+    return g / g.sum()
+
+
+def poirson_spatio_chromatic(
+    samp_per_deg: float | None = None, dimension: int = 2
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return Poirson & Wandell spatio-chromatic filters."""
+    if samp_per_deg is None:
+        samp_per_deg = 241.0
+
+    x1 = [0.05, 0.9207, 0.225, 0.105, 7.0, -0.1080]
+    x2 = [0.0685, 0.5310, 0.826, 0.33]
+    x3 = [0.0920, 0.4877, 0.6451, 0.3711]
+
+    for idx in (0, 2, 4):
+        if idx < len(x1):
+            x1[idx] *= samp_per_deg
+    for idx in (0, 2):
+        if idx < len(x2):
+            x2[idx] *= samp_per_deg
+    for idx in (0, 2):
+        if idx < len(x3):
+            x3[idx] *= samp_per_deg
+
+    width = int(np.ceil(samp_per_deg / 2) * 2 - 1)
+
+    lum = _sum_gauss([width, *x1], dimension)
+    rg = _sum_gauss([width, *x2], dimension)
+    by = _sum_gauss([width, *x3], dimension)
+
+    lum = lum / lum.sum()
+    rg = rg / rg.sum()
+    by = by / by.sum()
+
+    center = (width + 1) / 2
+    positions = (np.arange(width) - center) / samp_per_deg
+
+    return lum, rg, by, positions
+
+
+__all__ = ["poirson_spatio_chromatic"]

--- a/python/tests/test_human_space_time.py
+++ b/python/tests/test_human_space_time.py
@@ -1,5 +1,10 @@
 import numpy as np
-from isetcam.human import human_space_time, kelly_space_time, westheimer_lsf
+from isetcam.human import (
+    human_space_time,
+    kelly_space_time,
+    westheimer_lsf,
+    poirson_spatio_chromatic,
+)
 
 
 def _kelly_expected():
@@ -38,3 +43,59 @@ def test_westheimer_lsf_defaults():
     exp = 0.47 * np.exp(-3.3 * (x_min ** 2)) + 0.53 * np.exp(-0.93 * np.abs(x_min))
     exp = exp / exp.sum()
     assert np.allclose(ls, exp)
+
+
+def _gauss2(hwhm_y: float, support_y: int, hwhm_x: float, support_x: int) -> np.ndarray:
+    x = np.arange(support_x) - round(support_x / 2)
+    y = np.arange(support_y) - round(support_y / 2)
+    X, Y = np.meshgrid(x, y)
+    sd_x = hwhm_x / np.sqrt(2 * np.log(2))
+    sd_y = hwhm_y / np.sqrt(2 * np.log(2))
+    g = np.exp(-0.5 * ((X / sd_x) ** 2 + (Y / sd_y) ** 2))
+    return g / g.sum()
+
+
+def _sum_gauss(params: list[float]) -> np.ndarray:
+    width = int(round(params[0]))
+    g = np.zeros((width, width), dtype=float)
+    n = (len(params) - 1) // 2
+    for i in range(n):
+        h = params[2 * i + 1]
+        w = params[2 * i + 2]
+        g += w * _gauss2(h, width, h, width)
+    return g / g.sum()
+
+
+def _poirson_expected():
+    samp = 241.0
+    x1 = np.array([0.05, 0.9207, 0.225, 0.105, 7.0, -0.1080])
+    x2 = np.array([0.0685, 0.5310, 0.826, 0.33])
+    x3 = np.array([0.0920, 0.4877, 0.6451, 0.3711])
+    x1[[0, 2, 4]] *= samp
+    x2[[0, 2]] *= samp
+    x3[[0, 2]] *= samp
+    width = int(np.ceil(samp / 2) * 2 - 1)
+    lum = _sum_gauss([width, *x1])
+    rg = _sum_gauss([width, *x2])
+    by = _sum_gauss([width, *x3])
+    pos = (np.arange(width) - (width + 1) / 2) / samp
+    return lum, rg, by, pos
+
+
+def test_poirson_spatio_chromatic_defaults():
+    lum, rg, by, pos = poirson_spatio_chromatic()
+    exp_lum, exp_rg, exp_by, exp_pos = _poirson_expected()
+    assert np.allclose(lum, exp_lum)
+    assert np.allclose(rg, exp_rg)
+    assert np.allclose(by, exp_by)
+    assert np.allclose(pos, exp_pos)
+
+
+def test_human_space_time_poirson():
+    sens, fs, ft = human_space_time("poirsoncolor")
+    exp_lum, exp_rg, exp_by, exp_pos = _poirson_expected()
+    assert np.array_equal(fs, exp_pos)
+    assert np.array_equal(ft, 10 ** np.arange(-0.5, 1.7 + 0.05, 0.05))
+    assert np.allclose(sens["lum"], exp_lum)
+    assert np.allclose(sens["rg"], exp_rg)
+    assert np.allclose(sens["by"], exp_by)


### PR DESCRIPTION
## Summary
- implement Poirson/Wandell spatial color model in Python
- expose `poirson_spatio_chromatic` in human API
- support the model from `human_space_time`
- test Poirson spatio-chromatic filters and gateway

## Testing
- `flake8 python/isetcam` *(fails: F401 etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'isetcam')*

------
https://chatgpt.com/codex/tasks/task_e_683c4f0fc824832387ed6dadfeab3f76