### PR TITLE
Add Dead Leaves scene generator

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -43,6 +43,7 @@ from .scene_depth_overlay import scene_depth_overlay
 from .scene_depth_range import scene_depth_range
 from .scene_list import scene_list
 from .scene_make_video import scene_make_video
+from .scene_dead_leaves import scene_dead_leaves
 from .scene_wb_create import scene_wb_create
 from .scene_plot import scene_plot
 from .scene_description import scene_description
@@ -97,6 +98,7 @@ __all__ = [
     "scene_depth_overlay",
     "scene_depth_range",
     "scene_list",
+    "scene_dead_leaves",
     "scene_wb_create",
     "scene_description",
     "scene_clear_data",

--- a/python/isetcam/scene/imgtargets/__init__.py
+++ b/python/isetcam/scene/imgtargets/__init__.py
@@ -1,0 +1,3 @@
+from .img_dead_leaves import img_dead_leaves
+
+__all__ = ["img_dead_leaves"]

--- a/python/isetcam/scene/imgtargets/img_dead_leaves.py
+++ b/python/isetcam/scene/imgtargets/img_dead_leaves.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+
+def img_dead_leaves(patch_size: int = 256, noise_level: float = 0.0, seed: int | None = None) -> np.ndarray:
+    """Return a grayscale dead-leaves test pattern.
+
+    Parameters
+    ----------
+    patch_size: int
+        Size in pixels of the square image.
+    noise_level: float
+        Standard deviation of optional additive Gaussian noise.
+    seed: int, optional
+        Seed for the random number generator for reproducibility.
+    """
+    rng = np.random.default_rng(seed)
+    n = int(patch_size)
+
+    sigma = 3.0
+    rmin = 0.01
+    rmax = 1.0
+    nbr_iter = 5000
+
+    img = np.full((n, n), np.inf, dtype=float)
+
+    x = np.linspace(0.0, 1.0, n)
+    Y, X = np.meshgrid(x, x)
+
+    # radius distribution
+    k = 200
+    r_list = np.linspace(rmin, rmax, k)
+    r_dist = 1.0 / (r_list ** sigma)
+    if sigma > 0:
+        r_dist = r_dist - 1.0 / (rmax ** sigma)
+    r_dist = np.cumsum(r_dist)
+    r_dist = (r_dist - r_dist.min()) / (r_dist.max() - r_dist.min())
+
+    remaining = n * n
+    for _ in range(nbr_iter):
+        r = rng.random()
+        idx = np.argmin(np.abs(r - r_dist))
+        radius = r_list[idx]
+
+        x0 = rng.random()
+        y0 = rng.random()
+        albedo = rng.random()
+
+        mask = np.isinf(img) & ((X - x0) ** 2 + (Y - y0) ** 2 < radius ** 2)
+        count = int(mask.sum())
+        if count > 0:
+            img[mask] = albedo
+            remaining -= count
+            if remaining <= 0:
+                break
+
+    img[np.isinf(img)] = 0.0
+
+    if noise_level > 0:
+        img += rng.normal(scale=float(noise_level), size=img.shape)
+        img = np.clip(img, 0.0, 1.0)
+
+    return img
+
+
+__all__ = ["img_dead_leaves"]

--- a/python/isetcam/scene/scene_dead_leaves.py
+++ b/python/isetcam/scene/scene_dead_leaves.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from .scene_class import Scene
+from .imgtargets.img_dead_leaves import img_dead_leaves
+
+
+def scene_dead_leaves(patch_size: int = 256, noise_level: float = 0.0, seed: int | None = None) -> Scene:
+    """Return a Scene containing a dead-leaves chart.
+
+    Parameters
+    ----------
+    patch_size: int
+        Size in pixels of the square image.
+    noise_level: float
+        Standard deviation of optional additive Gaussian noise.
+    seed: int, optional
+        Seed for the random number generator.
+    """
+    img = img_dead_leaves(patch_size=patch_size, noise_level=noise_level, seed=seed)
+    wave = np.array([550.0], dtype=float)
+    photons = img[:, :, None]
+    sc = Scene(photons=photons, wave=wave, name="Dead leaves")
+    sc.fov = 10.0
+    return sc
+
+
+__all__ = ["scene_dead_leaves"]

--- a/python/tests/test_scene_dead_leaves.py
+++ b/python/tests/test_scene_dead_leaves.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+from isetcam.scene import scene_dead_leaves
+from isetcam.luminance_from_photons import luminance_from_photons
+
+
+def test_scene_dead_leaves_shape_and_luminance():
+    sc = scene_dead_leaves(patch_size=32, noise_level=0.0, seed=0)
+    assert sc.photons.shape == (32, 32, 1)
+    lum = luminance_from_photons(sc.photons, sc.wave)
+    mean_val = lum.mean()
+    # Deterministic mean value for this seed
+    assert np.isclose(mean_val, 1.0610504399e-15, rtol=1e-6)


### PR DESCRIPTION
## Summary
- implement `img_dead_leaves` for grayscale dead-leaves pattern
- add `scene_dead_leaves` to wrap the image in a `Scene`
- expose via `scene/__init__.py`
- include tests for luminance and shape

## Testing
- `PYTHONPATH=python pytest python/tests/test_scene_dead_leaves.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683cdd8284688323ace31e438c902f40