### PR TITLE
Add illuminant_modernize helper

### DIFF
--- a/python/isetcam/illuminant/__init__.py
+++ b/python/isetcam/illuminant/__init__.py
@@ -8,6 +8,7 @@ from .illuminant_to_file import illuminant_to_file
 from .illuminant_get import illuminant_get
 from .illuminant_set import illuminant_set
 from .illuminant_list import illuminant_list
+from .illuminant_modernize import illuminant_modernize
 
 __all__ = [
     "Illuminant",
@@ -18,4 +19,5 @@ __all__ = [
     "illuminant_get",
     "illuminant_set",
     "illuminant_list",
+    "illuminant_modernize",
 ]

--- a/python/isetcam/illuminant/illuminant_modernize.py
+++ b/python/isetcam/illuminant/illuminant_modernize.py
@@ -1,0 +1,68 @@
+"""Convert legacy illuminant structures to :class:`Illuminant`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .illuminant_class import Illuminant
+
+
+def _get(obj: Any, attr: str) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(attr)
+    return getattr(obj, attr, None)
+
+
+def illuminant_modernize(illuminant: Any) -> Illuminant:
+    """Return ``illuminant`` in modern :class:`Illuminant` form.
+
+    Parameters
+    ----------
+    illuminant : Any
+        Either an :class:`Illuminant` instance or a legacy structure that
+        stores the spectral distribution in ``data`` or ``spd`` and the
+        wavelength samples in ``wavelength`` or ``wave``.
+    """
+    if isinstance(illuminant, Illuminant):
+        return illuminant
+
+    # Attempt to detect modern attributes first
+    spd = _get(illuminant, "spd")
+    wave = _get(illuminant, "wave")
+    if spd is not None and wave is not None:
+        name = _get(illuminant, "name")
+        return Illuminant(
+            spd=np.asarray(spd, dtype=float).reshape(-1),
+            wave=np.asarray(wave, dtype=float).reshape(-1),
+            name=None if name is None else str(name),
+        )
+
+    # Legacy fields
+    data = _get(illuminant, "data")
+    if spd is None:
+        if isinstance(data, dict):
+            spd = data.get("photons")
+        else:
+            spd = getattr(data, "photons", None)
+        if spd is None and data is not None:
+            spd = data
+    if spd is None:
+        raise KeyError("Illuminant structure has no spectral data")
+
+    wave = wave or _get(illuminant, "wavelength")
+    if wave is None:
+        spec = _get(illuminant, "spectrum")
+        if spec is not None:
+            wave = _get(spec, "wave")
+    if wave is None:
+        raise KeyError("Illuminant structure has no wavelength information")
+
+    name = _get(illuminant, "name")
+
+    return Illuminant(
+        spd=np.asarray(spd, dtype=float).reshape(-1),
+        wave=np.asarray(wave, dtype=float).reshape(-1),
+        name=None if name is None else str(name),
+    )

--- a/python/tests/test_illuminant_modernize.py
+++ b/python/tests/test_illuminant_modernize.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from isetcam.illuminant import Illuminant, illuminant_modernize
+
+
+def test_modernize_passthrough():
+    illum = Illuminant(spd=np.array([1.0, 0.5]), wave=np.array([500, 510]), name="demo")
+    out = illuminant_modernize(illum)
+    assert out is illum
+
+
+def test_modernize_from_simple_dict():
+    legacy = {
+        "spd": np.array([0.1, 0.2, 0.3]),
+        "wave": np.array([400, 500, 600]),
+        "name": "simple",
+    }
+    out = illuminant_modernize(legacy)
+    assert isinstance(out, Illuminant)
+    assert np.allclose(out.spd, legacy["spd"])
+    assert np.array_equal(out.wave, legacy["wave"])
+    assert out.name == legacy["name"]
+
+
+def test_modernize_from_legacy_fields():
+    legacy = {
+        "data": {"photons": np.array([1.0, 2.0])},
+        "wavelength": np.array([500, 510]),
+        "name": "old",
+    }
+    out = illuminant_modernize(legacy)
+    assert np.allclose(out.spd, legacy["data"]["photons"])
+    assert np.array_equal(out.wave, legacy["wavelength"])
+    assert out.name == "old"


### PR DESCRIPTION
## Summary
- add `illuminant_modernize` utility to convert legacy illuminant structures
- expose new helper in `isetcam.illuminant`
- test modernization behaviour

## Testing
- `PYTHONPATH=$PWD/python pytest -q -c /tmp/empty.ini python/tests/test_illuminant_modernize.py`


------
https://chatgpt.com/codex/tasks/task_e_683d3912e9348323ae7e37fb24e116e3