### PR TITLE
Add VC session utilities to Python API

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -45,6 +45,14 @@ from .vc_replace_object import vc_replace_object
 from .vc_replace_and_select_object import vc_replace_and_select_object
 from .vc_delete_object import vc_delete_object
 from .vc_clear_objects import vc_clear_objects
+from .vc_get_objects import vc_get_objects
+from .vc_count_objects import vc_count_objects
+from .vc_get_object_names import vc_get_object_names
+from .vc_get_selected_object import vc_get_selected_object
+from .vc_set_objects import vc_set_objects
+from .vc_set_selected_object import vc_set_selected_object
+from .vc_new_object_name import vc_new_object_name
+from .vc_new_object_value import vc_new_object_value
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 from .xyz_to_lab import xyz_to_lab
@@ -311,4 +319,12 @@ __all__ = [
     'vc_replace_and_select_object',
     'vc_delete_object',
     'vc_clear_objects',
+    'vc_get_objects',
+    'vc_count_objects',
+    'vc_get_object_names',
+    'vc_get_selected_object',
+    'vc_set_objects',
+    'vc_set_selected_object',
+    'vc_new_object_name',
+    'vc_new_object_value',
 ]

--- a/python/isetcam/vc_count_objects.py
+++ b/python/isetcam/vc_count_objects.py
@@ -1,0 +1,14 @@
+"""Count objects of a given type stored in ``vcSESSION``."""
+
+from __future__ import annotations
+
+from .vc_get_objects import vc_get_objects
+
+
+def vc_count_objects(obj_type: str) -> int:
+    """Return the number of stored objects of ``obj_type``."""
+    objs = vc_get_objects(obj_type)
+    if len(objs) == 1 and objs[0] is None:
+        return 0
+    return len(objs) - 1
+

--- a/python/isetcam/vc_get_object_names.py
+++ b/python/isetcam/vc_get_object_names.py
@@ -1,0 +1,39 @@
+"""List the names of stored objects of a given type."""
+
+from __future__ import annotations
+
+from typing import List
+import warnings
+
+from .vc_get_objects import vc_get_objects
+
+
+def vc_get_object_names(obj_type: str, make_unique: bool = False) -> list[str]:
+    """Return the object names for ``obj_type``.
+
+    Parameters
+    ----------
+    obj_type : str
+        Object type to query.
+    make_unique : bool, optional
+        When ``True`` prefix the names with their index to ensure
+        uniqueness.
+    """
+    objs = vc_get_objects(obj_type)
+    if len(objs) == 1 and objs[0] is None:
+        return []
+
+    names: list[str] = []
+    for idx, obj in enumerate(objs[1:], start=1):
+        if obj is None:
+            continue
+        name = getattr(obj, "name", None)
+        if name is None:
+            warnings.warn("Missing object name", RuntimeWarning)
+            continue
+        names.append(name)
+
+    if make_unique:
+        names = [f"{i}-{n}" for i, n in enumerate(names, start=1)]
+    return names
+

--- a/python/isetcam/vc_get_objects.py
+++ b/python/isetcam/vc_get_objects.py
@@ -1,0 +1,27 @@
+"""Retrieve the list of objects for a given type from ``vcSESSION``."""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_get_objects(obj_type: str) -> list[Any]:
+    """Return the stored list of objects for ``obj_type``.
+
+    Parameters
+    ----------
+    obj_type : str
+        The object type (e.g. ``'scene'`` or ``'sensor'``).
+
+    Returns
+    -------
+    list[Any]
+        The list of objects. If none exist a list with a single ``None``
+        placeholder is returned.
+    """
+    field = _norm_objtype(obj_type)
+    return vcSESSION.get(field, [None])
+

