### PR TITLE
Add sensor_to_exr utility

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -12,6 +12,7 @@ from .sensor_compute import sensor_compute
 from .sensor_photon_noise import sensor_photon_noise
 from .sensor_add_noise import sensor_add_noise
 from .sensor_to_file import sensor_to_file
+from .sensor_to_exr import sensor_to_exr
 from .sensor_create import sensor_create
 from .sensor_snr import sensor_snr
 from .sensor_snr_luxsec import sensor_snr_luxsec
@@ -74,6 +75,7 @@ __all__ = [
     "sensor_photon_noise",
     "sensor_add_noise",
     "sensor_to_file",
+    "sensor_to_exr",
     "sensor_create",
     "sensor_crop",
     "sensor_roi",

--- a/python/isetcam/sensor/sensor_to_exr.py
+++ b/python/isetcam/sensor/sensor_to_exr.py
@@ -1,0 +1,39 @@
+"""Save Sensor voltage data to an OpenEXR file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+
+from .sensor_class import Sensor
+from ..io import openexr_write
+
+
+def _volts_to_channels(volts: np.ndarray) -> Dict[str, np.ndarray]:
+    """Return mapping of channel names to planes of ``volts``."""
+    arr = np.asarray(volts, dtype=np.float32)
+    if arr.ndim == 2:
+        arr = arr[:, :, np.newaxis]
+    if arr.ndim != 3:
+        raise ValueError("volts must be 2-D or 3-D array")
+    n_chan = arr.shape[2]
+    if n_chan == 1:
+        names = ["Y"]
+    elif n_chan == 3:
+        names = ["R", "G", "B"]
+    elif n_chan == 4:
+        names = ["R", "G", "B", "A"]
+    else:
+        names = [f"channel{i}" for i in range(n_chan)]
+    return {name: arr[:, :, i] for i, name in enumerate(names)}
+
+
+def sensor_to_exr(sensor: Sensor, path: str | Path) -> None:
+    """Save ``sensor`` voltage data to ``path`` as an OpenEXR image."""
+    channels = _volts_to_channels(sensor.volts)
+    openexr_write(path, channels)
+
+
+__all__ = ["sensor_to_exr"]

--- a/python/tests/test_sensor_to_exr.py
+++ b/python/tests/test_sensor_to_exr.py
@@ -1,0 +1,49 @@
+import io
+import numpy as np
+import pytest
+
+from isetcam.io import openexr_read
+from isetcam.sensor import Sensor, sensor_to_exr
+
+
+def _backend_available() -> bool:
+    try:
+        import OpenEXR  # noqa: F401
+        return True
+    except Exception:
+        pass
+    import imageio.v2 as iio
+    try:
+        with iio.get_writer(io.BytesIO(), format='EXR-FI'):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _backend_available(), reason="OpenEXR support not available")
+def test_sensor_to_exr_roundtrip_rgb(tmp_path):
+    volts = np.stack([
+        np.full((2, 3), 0.1, dtype=np.float32),
+        np.full((2, 3), 0.2, dtype=np.float32),
+        np.full((2, 3), 0.3, dtype=np.float32),
+    ], axis=2)
+    s = Sensor(volts=volts, exposure_time=0.01, wave=np.array([550]))
+    path = tmp_path / 'sensor.exr'
+    sensor_to_exr(s, path)
+    loaded = openexr_read(path)
+    assert set(loaded.keys()) == {'R', 'G', 'B'}
+    assert np.allclose(loaded['R'], volts[:, :, 0])
+    assert np.allclose(loaded['G'], volts[:, :, 1])
+    assert np.allclose(loaded['B'], volts[:, :, 2])
+
+
+@pytest.mark.skipif(not _backend_available(), reason="OpenEXR support not available")
+def test_sensor_to_exr_roundtrip_gray(tmp_path):
+    volts = np.random.rand(3, 2).astype(np.float32)
+    s = Sensor(volts=volts, exposure_time=0.01, wave=np.array([550]))
+    path = tmp_path / 'sensor_gray.exr'
+    sensor_to_exr(s, path)
+    loaded = openexr_read(path)
+    assert list(loaded.keys()) == ['Y']
+    assert np.allclose(loaded['Y'], volts)


### PR DESCRIPTION
## Summary
- implement `sensor_to_exr` using `openexr_write`
- expose the helper from `sensor.__init__`
- test round‑trip EXR I/O for sensor data

## Testing
- `PYTHONPATH=python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c51b84d2c83238f35d8b5f842b8a3