### PR TITLE
Add concise reprs for core dataclasses

### DIFF
--- a/python/isetcam/opticalimage/oi_class.py
+++ b/python/isetcam/opticalimage/oi_class.py
@@ -20,3 +20,15 @@ class OpticalImage:
     def __post_init__(self) -> None:
         if self.wave is None:
             init_default_spectrum(self)
+
+    def __repr__(self) -> str:
+        """Return a concise representation for debugging."""
+        shape = tuple(self.photons.shape)
+        if self.wave is None or self.wave.size == 0:
+            wave_range = "None"
+        else:
+            wave_range = f"({float(self.wave[0])}, {float(self.wave[-1])})"
+        return (
+            f"{self.__class__.__name__}(name={self.name!r}, "
+            f"shape={shape}, wave_range={wave_range})"
+        )

--- a/python/isetcam/scene/scene_class.py
+++ b/python/isetcam/scene/scene_class.py
@@ -22,3 +22,15 @@ class Scene:
     def __post_init__(self) -> None:
         if self.wave is None:
             init_default_spectrum(self)
+
+    def __repr__(self) -> str:
+        """Return a concise representation for debugging."""
+        shape = tuple(self.photons.shape)
+        if self.wave is None or self.wave.size == 0:
+            wave_range = "None"
+        else:
+            wave_range = f"({float(self.wave[0])}, {float(self.wave[-1])})"
+        return (
+            f"{self.__class__.__name__}(name={self.name!r}, "
+            f"shape={shape}, wave_range={wave_range})"
+        )

--- a/python/isetcam/sensor/sensor_class.py
+++ b/python/isetcam/sensor/sensor_class.py
@@ -21,3 +21,15 @@ class Sensor:
     def __post_init__(self) -> None:
         if self.wave is None:
             init_default_spectrum(self)
+
+    def __repr__(self) -> str:
+        """Return a concise representation for debugging."""
+        shape = tuple(self.volts.shape)
+        if self.wave is None or self.wave.size == 0:
+            wave_range = "None"
+        else:
+            wave_range = f"({float(self.wave[0])}, {float(self.wave[-1])})"
+        return (
+            f"{self.__class__.__name__}(name={self.name!r}, "
+            f"shape={shape}, wave_range={wave_range})"
+        )

--- a/python/tests/test_oi_class.py
+++ b/python/tests/test_oi_class.py
@@ -1,0 +1,12 @@
+import numpy as np
+from isetcam.opticalimage import OpticalImage
+
+
+def test_oi_repr():
+    wave = np.array([400, 500, 600])
+    photons = np.zeros((2, 2, 3))
+    oi = OpticalImage(photons=photons, wave=wave, name="my oi")
+    r = repr(oi)
+    assert "my oi" in r
+    assert "(2, 2, 3)" in r
+    assert "400" in r and "600" in r

--- a/python/tests/test_scene_class.py
+++ b/python/tests/test_scene_class.py
@@ -1,0 +1,12 @@
+import numpy as np
+from isetcam.scene import Scene
+
+
+def test_scene_repr():
+    wave = np.array([400, 500, 600])
+    photons = np.zeros((2, 2, 3))
+    sc = Scene(photons=photons, wave=wave, name="my scene")
+    r = repr(sc)
+    assert "my scene" in r
+    assert "(2, 2, 3)" in r
+    assert "400" in r and "600" in r

--- a/python/tests/test_sensor_class.py
+++ b/python/tests/test_sensor_class.py
@@ -26,3 +26,13 @@ def test_sensor_accessors():
     new_exposure = 0.02
     set_exposure_time(s, new_exposure)
     assert get_exposure_time(s) == new_exposure
+
+
+def test_sensor_repr():
+    wave = np.array([500, 510, 520])
+    volts = np.ones((2, 2, 3))
+    s = Sensor(volts=volts, wave=wave, exposure_time=0.01, name="my sensor")
+    r = repr(s)
+    assert "my sensor" in r
+    assert "(2, 2, 3)" in r
+    assert "500" in r and "520" in r


### PR DESCRIPTION
## Summary
- implement `__repr__` in `Scene`, `OpticalImage`, and `Sensor`
- verify new representations in unit tests

## Testing
- `flake8 python/isetcam/scene/scene_class.py python/isetcam/opticalimage/oi_class.py python/isetcam/sensor/sensor_class.py`
- `PYTHONPATH=python pytest -q python/tests/test_scene_class.py python/tests/test_oi_class.py python/tests/test_sensor_class.py`


------
https://chatgpt.com/codex/tasks/task_e_683d25bbe1408323ac45807e947f5830