### PR TITLE
Add ie_scale utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -79,6 +79,8 @@ from .mk_inv_gamma_table import mk_inv_gamma_table
 from .ie_cov_ellipsoid import ie_cov_ellipsoid
 from .ie_read_spectra import ie_read_spectra
 from .ie_hist_image import ie_hist_image
+from .ie_scale import ie_scale
+from .ie_scale_columns import ie_scale_columns
 from .ie_format_figure import (
     ie_format_figure,
     set_ie_figure_defaults,
@@ -216,6 +218,8 @@ __all__ = [
     'ie_cov_ellipsoid',
     'ie_read_spectra',
     'ie_hist_image',
+    'ie_scale',
+    'ie_scale_columns',
     'ie_format_figure',
     'set_ie_figure_defaults',
     '_IE_FIGURE_DEFAULTS',

--- a/python/isetcam/ie_scale.py
+++ b/python/isetcam/ie_scale.py
@@ -1,0 +1,64 @@
+"""Scale numeric data to a specified range."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Tuple
+
+
+def ie_scale(im: np.ndarray, b1: float | None = None, b2: float | None = None) -> Tuple[np.ndarray, float, float]:
+    """Scale ``im`` into the range ``[b1, b2]``.
+
+    The function mirrors the behavior of the MATLAB ``ieScale`` utility.
+
+    Parameters
+    ----------
+    im : np.ndarray
+        Input data to be scaled.
+    b1 : float, optional
+        Lower bound of the output range when ``b2`` is provided or the desired
+        maximum value when ``b2`` is ``None``.
+    b2 : float, optional
+        Upper bound of the output range. When omitted, ``b1`` specifies the
+        maximum value and the data are simply scaled so that the maximum equals
+        ``b1``.
+
+    Returns
+    -------
+    tuple[np.ndarray, float, float]
+        The scaled array along with the minimum and maximum of the input data.
+    """
+
+    arr = np.asarray(im, dtype=float)
+    mx = float(arr.max())
+    mn = float(arr.min())
+
+    if b1 is not None and b2 is None:
+        # Single bound: scale so the maximum equals ``b1``
+        if mx == 0:
+            scaled = np.zeros_like(arr)
+        else:
+            scaled = arr * (float(b1) / mx)
+        return scaled, mn, mx
+
+    # Scale to [0, 1]
+    if mx == mn:
+        norm = np.zeros_like(arr)
+    else:
+        norm = (arr - mn) / (mx - mn)
+
+    if b1 is None and b2 is None:
+        b1, b2 = 0.0, 1.0
+    elif b2 is not None:
+        if b1 is None or b1 >= b2:
+            raise ValueError("ie_scale: bad bounds values")
+    else:
+        # Should not reach here (handled by first branch)
+        b1, b2 = 0.0, 1.0
+
+    range_ = float(b2 - b1)
+    scaled = range_ * norm + float(b1)
+    return scaled, mn, mx
+
+
+__all__ = ["ie_scale"]

--- a/python/isetcam/ie_scale_columns.py
+++ b/python/isetcam/ie_scale_columns.py
@@ -1,0 +1,42 @@
+"""Apply :func:`ie_scale` to each column of an array."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .ie_scale import ie_scale
+
+
+def ie_scale_columns(X: np.ndarray, b1: float | None = 1.0, b2: float | None = None) -> np.ndarray:
+    """Scale each column of ``X`` using :func:`ie_scale`.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Input matrix whose columns will be scaled.
+    b1 : float, optional
+        When ``b2`` is ``None`` this value becomes the maximum of each scaled
+        column. Otherwise it is the lower bound of the output range.
+    b2 : float, optional
+        Upper bound of the output range for each column. When omitted, only a
+        single bound ``b1`` is used and columns are scaled so their maxima equal
+        ``b1``.
+
+    Returns
+    -------
+    np.ndarray
+        Matrix with each column individually scaled.
+    """
+
+    X = np.asarray(X, dtype=float)
+    result = np.zeros_like(X)
+    if b2 is None:
+        for ii in range(X.shape[1]):
+            result[:, ii], _, _ = ie_scale(X[:, ii], b1)
+    else:
+        for ii in range(X.shape[1]):
+            result[:, ii], _, _ = ie_scale(X[:, ii], b1, b2)
+    return result
+
+
+__all__ = ["ie_scale_columns"]

--- a/python/tests/test_ie_scale.py
+++ b/python/tests/test_ie_scale.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from isetcam import ie_scale, ie_scale_columns
+
+
+def test_ie_scale_default():
+    data = np.array([-1.0, 0.0, 1.0, 2.0])
+    scaled, mn, mx = ie_scale(data)
+    assert np.isclose(mn, -1.0)
+    assert np.isclose(mx, 2.0)
+    assert np.isclose(scaled.min(), 0.0)
+    assert np.isclose(scaled.max(), 1.0)
+
+
+def test_ie_scale_range():
+    data = np.array([-5.0, 0.0, 5.0])
+    scaled, mn, mx = ie_scale(data, -1.0, 1.0)
+    assert np.isclose(mn, -5.0)
+    assert np.isclose(mx, 5.0)
+    assert np.allclose(scaled, [-1.0, 0.0, 1.0])
+
+
+def test_ie_scale_columns():
+    X = np.array([[1.0, 2.0], [2.0, 4.0]])
+    out = ie_scale_columns(X)
+    expected = np.array([[0.5, 0.5], [1.0, 1.0]])
+    assert np.allclose(out, expected)


### PR DESCRIPTION
## Summary
- implement `ie_scale` for scaling arrays to a range
- implement `ie_scale_columns` to apply scaling column-wise
- expose the new helpers in `isetcam.__init__`
- add unit tests covering default scaling, custom ranges and column behaviour

## Testing
- `pytest python/tests/test_ie_scale.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683cc9cdb2888323b9e0508cb07b32b8