--- a/python/isetcam/vc_get_selected_object.py
+++ b/python/isetcam/vc_get_selected_object.py
@@ -1,0 +1,19 @@
+"""Return the index and object currently selected in ``vcSESSION``."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+from .vc_get_object import vc_get_object
+
+
+def vc_get_selected_object(obj_type: str) -> tuple[Optional[int], Any]:
+    """Return the selected index and object of ``obj_type``."""
+    field = _norm_objtype(obj_type)
+    index = vcSESSION.get("SELECTED", {}).get(field)
+    if index is None:
+        return None, None
+    return index, vc_get_object(obj_type, index)
+

--- a/python/isetcam/vc_new_object_name.py
+++ b/python/isetcam/vc_new_object_name.py
@@ -1,0 +1,14 @@
+"""Generate a new default name for an object type."""
+
+from __future__ import annotations
+
+from .vc_count_objects import vc_count_objects
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_new_object_name(obj_type: str) -> str:
+    """Return a new name for ``obj_type`` based on current count."""
+    field = _norm_objtype(obj_type)
+    idx = vc_count_objects(obj_type) + 1
+    return f"{field}{idx}"
+

--- a/python/isetcam/vc_new_object_value.py
+++ b/python/isetcam/vc_new_object_value.py
@@ -1,0 +1,31 @@
+"""Compute the next available numeric identifier for an object type."""
+
+from __future__ import annotations
+
+from typing import Tuple, Union
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+from .vc_count_objects import vc_count_objects
+
+
+def vc_new_object_value(obj_type: str) -> Union[int, Tuple[int, int, int]]:
+    """Return the next numeric identifier for ``obj_type``.
+
+    For cameras the return value is a 3-tuple with the next identifiers for
+    the optical image, sensor and image processor objects that compose the
+    camera.
+    """
+    field = _norm_objtype(obj_type)
+    if field == "CAMERA":
+        oi_val = vc_count_objects("opticalimage") + 1
+        sensor_val = vc_count_objects("sensor") + 1
+        ip_list = vcSESSION.get("VCIMAGE", [None])
+        if len(ip_list) == 1 and ip_list[0] is None:
+            ip_val = 1
+        else:
+            ip_val = len(ip_list)
+        return oi_val, sensor_val, ip_val
+
+    return vc_count_objects(obj_type) + 1
+

--- a/python/isetcam/vc_set_objects.py
+++ b/python/isetcam/vc_set_objects.py
@@ -1,0 +1,15 @@
+"""Replace the list of objects stored for a given type in ``vcSESSION``."""
+
+from __future__ import annotations
+
+from typing import Sequence, Any
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_set_objects(obj_type: str, objects: Sequence[Any]) -> None:
+    """Set the list of objects for ``obj_type``."""
+    field = _norm_objtype(obj_type)
+    vcSESSION[field] = list(objects)
+

--- a/python/isetcam/vc_set_selected_object.py
+++ b/python/isetcam/vc_set_selected_object.py
@@ -1,0 +1,24 @@
+"""Update the selected object index for a given type in ``vcSESSION``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+from .vc_get_objects import vc_get_objects
+
+
+def vc_set_selected_object(obj_type: str, index: Optional[int]) -> None:
+    """Set the selected index for ``obj_type``."""
+    field = _norm_objtype(obj_type)
+    if index is None or index < 1:
+        vcSESSION.setdefault("SELECTED", {})[field] = []
+        return
+
+    objs = vc_get_objects(obj_type)
+    count = len(objs) - 1 if not (len(objs) == 1 and objs[0] is None) else 0
+    if index > count:
+        raise IndexError("Selected object out of range")
+    vcSESSION.setdefault("SELECTED", {})[field] = index
+

--- a/python/tests/test_vc_object_management.py
+++ b/python/tests/test_vc_object_management.py
@@ -8,6 +8,14 @@ from isetcam import (
     vc_replace_and_select_object,
     vc_delete_object,
     vc_clear_objects,
+    vc_count_objects,
+    vc_get_objects,
+    vc_get_object_names,
+    vc_get_selected_object,
+    vc_set_objects,
+    vc_set_selected_object,
+    vc_new_object_name,
+    vc_new_object_value,
 )
 from isetcam.scene import Scene
 from isetcam.opticalimage import OpticalImage
@@ -109,4 +117,46 @@ def test_vc_clear_objects():
         "CAMERA",
     ]:
         assert vcSESSION["SELECTED"][fld] == []
+
+
+def test_vc_object_queries_and_selection():
+    ie_init()
+    sc1 = Scene(photons=np.zeros((1, 1, 1)), name="sc1")
+    sc2 = Scene(photons=np.ones((1, 1, 1)), name="sc2")
+
+    vc_add_and_select_object("scene", sc1)
+    vc_add_and_select_object("scene", sc2)
+
+    assert vc_count_objects("scene") == 2
+
+    objs = vc_get_objects("scene")
+    assert objs[1] is sc1 and objs[2] is sc2
+
+    names = vc_get_object_names("scene")
+    assert names == ["sc1", "sc2"]
+    assert vc_get_object_names("scene", make_unique=True) == ["1-sc1", "2-sc2"]
+
+    idx, obj = vc_get_selected_object("scene")
+    assert idx == 2 and obj is sc2
+
+    vc_set_selected_object("scene", 1)
+    idx, obj = vc_get_selected_object("scene")
+    assert idx == 1 and obj is sc1
+
+    vc_set_objects("scene", [None, sc1])
+    assert vc_count_objects("scene") == 1
+
+
+def test_vc_new_object_helpers():
+    ie_init()
+    assert vc_new_object_name("scene") == "SCENE1"
+    assert vc_new_object_value("scene") == 1
+
+    Scene(photons=np.zeros((1, 1, 1)))
+    vc_add_and_select_object("scene", Scene(photons=np.zeros((1, 1, 1))))
+    assert vc_new_object_name("scene") == "SCENE2"
+    assert vc_new_object_value("scene") == 2
+
+    vals = vc_new_object_value("camera")
+    assert isinstance(vals, tuple) and len(vals) == 3
 


### PR DESCRIPTION
## Summary
- implement vc_count_objects, vc_get_objects, vc_get_object_names, vc_get_selected_object, vc_set_objects, vc_set_selected_object, vc_new_object_name, and vc_new_object_value
- expose new APIs in `isetcam.__init__`
- extend unit tests for object management

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ccca8b42c83239c6bd6cbf35479df