### PR TITLE
Add gamma and tone utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -85,6 +85,8 @@ from .adobergb_parameters import adobergb_parameters
 from .ctemp_to_srgb import ctemp_to_srgb
 from .init_default_spectrum import init_default_spectrum
 from .mk_inv_gamma_table import mk_inv_gamma_table
+from .ie_gamma import ie_gamma
+from .ie_tone import ie_tone_curve, ie_apply_tone
 from .ie_cov_ellipsoid import ie_cov_ellipsoid
 from .ie_read_spectra import ie_read_spectra
 from .ie_hist_image import ie_hist_image
@@ -229,6 +231,9 @@ __all__ = [
     'ctemp_to_srgb',
     'init_default_spectrum',
     'mk_inv_gamma_table',
+    'ie_gamma',
+    'ie_tone_curve',
+    'ie_apply_tone',
     'ie_cov_ellipsoid',
     'ie_read_spectra',
     'ie_hist_image',

--- a/python/isetcam/ie_gamma.py
+++ b/python/isetcam/ie_gamma.py
@@ -1,0 +1,80 @@
+"""Apply or remove gamma correction curves."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+
+def ie_gamma(img: np.ndarray, gamma: float | np.ndarray, inverse: bool = False) -> np.ndarray:
+    """Apply or remove gamma correction.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Image data. Can be ``(M, N)`` XW format or ``(R, C, 3)`` RGB.
+    gamma : float or array-like
+        Scalar gamma exponent or lookup table mapping digital code values
+        to linear intensity. When an array is supplied it may be ``(G,)``
+        or ``(G, C)`` where ``G`` is the number of table entries and
+        ``C`` is either ``1`` or matches the number of image channels.
+    inverse : bool, optional
+        When ``True`` remove gamma correction using the provided exponent
+        or lookup table.
+
+    Returns
+    -------
+    np.ndarray
+        Array with gamma correction applied in the same shape as ``img``.
+    """
+    arr = np.asarray(img, dtype=float)
+
+    if arr.ndim == 3:
+        xw, rows, cols = rgb_to_xw_format(arr)
+        reshape = True
+    elif arr.ndim == 2:
+        xw = arr
+        reshape = False
+    else:
+        raise ValueError("img must be a 2-D or 3-D array")
+
+    if np.isscalar(gamma):
+        g = float(gamma)
+        if inverse:
+            out = xw ** g
+        else:
+            out = np.clip(xw, 0.0, None) ** (1 / g)
+    else:
+        tbl = np.asarray(gamma, dtype=float)
+        if tbl.ndim == 1:
+            tbl = tbl[:, np.newaxis]
+        n_levels, g_channels = tbl.shape
+        n_channels = xw.shape[1]
+        if g_channels == 1 and n_channels > 1:
+            tbl = np.tile(tbl, (1, n_channels))
+        elif g_channels != n_channels:
+            raise ValueError("Gamma table channel mismatch with image")
+
+        out = np.empty_like(xw)
+        if inverse:
+            inv_levels = np.linspace(0, 1, n_levels)
+            for i in range(n_channels):
+                out[:, i] = np.interp(xw[:, i], tbl[:, i], inv_levels)
+        else:
+            if xw.max() <= 1:
+                idx = np.round(xw * (n_levels - 1)).astype(int)
+            else:
+                idx = np.round(xw).astype(int)
+            idx = np.clip(idx, 0, n_levels - 1)
+            for i in range(n_channels):
+                out[:, i] = tbl[idx[:, i], i]
+
+    if reshape:
+        out = xw_to_rgb_format(out, rows, cols)
+
+    return out
+
+
+__all__ = ["ie_gamma"]

--- a/python/isetcam/ie_tone.py
+++ b/python/isetcam/ie_tone.py
@@ -1,0 +1,96 @@
+"""Tone curve utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .rgb_to_xw_format import rgb_to_xw_format
+from .xw_to_rgb_format import xw_to_rgb_format
+
+
+def ie_tone_curve(
+    num_points: int = 256,
+    *,
+    contrast: float = 4.0,
+    midpoint: float = 0.5,
+    toe: float = 0.0,
+    shoulder: float = 1.0,
+) -> np.ndarray:
+    """Generate an S-shaped tone curve using a logistic function.
+
+    Parameters
+    ----------
+    num_points : int, optional
+        Number of samples in the curve, by default ``256``.
+    contrast : float, optional
+        Slope of the curve at ``midpoint``.
+    midpoint : float, optional
+        Location of the inflection point in ``[0, 1]``.
+    toe : float, optional
+        Minimum output value of the curve.
+    shoulder : float, optional
+        Maximum output value of the curve.
+
+    Returns
+    -------
+    np.ndarray
+        Tone curve sampled at ``num_points`` positions.
+    """
+    x = np.linspace(0, 1, num_points)
+    y = 1 / (1 + np.exp(-contrast * (x - midpoint)))
+    y = (y - y.min()) / (y.max() - y.min())
+    y = y * (shoulder - toe) + toe
+    return y
+
+
+def ie_apply_tone(img: np.ndarray, curve: np.ndarray) -> np.ndarray:
+    """Apply a tone curve to ``img``.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Image data in either ``(M, N)`` or ``(R, C, 3)`` format. Values are
+        expected to be in the range ``[0, 1]``.
+    curve : np.ndarray
+        Lookup table mapping input values to output values. Can be ``(L,)`` or
+        ``(L, C)`` where ``L`` is the number of levels and ``C`` is ``1`` or
+        matches the number of image channels.
+
+    Returns
+    -------
+    np.ndarray
+        Image after tone mapping in the same shape as ``img``.
+    """
+    img = np.asarray(img, dtype=float)
+
+    if img.ndim == 3:
+        xw, rows, cols = rgb_to_xw_format(img)
+        reshape = True
+    elif img.ndim == 2:
+        xw = img
+        reshape = False
+    else:
+        raise ValueError("img must be a 2-D or 3-D array")
+
+    tbl = np.asarray(curve, dtype=float)
+    if tbl.ndim == 1:
+        tbl = tbl[:, np.newaxis]
+    n_levels, t_channels = tbl.shape
+    n_channels = xw.shape[1]
+
+    if t_channels == 1 and n_channels > 1:
+        tbl = np.tile(tbl, (1, n_channels))
+    elif t_channels != n_channels:
+        raise ValueError("Tone curve channel mismatch with image")
+
+    idx = np.clip(np.round(xw * (n_levels - 1)).astype(int), 0, n_levels - 1)
+    out = np.empty_like(xw)
+    for i in range(n_channels):
+        out[:, i] = tbl[idx[:, i], i]
+
+    if reshape:
+        out = xw_to_rgb_format(out, rows, cols)
+    return out
+
+
+__all__ = ["ie_tone_curve", "ie_apply_tone"]

--- a/python/tests/test_ie_gamma.py
+++ b/python/tests/test_ie_gamma.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from isetcam import ie_gamma
+
+
+def test_ie_gamma_scalar_round_trip():
+    img = np.random.rand(5, 5, 3)
+    out = ie_gamma(img, 2.2)
+    back = ie_gamma(out, 2.2, inverse=True)
+    assert np.allclose(img, back, atol=1e-7)
+
+
+def test_ie_gamma_table_round_trip():
+    tbl = np.linspace(0, 1, 512) ** (1 / 2.2)
+    img = np.random.rand(10, 3)
+    out = ie_gamma(img, tbl)
+    back = ie_gamma(out, tbl, inverse=True)
+    assert np.allclose(img, back, atol=5e-3)
+
+
+def test_ie_gamma_table_channel_mismatch():
+    tbl = np.random.rand(10, 3)
+    img = np.random.rand(4, 2)
+    with pytest.raises(ValueError):
+        ie_gamma(img, tbl)
+
+

--- a/python/tests/test_ie_tone.py
+++ b/python/tests/test_ie_tone.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from isetcam import ie_tone_curve, ie_apply_tone
+
+
+def test_ie_tone_curve_properties():
+    curve = ie_tone_curve(num_points=64)
+    assert curve[0] >= 0 and curve[-1] <= 1
+    assert np.all(np.diff(curve) >= 0)
+
+
+def test_ie_apply_tone_identity():
+    curve = np.linspace(0, 1, 32)
+    img = np.random.rand(4, 4, 3)
+    out = ie_apply_tone(img, curve)
+    assert np.allclose(out, img, atol=0.05)
+
+
+def test_ie_apply_tone_channels():
+    curve = np.stack([np.linspace(0, 1, 16), np.linspace(0, 1, 16)**2], axis=1)
+    img = np.random.rand(8, 2)
+    out = ie_apply_tone(img, curve)
+    assert out.shape == img.shape
+
+


### PR DESCRIPTION
## Summary
- add `ie_gamma` helper to apply or remove gamma correction
- add `ie_tone_curve` and `ie_apply_tone` for tone curve creation and application
- export new helpers in `isetcam.__init__`
- add tests for gamma and tone utilities

## Testing
- `PYTHONPATH=python pytest python/tests/test_ie_gamma.py python/tests/test_ie_tone.py -q`
- `PYTHONPATH=python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cdda16d608323b416497c458a6ba0