### PR TITLE
Add isetcam CLI utilities

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -99,6 +99,20 @@ Check `.github/workflows/python-tests.yml` for details.
 pytest -q
 ```
 
+## Command Line Interface
+
+Installing the package in editable mode exposes an ``isetcam`` command
+with a few helper subcommands:
+
+```bash
+isetcam info          # show version and repository path
+isetcam list-scenes   # list bundled sample scenes
+isetcam run-tests     # execute the Python test suite
+```
+
+The ``run-tests`` command simply invokes ``pytest`` in the repository
+root.
+
 ## Building the Documentation
 
 HTML documentation is generated with Sphinx. After installing the

--- a/python/isetcam/cli.py
+++ b/python/isetcam/cli.py
@@ -1,0 +1,60 @@
+"""Command line interface for ISETCam utilities."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+import isetcam
+
+
+
+
+def _cmd_info(args: argparse.Namespace) -> int:
+    """Print package version and repository root."""
+    print(f"isetcam {isetcam.__version__}")
+    print(isetcam.iset_root_path())
+    return 0
+
+
+def _cmd_list_scenes(args: argparse.Namespace) -> int:
+    """List sample scene names."""
+    from isetcam.scene import scene_list
+
+    for name in scene_list():
+        print(name)
+    return 0
+
+
+def _cmd_run_tests(args: argparse.Namespace) -> int:
+    """Run the Python unit tests using pytest."""
+    root = isetcam.iset_root_path()
+    cmd = [sys.executable, "-m", "pytest", "-q"]
+    result = subprocess.run(cmd, cwd=root)
+    return result.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``isetcam`` command."""
+    parser = argparse.ArgumentParser(prog="isetcam")
+    subparsers = parser.add_subparsers(dest="command")
+
+    p_info = subparsers.add_parser("info", help="Show version information")
+    p_info.set_defaults(func=_cmd_info)
+
+    p_list = subparsers.add_parser("list-scenes", help="List available scenes")
+    p_list.set_defaults(func=_cmd_list_scenes)
+
+    p_tests = subparsers.add_parser("run-tests", help="Run the unit tests")
+    p_tests.set_defaults(func=_cmd_run_tests)
+
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return 0
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    sys.exit(main())

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,3 +25,6 @@ OpenEXR = ["OpenEXR"]
 
 [tool.setuptools.package-data]
 "isetcam" = ["data/**/*"]
+
+[project.scripts]
+isetcam = "isetcam.cli:main"

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,37 @@
+import subprocess
+import sys
+
+from isetcam.cli import main
+
+
+def test_cli_info(capsys):
+    rc = main(["info"])
+    out = capsys.readouterr().out
+    assert "isetcam" in out
+    assert rc == 0
+
+
+def test_cli_list_scenes(capsys):
+    rc = main(["list-scenes"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert isinstance(out, str)
+
+
+def test_cli_run_tests(monkeypatch):
+    called = {}
+
+    def fake_run(cmd, cwd=None):
+        called["cmd"] = cmd
+        called["cwd"] = cwd
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc = main(["run-tests"])
+    assert called["cmd"][0] == sys.executable
+    assert "pytest" in called["cmd"]
+    assert rc == 0


### PR DESCRIPTION
## Summary
- add `python/isetcam/cli.py` implementing a small command line interface
- expose the CLI through a `isetcam` console script in `pyproject.toml`
- test that the CLI subcommands work
- document the new command in the migration guide

## Testing
- `flake8 python/isetcam`
- `PYTEST_ADDOPTS='' pytest -q -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_683d34fba5cc832388cabed621971bcd