### PR TITLE
Add coverage reporting

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,9 +26,13 @@ jobs:
             python/pyproject.toml
             python/requirements.txt
       - name: Install package
-        run: pip install -e python flake8 mypy
+        run: pip install -e "python[tests]" flake8 mypy pytest-cov
       - name: Run tests
-        run: pytest -q
+        run: pytest --cov=python/isetcam --cov-report=xml -q
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
       - name: Run flake8
         run: flake8 python/isetcam
       - name: Run mypy

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ISETCam
+[![Codecov](https://codecov.io/gh/iset/isetcam/branch/main/graph/badge.svg)](https://codecov.io/gh/iset/isetcam)
 
 Please see the [ISETCam wiki page](https://github.com/iset/isetcam/wiki) for more information.
 
@@ -25,7 +26,8 @@ pytest -q
 
 The same test suite runs automatically via GitHub Actions for every push
 and pull request, but you should also run `pytest -q` locally after
-making changes.
+making changes. Coverage results are uploaded to
+[Codecov](https://codecov.io/gh/iset/isetcam).
 
 # Notes
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=python/isetcam

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,7 @@ imageio = "*"
 scikit-image = "*"
 
 [project.optional-dependencies]
-tests = ["pytest"]
+tests = ["pytest", "coverage"]
 rawpy = ["rawpy"]
 OpenEXR = ["OpenEXR"]
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,3 +3,4 @@ scipy
 pillow
 imageio
 scikit-image
+coverage


### PR DESCRIPTION
## Summary
- track coverage via `coverage` package
- generate coverage stats when running `pytest`
- upload the report in GitHub Actions using Codecov
- show a coverage badge in the README

## Testing
- `pytest -q` *(fails: `ProxyError: Cannot connect to proxy`)*

------
https://chatgpt.com/codex/tasks/task_e_683d2efaaa908323ade0cf2bfe9ef939