### PR TITLE
Add Sphinx docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Documentation
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: |
+            python/pyproject.toml
+            python/requirements.txt
+      - name: Install dependencies
+        run: |
+          pip install -r python/requirements.txt
+          pip install sphinx
+          pip install -e python
+      - name: Build documentation
+        run: |
+          cd docs
+          make html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,11 @@
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+.PHONY: html clean
+
+html:
+$(SPHINXBUILD) -b html $(SOURCEDIR) $(BUILDDIR)
+
+clean:
+rm -rf $(BUILDDIR) $(SOURCEDIR)/api

--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -99,6 +99,18 @@ Check `.github/workflows/python-tests.yml` for details.
 pytest -q
 ```
 
+## Building the Documentation
+
+HTML documentation is generated with Sphinx. After installing the
+package in editable mode you can build the docs locally:
+
+```bash
+cd docs
+make html
+```
+
+The generated pages will be placed under `docs/build/html`.
+
 
 ## Finding the Repository Root
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from datetime import datetime
+
+# Add the python package to sys.path
+sys.path.insert(0, os.path.abspath('../../python'))
+
+project = 'ISETCam'
+copyright = f'{datetime.now().year}, ISETCam'
+
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+html_theme = 'alabaster'
+html_static_path = ['_static']
+
+# Automatically generate API docs
+def run_apidoc(app):
+    from sphinx.ext.apidoc import main
+    src_dir = os.path.abspath('../../python/isetcam')
+    out_dir = os.path.abspath('api')
+    main(['-f', '-o', out_dir, src_dir])
+
+def setup(app):
+    app.connect('builder-inited', run_apidoc)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,9 @@
+ISETCam Documentation
+=====================
+
+Welcome to the experimental Python documentation.
+
+.. toctree::
+   :maxdepth: 2
+
+   api/modules


### PR DESCRIPTION
## Summary
- create Sphinx config under `docs/source`
- build API docs automatically during `sphinx-build`
- add docs workflow running on every push
- mention `make html` docs build in migration guide

## Testing
- `pytest -q` *(fails: 221 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_683d296e41d48323a504d31dec0e9eb4