### PR TITLE
Add lstar_to_y conversion

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -60,6 +60,7 @@ from .lab_to_xyz import lab_to_xyz
 from .xyz_to_xyy import xyz_to_xyy
 from .xyy_to_xyz import xyy_to_xyz
 from .y_to_lstar import y_to_lstar
+from .lstar_to_y import lstar_to_y
 from .xyz_to_uv import xyz_to_uv
 from .xyz_to_luv import xyz_to_luv
 from .lms_to_xyz import lms_to_xyz
@@ -204,6 +205,7 @@ __all__ = [
     'xyz_to_xyy',
     'xyy_to_xyz',
     'y_to_lstar',
+    'lstar_to_y',
     'xyz_to_uv',
     'xyz_to_luv',
     'lms_to_xyz',

--- a/python/isetcam/lstar_to_y.py
+++ b/python/isetcam/lstar_to_y.py
@@ -1,0 +1,55 @@
+"""Convert CIE L* (CIELAB/CIELUV) to luminance Y."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+
+# Threshold for switching formula based on L* value
+_LSTAR_THRESHOLD = 7.9996
+
+
+def lstar_to_y(L: np.ndarray, Yn: float) -> np.ndarray:
+    """Convert L* values to luminance ``Y``.
+
+    Parameters
+    ----------
+    L : np.ndarray
+        L* values in either ``(n,)`` XW format or ``(rows, cols)`` RGB
+        format.
+    Yn : float
+        Luminance of the reference white point.
+
+    Returns
+    -------
+    np.ndarray
+        Luminance values in the same shape as ``L``.
+    """
+    L = np.asarray(L, dtype=float)
+    Yn = float(Yn)
+
+    if L.ndim == 2:
+        xw, r, c = rgb_to_xw_format(L)
+        reshape = True
+    elif L.ndim == 1:
+        xw = L.reshape(-1, 1)
+        reshape = False
+    else:
+        raise ValueError("L must be 1D or 2D array")
+
+    vals = xw[:, 0]
+    Y = np.empty_like(vals)
+
+    mask = vals > _LSTAR_THRESHOLD
+    Y[mask] = Yn * ((vals[mask] + 16) / 116) ** 3
+    Y[~mask] = Yn * vals[~mask] / 903.3
+
+    if reshape:
+        Y = xw_to_rgb_format(Y[:, np.newaxis], r, c).reshape(r, c)
+    else:
+        Y = Y.reshape(L.shape)
+
+    return Y

--- a/python/tests/test_lstar_to_y.py
+++ b/python/tests/test_lstar_to_y.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from isetcam import y_to_lstar, lstar_to_y
+
+WHITE_Y = 100.0
+
+
+def test_round_trip_xw():
+    y = np.random.rand(10) * WHITE_Y
+    L = y_to_lstar(y, WHITE_Y)
+    y2 = lstar_to_y(L, WHITE_Y)
+    assert np.allclose(y2, y, atol=1e-6)
+
+
+def test_round_trip_rgb():
+    y = np.random.rand(4, 5) * WHITE_Y
+    L = y_to_lstar(y, WHITE_Y)
+    y2 = lstar_to_y(L, WHITE_Y)
+    assert np.allclose(y2, y, atol=1e-6)


### PR DESCRIPTION
## Summary
- implement `lstar_to_y` for converting L* to luminance
- export `lstar_to_y` in package
- test round-trip conversions between luminance and L*

## Testing
- `pytest -q python/tests/test_lstar_to_y.py`

------
https://chatgpt.com/codex/tasks/task_e_683ccfbbe2888323a566d9b014435e82