### PR TITLE
Add camera_computesrgb utility

### DIFF
--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -16,6 +16,7 @@ from .camera_color_accuracy import camera_color_accuracy
 from .camera_compute_sequence import camera_compute_sequence
 from .camera_clear_data import camera_clear_data
 from .camera_full_reference import camera_full_reference
+from .camera_computesrgb import camera_computesrgb
 
 __all__ = [
     "Camera",
@@ -34,4 +35,5 @@ __all__ = [
     "camera_compute_sequence",
     "camera_clear_data",
     "camera_full_reference",
+    "camera_computesrgb",
 ]

--- a/python/isetcam/camera/camera_computesrgb.py
+++ b/python/isetcam/camera/camera_computesrgb.py
@@ -1,0 +1,99 @@
+"""Compute simple sRGB rendering for a camera scene pair."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+try:  # pragma: no cover - matplotlib might not be installed
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+from .camera_class import Camera
+from .camera_compute import camera_compute
+from ..scene import Scene, scene_create, scene_adjust_luminance
+from ..quanta2energy import quanta_to_energy
+from ..ie_xyz_from_energy import ie_xyz_from_energy
+from ..srgb_xyz import xyz_to_srgb
+from ..ie_format_figure import ie_format_figure
+
+
+_DEF_SCENE = "macbeth d65"
+_DEF_LUM = 100.0
+_DEF_FOV = 10.0
+_DEF_PATCH = 16
+
+
+def camera_computesrgb(
+    camera: Camera,
+    scene: Scene | str | None = None,
+    *,
+    mean_luminance: float = _DEF_LUM,
+    fov: float = _DEF_FOV,
+    patch_size: int = _DEF_PATCH,
+    plot: bool = False,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return an sRGB rendering of ``scene`` captured by ``camera``.
+
+    Parameters
+    ----------
+    camera : Camera
+        Camera instance to use for rendering.
+    scene : Scene or str or None, optional
+        Scene to render. When a string or ``None`` a new scene is created
+        using :func:`scene_create`.  ``None`` defaults to ``"macbeth d65"``.
+    mean_luminance : float, optional
+        Target mean luminance for the scene. Default is ``100``.
+    fov : float, optional
+        Field of view assigned to the scene in degrees. Default is ``10``.
+    patch_size : int, optional
+        Patch size passed to :func:`scene_create` when ``scene`` is a string
+        or ``None``. Default is ``16``.
+    plot : bool, optional
+        Display the resulting sRGB image using Matplotlib.
+
+    Returns
+    -------
+    srgb_result : np.ndarray
+        Approximate sRGB image produced by the camera.
+    srgb_ideal : np.ndarray
+        Ideal sRGB rendering derived directly from the scene photons.
+    raw_volts : np.ndarray
+        Sensor voltage image after calling :func:`camera_compute`.
+    """
+
+    if scene is None or isinstance(scene, str):
+        name = _DEF_SCENE if scene is None else scene
+        sc = scene_create(name, patch_size=patch_size)
+    else:
+        sc = scene
+
+    sc = scene_adjust_luminance(sc, "mean", float(mean_luminance))
+    sc.fov = float(fov)
+
+    camera_compute(camera, sc)
+    volts = camera.sensor.volts.astype(float)
+
+    # Ideal sRGB rendering from the scene
+    energy = quanta_to_energy(sc.wave, sc.photons)
+    xyz = ie_xyz_from_energy(energy, sc.wave)
+    srgb_ideal, _, _ = xyz_to_srgb(xyz)
+
+    # Camera result scaled to [0, 1] and replicated across channels
+    scaled = volts / volts.max() if volts.max() > 0 else volts
+    srgb_result = np.repeat(scaled[:, :, None], 3, axis=2)
+
+    if plot:
+        if plt is None:
+            raise ImportError("matplotlib is required for plotting")
+        fig, ax = plt.subplots()
+        ax.imshow(np.clip(srgb_result, 0.0, 1.0))
+        ax.axis("off")
+        ie_format_figure(ax)
+
+    return srgb_result, srgb_ideal, volts.copy()
+
+
+__all__ = ["camera_computesrgb"]

--- a/python/tests/test_camera_computesrgb.py
+++ b/python/tests/test_camera_computesrgb.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from isetcam.camera import camera_create, camera_computesrgb
+
+
+def test_camera_computesrgb_basic():
+    cam = camera_create()
+    srgb_res, srgb_ideal, volts = camera_computesrgb(
+        cam,
+        scene="macbeth d65",
+        patch_size=4,
+        mean_luminance=20,
+        fov=15,
+    )
+    assert srgb_res.shape == srgb_ideal.shape
+    assert srgb_res.shape[2] == 3
+    assert volts.shape == cam.sensor.volts.shape
+    assert np.all((srgb_res >= 0) & (srgb_res <= 1))
+    assert np.all((srgb_ideal >= 0) & (srgb_ideal <= 1))
+    assert np.all(np.isfinite(volts))


### PR DESCRIPTION
## Summary
- add `camera_computesrgb` to compute a simple sRGB rendering
- export new utility from the `camera` package
- test camera_computesrgb behaviour

## Testing
- `PYTHONPATH=python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683cf606e4a08323867fa0380baffe4e