### PR TITLE
Add scene checkerboard generator

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -27,6 +27,7 @@ from .scene_interpolate_w import scene_interpolate_w
 from .scene_to_file import scene_to_file
 from .scene_extract_waveband import scene_extract_waveband
 from .scene_add_grid import scene_add_grid
+from .scene_checkerboard import scene_checkerboard
 from .scene_combine import scene_combine
 from .scene_adjust_pixel_size import scene_adjust_pixel_size
 from .scene_show_image import scene_show_image
@@ -85,6 +86,7 @@ __all__ = [
     "scene_to_file",
     "scene_extract_waveband",
     "scene_add_grid",
+    "scene_checkerboard",
     "scene_combine",
     "scene_adjust_pixel_size",
     "scene_show_image",

--- a/python/isetcam/scene/scene_checkerboard.py
+++ b/python/isetcam/scene/scene_checkerboard.py
@@ -1,0 +1,64 @@
+"""Create a checkerboard test scene."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+from ..illuminant import illuminant_create
+
+_DEF_WAVE = np.arange(400, 701, 10, dtype=float)
+
+
+def _illuminant_photons(wave: np.ndarray, spectral_type: str) -> np.ndarray:
+    stype = spectral_type.lower().replace(" ", "")
+    if stype == "d65":
+        ill = illuminant_create("D65", wave)
+        return ill.spd.astype(float)
+    if stype in {"ee", "equalenergy"}:
+        return np.ones_like(wave, dtype=float)
+    if stype in {"ep", "equalphoton", "equalphotons"}:
+        return np.ones_like(wave, dtype=float)
+    raise ValueError(f"Unknown spectral_type '{spectral_type}'")
+
+
+def scene_checkerboard(
+    pixels_per_check: int,
+    n_checks: int,
+    spectral_type: str = "d65",
+) -> Scene:
+    """Return a checkerboard pattern scene.
+
+    Parameters
+    ----------
+    pixels_per_check : int
+        Size of each square in pixels.
+    n_checks : int
+        Number of black/white check pairs along each axis.
+    spectral_type : {'d65', 'ee', 'equalenergy', 'ep', 'equalphotons'}, optional
+        Type of illuminant used for the checkerboard. Defaults to ``'d65'``.
+
+    Returns
+    -------
+    Scene
+        Checkerboard scene with photon data scaled by the chosen illuminant.
+    """
+
+    pp = int(pixels_per_check)
+    nc = int(n_checks)
+    if pp <= 0 or nc <= 0:
+        raise ValueError("pixels_per_check and n_checks must be > 0")
+
+    base = np.kron([[0, 1], [1, 0]], np.ones((pp, pp), dtype=float))
+    pattern = np.tile(base, (nc, nc))
+    pattern = pattern / pattern.max()
+    pattern = np.clip(pattern, 1e-6, 1.0)
+
+    wave = _DEF_WAVE
+    ill_photons = _illuminant_photons(wave, spectral_type)
+    img = pattern[:, :, None] * ill_photons[None, None, :]
+    name = f"Checker-{spectral_type}"
+    return Scene(photons=img, wave=wave, name=name)
+
+
+__all__ = ["scene_checkerboard"]

--- a/python/tests/test_scene_checkerboard.py
+++ b/python/tests/test_scene_checkerboard.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from isetcam.scene import scene_checkerboard
+from isetcam.illuminant import illuminant_create
+
+
+def test_scene_checkerboard_size():
+    sc = scene_checkerboard(4, 3)
+    assert sc.photons.shape[0] == 24
+    assert sc.photons.shape[1] == 24
+    assert sc.photons.shape[2] == sc.wave.size
+
+
+def test_scene_checkerboard_spectra():
+    sc = scene_checkerboard(1, 1, spectral_type="d65")
+    wave = sc.wave
+    ill = illuminant_create("D65", wave)
+    white = sc.photons[0, 1, :]
+    black = sc.photons[0, 0, :]
+    assert np.allclose(white, ill.spd)
+    assert np.allclose(black, ill.spd * 1e-6)


### PR DESCRIPTION
## Summary
- implement `scene_checkerboard` to create checkerboard scenes
- expose `scene_checkerboard` in the `scene` module
- test checkerboard scene creation

## Testing
- `PYTHONPATH=python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cdd316c6c8323a52e8cbf16d014f9