### PR TITLE
Add scene_from_basis functionality

### DIFF
--- a/python/isetcam/illuminant/__init__.py
+++ b/python/isetcam/illuminant/__init__.py
@@ -8,6 +8,7 @@ from .illuminant_to_file import illuminant_to_file
 from .illuminant_get import illuminant_get
 from .illuminant_set import illuminant_set
 from .illuminant_list import illuminant_list
+from .illuminant_modernize import illuminant_modernize
 
 __all__ = [
     "Illuminant",
@@ -18,4 +19,5 @@ __all__ = [
     "illuminant_get",
     "illuminant_set",
     "illuminant_list",
+    "illuminant_modernize",
 ]

--- a/python/isetcam/illuminant/illuminant_modernize.py
+++ b/python/isetcam/illuminant/illuminant_modernize.py
@@ -1,0 +1,55 @@
+"""Convert legacy illuminant structures to :class:`Illuminant`."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import numpy as np
+
+from .illuminant_class import Illuminant
+
+
+def illuminant_modernize(illuminant: Any) -> Illuminant:
+    """Return ``illuminant`` as an :class:`Illuminant` instance."""
+
+    if isinstance(illuminant, Illuminant):
+        return illuminant
+
+    if not isinstance(illuminant, Mapping):
+        raise TypeError("Illuminant must be mapping or Illuminant")
+
+    # Wavelength information
+    if "wave" in illuminant:
+        wave = np.asarray(illuminant["wave"], dtype=float).reshape(-1)
+    elif "wavelength" in illuminant:
+        wave = np.asarray(illuminant["wavelength"], dtype=float).reshape(-1)
+    elif isinstance(illuminant.get("spectrum"), Mapping) and "wave" in illuminant["spectrum"]:
+        wave = np.asarray(illuminant["spectrum"]["wave"], dtype=float).reshape(-1)
+    else:
+        raise ValueError("Illuminant missing wavelength data")
+
+    # Spectral data
+    data = illuminant.get("data")
+    spd = None
+    if isinstance(data, Mapping):
+        if "photons" in data:
+            spd = np.asarray(data["photons"], dtype=float).reshape(-1)
+        elif "energy" in data:
+            spd = np.asarray(data["energy"], dtype=float).reshape(-1)
+    elif data is not None:
+        spd = np.asarray(data, dtype=float).reshape(-1)
+
+    if spd is None and "photons" in illuminant:
+        spd = np.asarray(illuminant["photons"], dtype=float).reshape(-1)
+
+    if spd is None:
+        raise ValueError("Illuminant missing spectral data")
+
+    name = illuminant.get("name")
+    if name is not None:
+        name = str(name)
+
+    return Illuminant(spd=spd, wave=wave, name=name)
+
+
+__all__ = ["illuminant_modernize"]

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -5,6 +5,7 @@ from .scene_add import scene_add
 from .scene_utils import get_photons, set_photons, get_n_wave
 from .scene_from_file import scene_from_file
 from .scene_from_ddf_file import scene_from_ddf_file
+from .scene_from_basis import scene_from_basis
 from .scene_get import scene_get
 from .scene_set import scene_set
 from .scene_adjust_luminance import scene_adjust_luminance
@@ -66,6 +67,7 @@ __all__ = [
     "get_n_wave",
     "scene_from_file",
     "scene_from_ddf_file",
+    "scene_from_basis",
     "scene_get",
     "scene_set",
     "scene_adjust_luminance",

--- a/python/isetcam/scene/scene_from_basis.py
+++ b/python/isetcam/scene/scene_from_basis.py
@@ -1,0 +1,71 @@
+"""Create a :class:`Scene` from a basis representation."""
+
+from __future__ import annotations
+
+from typing import Mapping, Any
+
+import numpy as np
+
+from .scene_class import Scene
+from ..illuminant import illuminant_modernize
+
+
+_DEF_IMG_MEAN = None  # placeholder for mypy-type hints
+
+
+def _reshape_coeffs(mc: np.ndarray) -> tuple[np.ndarray, tuple[int, int] | None]:
+    """Return coefficient matrix in XW format and original spatial size."""
+    mc = np.asarray(mc, dtype=float)
+    if mc.ndim == 3:
+        h, w, n = mc.shape
+        return mc.reshape(h * w, n), (h, w)
+    if mc.ndim == 2:
+        return mc, None
+    raise ValueError("mcCOEF must be 2-D or 3-D")
+
+
+def _reshape_photons(flat: np.ndarray, shape: tuple[int, int] | None, n_wave: int) -> np.ndarray:
+    if shape is None:
+        return flat
+    h, w = shape
+    return flat.reshape(h, w, n_wave)
+
+
+def scene_from_basis(sceneS: Mapping[str, Any]) -> Scene:
+    """Return a :class:`Scene` reconstructed from ``sceneS``."""
+
+    if "mcCOEF" not in sceneS:
+        raise KeyError("mcCOEF required")
+    if "basis" not in sceneS:
+        raise KeyError("basis required")
+
+    basis_struct = sceneS["basis"]
+    if not isinstance(basis_struct, Mapping) or "basis" not in basis_struct or "wave" not in basis_struct:
+        raise KeyError("basis must contain 'basis' and 'wave'")
+
+    coeffs, shape = _reshape_coeffs(sceneS["mcCOEF"])
+    basis = np.asarray(basis_struct["basis"], dtype=float)
+    wave = np.asarray(basis_struct["wave"], dtype=float).reshape(-1)
+
+    photons_flat = coeffs @ basis.T
+    photons = _reshape_photons(photons_flat, shape, wave.size)
+
+    if "imgMean" in sceneS and sceneS["imgMean"] is not None:
+        mean = np.asarray(sceneS["imgMean"], dtype=float).reshape(-1)
+        if photons.ndim == 3:
+            photons = photons + mean.reshape(1, 1, -1)
+        else:
+            photons = photons + mean
+
+    photons = np.maximum(photons, 0.0)
+
+    scene = Scene(photons=photons, wave=wave)
+
+    illum = sceneS.get("illuminant")
+    if illum is not None:
+        scene.illuminant = illuminant_modernize(illum)
+
+    return scene
+
+
+__all__ = ["scene_from_basis"]

--- a/python/tests/test_scene_from_basis.py
+++ b/python/tests/test_scene_from_basis.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from isetcam.scene import scene_from_basis, Scene
+from isetcam.illuminant import Illuminant
+
+
+def test_scene_from_basis():
+    wave = np.array([1.0, 2.0, 3.0], dtype=float)
+    basis_mat = np.array([[1, 0], [0, 1], [1, 1]], dtype=float)
+    mc = np.array([[[1, 2]], [[3, 4]]], dtype=float)
+    img_mean = np.array([0.5, 1.0, 1.5], dtype=float)
+    illum = Illuminant(spd=np.array([10, 20, 30], dtype=float), wave=wave, name="test")
+
+    sceneS = {
+        "mcCOEF": mc,
+        "basis": {"basis": basis_mat, "wave": wave},
+        "imgMean": img_mean,
+        "illuminant": illum,
+    }
+
+    sc = scene_from_basis(sceneS)
+    assert isinstance(sc, Scene)
+    expected = mc.reshape(-1, mc.shape[-1]) @ basis_mat.T
+    expected = expected.reshape(mc.shape[0], mc.shape[1], wave.size) + img_mean.reshape(1, 1, -1)
+    assert np.allclose(sc.photons, expected)
+    assert np.array_equal(sc.wave, wave)
+    assert isinstance(getattr(sc, "illuminant", None), Illuminant)
+    assert np.array_equal(sc.illuminant.spd, illum.spd)


### PR DESCRIPTION
## Summary
- implement `scene_from_basis` to build Scene objects from basis decompositions
- translate illuminant modernization logic to `illuminant_modernize`
- export new helpers via `__init__` modules
- test scene reconstruction from basis data

## Testing
- `pytest -q -o addopts='' python/tests/test_scene_from_basis.py`
- `pytest -q -o addopts='' python/tests/test_scene_create.py`
- `pytest -q -o addopts='' python/tests/test_illuminant.py`


------
https://chatgpt.com/codex/tasks/task_e_683d3907a9748323b489e628b347c7f5