### PR TITLE
Add sensor waveband compute and vignetting helpers

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -34,6 +34,8 @@ from .sensor_dr import sensor_dr
 from .sensor_add_filter import sensor_add_filter
 from .sensor_delete_filter import sensor_delete_filter
 from .sensor_replace_filter import sensor_replace_filter
+from .sensor_wb_compute import sensor_wb_compute
+from .sensor_vignetting import sensor_vignetting
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -97,4 +99,6 @@ __all__ = [
     "sensor_add_filter",
     "sensor_delete_filter",
     "sensor_replace_filter",
+    "sensor_wb_compute",
+    "sensor_vignetting",
 ]

--- a/python/isetcam/sensor/sensor_vignetting.py
+++ b/python/isetcam/sensor/sensor_vignetting.py
@@ -1,0 +1,28 @@
+"""Compute pixel vignetting map for a sensor."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .sensor_class import Sensor
+
+
+def sensor_vignetting(
+    sensor: Sensor, pv_flag: int | str = 0, n_angles: int = 5
+) -> Sensor:
+    """Attach vignetting (etendue) information to ``sensor``.
+
+    This is a simplified version of the MATLAB ``sensorVignetting`` function.
+    When ``pv_flag`` is ``0`` or ``"skip"`` a unity etendue map matching the
+    voltage image size is stored on ``sensor`` as attribute ``etendue``.
+    Other ``pv_flag`` values are not implemented and will raise
+    ``NotImplementedError``.
+    """
+    if pv_flag in (0, "skip", None):
+        sensor.etendue = np.ones_like(sensor.volts, dtype=float)
+        return sensor
+
+    raise NotImplementedError("Microlens vignetting not implemented in Python")
+
+
+__all__ = ["sensor_vignetting"]

--- a/python/isetcam/sensor/sensor_wb_compute.py
+++ b/python/isetcam/sensor/sensor_wb_compute.py
@@ -1,0 +1,62 @@
+"""Compute sensor response one waveband at a time."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+import numpy as np
+
+from ..opticalimage import OpticalImage
+from .sensor_class import Sensor
+
+
+def sensor_wb_compute(sensor: Sensor, ois: Iterable[OpticalImage]) -> Sensor:
+    """Accumulate sensor response from ``ois``.
+
+    Each optical image in ``ois`` may contain one or more wavelength bands.
+    The response for each band is integrated and summed into ``sensor.volts``.
+
+    Parameters
+    ----------
+    sensor:
+        Destination sensor object. ``sensor.volts`` provides the output size
+        and is overwritten with the computed voltages.
+    ois:
+        Iterable of optical images ordered by wavelength.
+
+    Returns
+    -------
+    Sensor
+        The input ``sensor`` with its ``volts`` attribute updated with the
+        summed response.
+    """
+    wave = np.asarray(sensor.wave)
+    qe = getattr(sensor, "qe", np.ones_like(wave, dtype=float))
+    volts = np.zeros_like(sensor.volts, dtype=float)
+
+    oi_list: Sequence[OpticalImage] = list(ois)
+
+    for oi in oi_list:
+        photons = np.asarray(oi.photons)
+        oi_wave = np.asarray(oi.wave)
+        if photons.ndim == 2:
+            photons = photons[:, :, np.newaxis]
+        for band in range(photons.shape[2]):
+            w = oi_wave[band]
+            idx = int(np.argmin(np.abs(wave - w)))
+            volts += (
+                photons[:, :, band].astype(float)
+                * float(qe[idx])
+                * float(sensor.exposure_time)
+            )
+
+    sensor.volts = volts
+
+    if oi_list:
+        last = oi_list[-1]
+        if getattr(last, "name", None):
+            sensor.name = f"wb-{last.name}"
+    return sensor
+
+
+__all__ = ["sensor_wb_compute"]

--- a/python/tests/test_sensor_vignetting.py
+++ b/python/tests/test_sensor_vignetting.py
@@ -1,0 +1,12 @@
+import numpy as np
+from isetcam.sensor import Sensor, sensor_vignetting
+
+
+def test_sensor_vignetting_unity():
+    volts = np.zeros((3, 3), dtype=float)
+    s = Sensor(volts=volts.copy(), wave=np.array([550]), exposure_time=0.01)
+
+    sensor_vignetting(s)
+
+    assert hasattr(s, "etendue")
+    assert np.allclose(s.etendue, np.ones_like(volts))

--- a/python/tests/test_sensor_wb_compute.py
+++ b/python/tests/test_sensor_wb_compute.py
@@ -1,0 +1,30 @@
+import numpy as np
+from isetcam.sensor import Sensor, sensor_wb_compute
+from isetcam.opticalimage import OpticalImage
+
+
+def test_sensor_wb_compute_basic_sum():
+    wave = np.array([500, 510, 520])
+    s = Sensor(volts=np.zeros((2, 2)), wave=wave, exposure_time=0.5)
+    oi1 = OpticalImage(photons=np.ones((2, 2)), wave=np.array([500]), name="500")
+    oi2 = OpticalImage(photons=2 * np.ones((2, 2)), wave=np.array([510]), name="510")
+    oi3 = OpticalImage(photons=3 * np.ones((2, 2)), wave=np.array([520]), name="520")
+
+    sensor_wb_compute(s, [oi1, oi2, oi3])
+
+    expected = (1 + 2 + 3) * 0.5 * np.ones((2, 2))
+    assert np.allclose(s.volts, expected)
+    assert s.name == "wb-520"
+
+
+def test_sensor_wb_compute_with_qe():
+    wave = np.array([500, 510])
+    s = Sensor(volts=np.zeros((1, 1)), wave=wave, exposure_time=1.0)
+    s.qe = np.array([1.0, 2.0])
+    oi1 = OpticalImage(photons=np.ones((1, 1)), wave=np.array([500]))
+    oi2 = OpticalImage(photons=np.ones((1, 1)), wave=np.array([510]))
+
+    sensor_wb_compute(s, [oi1, oi2])
+
+    expected = 1.0 * 1.0 + 1.0 * 2.0
+    assert np.allclose(s.volts, expected)


### PR DESCRIPTION
## Summary
- add sensor_wb_compute and sensor_vignetting python implementations
- expose the new helpers in `sensor.__init__`
- test sensor white-balance accumulate and vignetting unity map

## Testing
- `flake8 python/isetcam/sensor/sensor_wb_compute.py python/isetcam/sensor/sensor_vignetting.py`
- `PYTHONPATH=python pytest -q python/tests/test_sensor_wb_compute.py python/tests/test_sensor_vignetting.py`

------
https://chatgpt.com/codex/tasks/task_e_683cf60b46f48323ac6d7fd8899d827d