### PR TITLE
Add camera_vsnr_sl function and tests

### DIFF
--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -11,6 +11,7 @@ from .camera_mtf import camera_mtf
 from .camera_plot import camera_plot
 from .camera_moire import camera_moire
 from .camera_vsnr import camera_vsnr
+from .camera_vsnr_sl import camera_vsnr_sl, VSNRSLResult
 from .camera_acutance import camera_acutance
 from .camera_color_accuracy import camera_color_accuracy
 from .camera_compute_sequence import camera_compute_sequence
@@ -29,6 +30,8 @@ __all__ = [
     "camera_plot",
     "camera_moire",
     "camera_vsnr",
+    "camera_vsnr_sl",
+    "VSNRSLResult",
     "camera_acutance",
     "camera_color_accuracy",
     "camera_compute_sequence",

--- a/python/isetcam/camera/camera_vsnr_sl.py
+++ b/python/isetcam/camera/camera_vsnr_sl.py
@@ -1,0 +1,61 @@
+"""Compute VSNR across luminance levels using a camera model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from .camera_class import Camera
+from .camera_compute import camera_compute
+from ..scene import Scene, scene_adjust_luminance
+from ..quanta2energy import quanta_to_energy
+from ..ie_xyz_from_energy import ie_xyz_from_energy
+from ..metrics import xyz_to_vsnr
+
+
+_DEFAULT_LEVELS = np.array([3, 6, 12, 25, 50, 100, 200, 400], dtype=float)
+
+
+@dataclass
+class VSNRSLResult:
+    """Container for VSNR sweep results."""
+
+    vsnr: np.ndarray
+    mean_luminances: np.ndarray
+
+
+_DEF_SCENE_WAVE = np.array([500.0, 510.0, 520.0], dtype=float)
+_DEF_SCENE_PHOTONS = np.ones((4, 4, _DEF_SCENE_WAVE.size), dtype=float)
+
+
+def _base_scene() -> Scene:
+    """Return a small uniform scene used for testing."""
+    return Scene(photons=_DEF_SCENE_PHOTONS.copy(), wave=_DEF_SCENE_WAVE.copy())
+
+
+def camera_vsnr_sl(
+    camera: Camera, mean_luminances: Sequence[float] | None = None
+) -> VSNRSLResult:
+    """Return VSNR values over several luminance levels."""
+
+    if mean_luminances is None:
+        levels = _DEFAULT_LEVELS
+    else:
+        levels = np.asarray(mean_luminances, dtype=float).reshape(-1)
+
+    vsnr_vals = np.zeros(levels.size, dtype=float)
+
+    for i, lum in enumerate(levels):
+        scene = _base_scene()
+        scene = scene_adjust_luminance(scene, "mean", float(lum))
+        camera_compute(camera, scene)
+        energy = quanta_to_energy(scene.wave, scene.photons)
+        xyz = ie_xyz_from_energy(energy, scene.wave)
+        vsnr_vals[i] = float(xyz_to_vsnr(xyz, np.array([1.0, 1.0, 1.0])))
+
+    return VSNRSLResult(vsnr=vsnr_vals, mean_luminances=levels)
+
+
+__all__ = ["camera_vsnr_sl", "VSNRSLResult"]

--- a/python/tests/test_camera_vsnr_sl.py
+++ b/python/tests/test_camera_vsnr_sl.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from isetcam.camera import camera_create, camera_vsnr_sl
+from isetcam.camera.camera_vsnr_sl import VSNRSLResult, _base_scene
+from isetcam.scene import Scene, scene_adjust_luminance
+from isetcam.quanta2energy import quanta_to_energy
+from isetcam.ie_xyz_from_energy import ie_xyz_from_energy
+from isetcam.metrics import xyz_to_vsnr
+
+
+def _simple_scene(w=4, h=4, n_wave=3) -> Scene:
+    wave = np.arange(500, 500 + 10 * n_wave, 10)
+    photons = np.arange(w * h * n_wave, dtype=float).reshape((h, w, n_wave))
+    return Scene(photons=photons, wave=wave)
+
+
+def test_camera_vsnr_sl_matches_manual():
+    cam = camera_create()
+    levels = np.array([1.0, 10.0, 20.0])
+    res = camera_vsnr_sl(cam, levels)
+    assert isinstance(res, VSNRSLResult)
+    assert np.allclose(res.mean_luminances, levels)
+
+    expected = []
+    for lum in levels:
+        sc = _base_scene()
+        sc = scene_adjust_luminance(sc, "mean", float(lum))
+        energy = quanta_to_energy(sc.wave, sc.photons)
+        xyz = ie_xyz_from_energy(energy, sc.wave)
+        expected.append(xyz_to_vsnr(xyz, np.array([1.0, 1.0, 1.0])))
+    assert np.allclose(res.vsnr, expected)


### PR DESCRIPTION
## Summary
- implement `camera_vsnr_sl` with luminance sweep
- export `camera_vsnr_sl` and supporting dataclass
- provide unit test covering the new function

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_camera_vsnr_sl.py`

------
https://chatgpt.com/codex/tasks/task_e_683cf5fe259083238542c6582aee81de