### PR TITLE
Add statistical utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -81,6 +81,10 @@ from .ie_read_spectra import ie_read_spectra
 from .ie_hist_image import ie_hist_image
 from .ie_scale import ie_scale
 from .ie_scale_columns import ie_scale_columns
+from .ie_prctile import ie_prctile
+from .ie_mvnrnd import ie_mvnrnd
+from .ie_poisson import ie_poisson
+from .ie_normpdf import ie_normpdf
 from .ie_format_figure import (
     ie_format_figure,
     set_ie_figure_defaults,
@@ -220,6 +224,10 @@ __all__ = [
     'ie_hist_image',
     'ie_scale',
     'ie_scale_columns',
+    'ie_prctile',
+    'ie_mvnrnd',
+    'ie_poisson',
+    'ie_normpdf',
     'ie_format_figure',
     'set_ie_figure_defaults',
     '_IE_FIGURE_DEFAULTS',

--- a/python/isetcam/ie_mvnrnd.py
+++ b/python/isetcam/ie_mvnrnd.py
@@ -1,0 +1,50 @@
+"""Multivariate normal random number generator."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def ie_mvnrnd(mu: np.ndarray | float = 0.0, sigma: np.ndarray | float = 1.0, k: int | None = None) -> np.ndarray:
+    """Draw samples from a multivariate normal distribution.
+
+    Parameters
+    ----------
+    mu : array-like, optional
+        Mean vector or array. When 1-D and ``k`` is provided, ``mu`` is
+        replicated ``k`` times along the first axis.
+    sigma : array-like, optional
+        Covariance matrix. Must be square with size equal to the trailing
+        dimension of ``mu``.
+    k : int, optional
+        Number of samples per row of ``mu`` when ``mu`` has a single row.
+
+    Returns
+    -------
+    np.ndarray
+        Samples drawn from ``N(mu, sigma)``.
+    """
+    mu = np.atleast_2d(np.asarray(mu, dtype=float))
+    d = mu.shape[1]
+
+    if k is not None and mu.shape[0] == 1:
+        mu = np.tile(mu, (int(k), 1))
+
+    sigma = np.asarray(sigma, dtype=float)
+    if sigma.shape != (d, d):
+        raise ValueError("sigma must be d x d matching columns of mu")
+
+    try:
+        u = np.linalg.cholesky(sigma)
+    except np.linalg.LinAlgError:
+        eigvals, eigvecs = np.linalg.eigh(sigma)
+        if np.min(eigvals) < 0:
+            raise ValueError("sigma must be positive semi-definite")
+        u = eigvecs @ np.diag(np.sqrt(eigvals))
+
+    rng = np.random.default_rng()
+    z = rng.standard_normal(mu.shape)
+    return z @ u.T + mu
+
+
+__all__ = ["ie_mvnrnd"]

--- a/python/isetcam/ie_normpdf.py
+++ b/python/isetcam/ie_normpdf.py
@@ -1,0 +1,36 @@
+"""Normal probability density function."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def ie_normpdf(x: np.ndarray, mu: np.ndarray | float = 0.0, sigma: np.ndarray | float = 1.0) -> np.ndarray:
+    """Return the normal probability density function evaluated at ``x``.
+
+    Parameters
+    ----------
+    x : array-like
+        Points at which to evaluate the pdf.
+    mu : array-like or float, optional
+        Mean of the distribution. Defaults to 0.
+    sigma : array-like or float, optional
+        Standard deviation of the distribution. Defaults to 1.
+
+    Returns
+    -------
+    np.ndarray
+        Values of the pdf evaluated at ``x``.
+    """
+    x = np.asarray(x, dtype=float)
+    mu = np.asarray(mu, dtype=float)
+    sigma = np.asarray(sigma, dtype=float)
+
+    if np.any(sigma <= 0):
+        raise ValueError("sigma must be > 0")
+
+    xn = (x - mu) / sigma
+    return np.exp(-0.5 * xn**2) / (np.sqrt(2 * np.pi) * sigma)
+
+
+__all__ = ["ie_normpdf"]

--- a/python/isetcam/ie_poisson.py
+++ b/python/isetcam/ie_poisson.py
@@ -1,0 +1,80 @@
+"""Poisson random number generator with ISETCam options."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.random import Generator
+
+
+_DEF_SEED = 1
+
+
+def _make_rng(noise_flag: str, seed: int) -> tuple[Generator, int]:
+    """Return a random generator according to ``noise_flag``.
+
+    Parameters
+    ----------
+    noise_flag : {'random', 'frozen', 'donotset'}
+        How the random generator seed should be handled.
+    seed : int
+        Seed value when ``noise_flag`` is 'frozen'.  When ``noise_flag`` is
+        'random', a random seed is generated and returned.
+
+    Returns
+    -------
+    tuple
+        ``(rng, seed)`` where ``rng`` is a :class:`numpy.random.Generator` and
+        ``seed`` is the seed actually used.
+    """
+    noise_flag = noise_flag.lower()
+    if noise_flag == "frozen":
+        return np.random.default_rng(seed), seed
+    if noise_flag == "random":
+        seed = np.random.SeedSequence().entropy % (2**32)
+        return np.random.default_rng(int(seed)), int(seed)
+    if noise_flag == "donotset":
+        return np.random.default_rng(), seed
+    raise ValueError("noise_flag must be 'random', 'frozen' or 'donotset'")
+
+
+def ie_poisson(
+    lam: np.ndarray | float,
+    *,
+    n_samp: int = 1,
+    noise_flag: str = "random",
+    seed: int = _DEF_SEED,
+) -> tuple[np.ndarray, int]:
+    """Generate Poisson-distributed random values.
+
+    Parameters
+    ----------
+    lam : array-like or float
+        Mean rate parameter(s) of the distribution.
+    n_samp : int, optional
+        Number of samples when ``lam`` is scalar. Ignored otherwise.
+    noise_flag : {'random', 'frozen', 'donotset'}, optional
+        Controls the random generator seed. ``'frozen'`` uses the supplied
+        ``seed`` and returns it; ``'random'`` chooses a new random seed and
+        returns it; ``'donotset'`` leaves the generator state unspecified.
+    seed : int, optional
+        Seed value used when ``noise_flag`` is ``'frozen'``.
+
+    Returns
+    -------
+    tuple of np.ndarray and int
+        ``(samples, seed)`` where ``samples`` contains the Poisson random
+        values and ``seed`` is the seed used for generation.
+    """
+    lam = np.asarray(lam, dtype=float)
+
+    rng, seed = _make_rng(noise_flag, int(seed))
+
+    if lam.size == 1:
+        val = rng.poisson(float(lam), size=(int(n_samp), int(n_samp)))
+    else:
+        val = rng.poisson(lam)
+
+    return val, seed
+
+
+__all__ = ["ie_poisson"]

--- a/python/isetcam/ie_prctile.py
+++ b/python/isetcam/ie_prctile.py
@@ -1,0 +1,39 @@
+"""Percentile calculation compatible with MATLAB's ``prctile``."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def ie_prctile(x: np.ndarray, p: np.ndarray | float) -> np.ndarray:
+    """Return percentiles of ``x``.
+
+    Parameters
+    ----------
+    x : array-like
+        Input data. For multi-dimensional arrays, percentiles are computed
+        along the first axis (rows) matching MATLAB behavior.
+    p : array-like or float
+        Percentile or percentiles in the range [0, 100].
+
+    Returns
+    -------
+    np.ndarray
+        Percentile values. If ``p`` is a scalar the result is a row vector
+        containing the percentile of each column of ``x``. When ``p`` is a
+        vector, each row contains the corresponding percentile.
+    """
+    arr = np.asarray(x, dtype=float)
+    perc = np.asarray(p, dtype=float).reshape(-1)
+
+    if np.any(perc < 0) or np.any(perc > 100):
+        raise ValueError("p must be between 0 and 100")
+
+    if arr.ndim == 1:
+        arr = arr.reshape(-1, 1)
+
+    result = np.percentile(arr, perc, axis=0)
+    return result
+
+
+__all__ = ["ie_prctile"]

--- a/python/tests/test_ie_statistics.py
+++ b/python/tests/test_ie_statistics.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+from isetcam import ie_poisson, ie_prctile, ie_mvnrnd, ie_normpdf
+
+
+def test_ie_poisson_scalar_frozen():
+    val1, seed1 = ie_poisson(5, n_samp=4, noise_flag="frozen", seed=42)
+    val2, seed2 = ie_poisson(5, n_samp=4, noise_flag="frozen", seed=42)
+    assert seed1 == 42
+    assert seed2 == 42
+    assert np.array_equal(val1, val2)
+
+
+def test_ie_poisson_random():
+    val1, seed1 = ie_poisson(2, n_samp=2, noise_flag="random")
+    val2, seed2 = ie_poisson(2, n_samp=2, noise_flag="random")
+    assert not np.array_equal(val1, val2) or seed1 != seed2
+
+
+def test_ie_prctile_basic():
+    data = np.arange(10)
+    p50 = ie_prctile(data, 50)
+    assert np.allclose(p50, np.percentile(data, 50))
+
+
+def test_ie_prctile_error():
+    with pytest.raises(ValueError):
+        ie_prctile([1, 2, 3], 150)
+
+
+def test_ie_mvnrnd_shape():
+    mu = [0, 0]
+    sigma = [[1, 0], [0, 1]]
+    out = ie_mvnrnd(mu, sigma, k=5)
+    assert out.shape == (5, 2)
+
+
+def test_ie_normpdf_values():
+    val = ie_normpdf(0)
+    assert np.isclose(val, 1 / np.sqrt(2 * np.pi))


### PR DESCRIPTION
## Summary
- implement ie_poisson, ie_prctile, ie_mvnrnd, and ie_normpdf
- export new functions from package
- test statistical utilities

## Testing
- `pytest -q python/tests/test_ie_statistics.py`

------
https://chatgpt.com/codex/tasks/task_e_683ccc639f6c8323a99d282c4e8bbf72