### PR TITLE
Implement optics circle of confusion

### DIFF
--- a/python/isetcam/optics/__init__.py
+++ b/python/isetcam/optics/__init__.py
@@ -10,6 +10,7 @@ from .optics_psf import optics_psf
 from .optics_otf import optics_otf
 from .optics_cos4th import optics_cos4th
 from .optics_defocused_mtf import optics_defocused_mtf, optics_defocus_core
+from .optics_coc import optics_coc
 
 __all__ = [
     "Optics",
@@ -23,4 +24,5 @@ __all__ = [
     "optics_cos4th",
     "optics_defocused_mtf",
     "optics_defocus_core",
+    "optics_coc",
 ]

--- a/python/isetcam/optics/optics_coc.py
+++ b/python/isetcam/optics/optics_coc.py
@@ -1,0 +1,68 @@
+"""Compute circle of confusion diameter."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .optics_class import Optics
+
+
+def _unit_scale_factor(unit: str) -> float:
+    """Return scale factor to convert meters to ``unit``."""
+    u = unit.lower()
+    if u in {"m", "meter", "meters"}:
+        return 1.0
+    if u in {"mm", "millimeter", "millimeters"}:
+        return 1e3
+    if u in {"um", "micron", "microns", "micrometer", "micrometers"}:
+        return 1e6
+    if u in {"nm", "nanometer", "nanometers"}:
+        return 1e9
+    if u in {"cm", "centimeter", "centimeters"}:
+        return 1e2
+    if u in {"km", "kilometer", "kilometers"}:
+        return 1e-3
+    if u in {"inches", "inch"}:
+        return 39.37007874
+    if u in {"foot", "feet"}:
+        return 3.280839895
+    raise ValueError(f"Unknown unit '{unit}'")
+
+
+def optics_coc(
+    optics: Optics,
+    focus_distance: float,
+    eval_distance: np.ndarray | float,
+    units: str = "m",
+) -> np.ndarray:
+    """Circle of confusion diameter.
+
+    Parameters
+    ----------
+    optics : Optics
+        Lens description.
+    focus_distance : float
+        Distance from the lens to the object in perfect focus (meters).
+    eval_distance : array-like or float
+        Distances from the lens for which to evaluate the circle
+        of confusion (meters).
+    units : str, optional
+        Desired output units. Default is meters.
+
+    Returns
+    -------
+    np.ndarray
+        Circle of confusion diameter for each ``eval_distance``.
+    """
+    eval_distance = np.asarray(eval_distance, dtype=float).reshape(-1)
+
+    A = optics.f_length / optics.f_number
+
+    fO = 1.0 / ((1.0 / optics.f_length) - (1.0 / focus_distance))
+
+    fX = 1.0 / ((1.0 / optics.f_length) - (1.0 / eval_distance))
+    fX = np.maximum(fX, 0.0)
+
+    circ = A * np.abs(fX - fO) / fX
+
+    return circ * _unit_scale_factor(units)

--- a/python/tests/test_optics_coc.py
+++ b/python/tests/test_optics_coc.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from isetcam.optics import Optics, optics_coc
+
+
+def _expected(optics: Optics, focus: float, dist: np.ndarray) -> np.ndarray:
+    A = optics.f_length / optics.f_number
+    fO = 1.0 / ((1.0 / optics.f_length) - (1.0 / focus))
+    fX = 1.0 / ((1.0 / optics.f_length) - (1.0 / dist))
+    fX = np.maximum(fX, 0.0)
+    return A * np.abs(fX - fO) / fX
+
+
+def test_optics_coc_basic():
+    opt = Optics(f_number=5.0, f_length=0.05)
+    focus = 3.0
+    dists = np.array([2.0, 3.0, 4.0])
+    out = optics_coc(opt, focus, dists)
+    exp = _expected(opt, focus, dists)
+    assert np.allclose(out, exp)
+    assert np.isclose(out[1], 0.0)
+
+
+def test_optics_coc_units():
+    opt = Optics(f_number=5.0, f_length=0.05)
+    focus = 3.0
+    d = 4.0
+    out_m = optics_coc(opt, focus, d, units="m")
+    out_mm = optics_coc(opt, focus, d, units="mm")
+    assert np.allclose(out_mm, out_m * 1e3)


### PR DESCRIPTION
## Summary
- add `optics_coc` to compute circle of confusion diameter
- export new function through `isetcam.optics`
- test calculation and unit conversion

## Testing
- `pytest -q --override-ini addopts='' python/tests/test_optics_coc.py`
- `pytest -q --override-ini addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_683d39192d9483239b8c2824097b3c62