### PR TITLE
Implement oi_camera_motion

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -14,6 +14,7 @@ from .oi_crop import oi_crop
 from .oi_pad import oi_pad
 from .oi_translate import oi_translate
 from .oi_rotate import oi_rotate
+from .oi_camera_motion import oi_camera_motion
 from .oi_spatial_support import oi_spatial_support
 from .oi_spatial_resample import oi_spatial_resample
 from .oi_frequency_support import oi_frequency_support
@@ -47,6 +48,7 @@ __all__ = [
     "oi_pad",
     "oi_translate",
     "oi_rotate",
+    "oi_camera_motion",
     "oi_spatial_support",
     "oi_spatial_resample",
     "oi_frequency_support",

--- a/python/isetcam/opticalimage/oi_camera_motion.py
+++ b/python/isetcam/opticalimage/oi_camera_motion.py
@@ -1,0 +1,74 @@
+"""Apply camera motion blur to an :class:`OpticalImage`."""
+
+from __future__ import annotations
+
+from typing import Sequence, Mapping
+
+import numpy as np
+
+from .oi_class import OpticalImage
+from .oi_translate import oi_translate
+
+
+def oi_camera_motion(
+    oi: OpticalImage,
+    options: Mapping[str, object] | None = None,
+) -> OpticalImage:
+    """Blur ``oi`` using a motion path.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image to blur.
+    options : mapping, optional
+        Options controlling the motion blur. Recognized keys are:
+
+        ``path`` : sequence of ``(dx, dy)``
+            Pixel offsets describing the camera motion.  Positive ``dx`` moves
+            the image to the right, positive ``dy`` moves it down.
+        ``weights`` : sequence of float, optional
+            Relative weight for each motion step.  Defaults to equal weights.
+        ``fill`` : float, optional
+            Value used to fill regions exposed by shifting.  Defaults to 0.
+
+    Returns
+    -------
+    OpticalImage
+        New optical image containing the blurred photon data.
+    """
+
+    if options is None:
+        options = {}
+
+    path = options.get("path")
+    if path is None:
+        raise ValueError("options must include a 'path' entry")
+
+    path = np.asarray(list(path), dtype=float)
+    if path.ndim != 2 or path.shape[1] != 2:
+        raise ValueError("path must be an Nx2 sequence")
+
+    weights = options.get("weights")
+    if weights is None:
+        weights = np.ones(path.shape[0], dtype=float)
+    else:
+        weights = np.asarray(weights, dtype=float)
+        if weights.size != path.shape[0]:
+            raise ValueError("weights length must match path length")
+
+    fill = float(options.get("fill", 0))
+
+    accum = np.zeros_like(oi.photons, dtype=float)
+
+    for (dx, dy), w in zip(path, weights):
+        shifted = oi_translate(oi, int(round(dx)), int(round(dy)), fill=fill)
+        accum += w * shifted.photons
+
+    total = float(np.sum(weights))
+    if total > 0:
+        accum /= total
+
+    return OpticalImage(photons=accum, wave=oi.wave, name=oi.name)
+
+
+__all__ = ["oi_camera_motion"]

--- a/python/tests/test_oi_camera_motion.py
+++ b/python/tests/test_oi_camera_motion.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from isetcam.opticalimage import OpticalImage, oi_camera_motion
+
+
+def _simple_oi(width: int = 3, height: int = 3, n_wave: int = 1) -> OpticalImage:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    return OpticalImage(photons=photons, wave=wave, name="simple")
+
+
+def test_camera_motion_average():
+    oi = _simple_oi(3, 3, 1)
+    path = [(0, 0), (1, 0)]
+    out = oi_camera_motion(oi, {"path": path, "fill": 0})
+
+    expected = np.zeros_like(oi.photons, dtype=float)
+    # shift (0,0)
+    expected += oi.photons
+    # shift (1,0)
+    shifted = np.zeros_like(oi.photons)
+    shifted[:, 1:, :] = oi.photons[:, :-1, :]
+    expected += shifted
+    expected /= 2.0
+
+    assert np.allclose(out.photons, expected)
+    assert np.array_equal(out.wave, oi.wave)
+    assert out.name == oi.name
+
+
+def test_camera_motion_weighted():
+    oi = _simple_oi(3, 3, 1)
+    path = [(0, 0), (0, 1)]
+    weights = [1, 2]
+    out = oi_camera_motion(oi, {"path": path, "weights": weights, "fill": 0})
+
+    shifted0 = oi.photons
+    shifted1 = np.zeros_like(oi.photons)
+    shifted1[1:, :, :] = oi.photons[:-1, :, :]
+    expected = (weights[0] * shifted0 + weights[1] * shifted1) / sum(weights)
+
+    assert np.allclose(out.photons, expected)
+


### PR DESCRIPTION
## Summary
- implement `oi_camera_motion` for applying motion blur via integer translations
- export `oi_camera_motion` in opticalimage package
- test camera motion blur behaviour

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_oi_camera_motion.py`

------
https://chatgpt.com/codex/tasks/task_e_683cf60954388323bed133d93b5dcb41