### PR TITLE
Add oi_make_even_row_col utility

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -12,6 +12,7 @@ from .oi_photon_noise import oi_photon_noise
 from .oi_to_file import oi_to_file
 from .oi_crop import oi_crop
 from .oi_pad import oi_pad
+from .oi_make_even_row_col import oi_make_even_row_col
 from .oi_translate import oi_translate
 from .oi_rotate import oi_rotate
 from .oi_camera_motion import oi_camera_motion
@@ -47,6 +48,7 @@ __all__ = [
     "oi_compute",
     "oi_crop",
     "oi_pad",
+    "oi_make_even_row_col",
     "oi_translate",
     "oi_rotate",
     "oi_camera_motion",

--- a/python/isetcam/opticalimage/oi_make_even_row_col.py
+++ b/python/isetcam/opticalimage/oi_make_even_row_col.py
@@ -1,0 +1,42 @@
+"""Ensure an :class:`OpticalImage` has even rows and columns."""
+
+from __future__ import annotations
+from .oi_class import OpticalImage
+from .oi_pad import oi_pad
+
+
+def oi_make_even_row_col(oi: OpticalImage, s_dist: float | None = None) -> OpticalImage:
+    """Pad odd dimensions so that rows and columns are even.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image.
+    s_dist : float, optional
+        Scene distance in meters. Included for API compatibility but
+        currently unused.
+
+    Returns
+    -------
+    OpticalImage
+        Optical image padded to have even row and column counts. The
+        ``sample_spacing`` attribute is updated so that the field of view
+        is preserved.
+    """
+
+    height, width = oi.photons.shape[:2]
+    pad_bottom = height % 2
+    pad_right = width % 2
+
+    if pad_bottom == 0 and pad_right == 0:
+        return oi
+
+    padded = oi_pad(oi, (0, pad_bottom, 0, pad_right), value=0)
+
+    old_spacing = getattr(oi, "sample_spacing", 1.0)
+    old_width_m = width * old_spacing
+    new_width = width + pad_right
+    new_spacing = old_width_m / new_width
+
+    padded.sample_spacing = new_spacing
+    return padded

--- a/python/tests/test_oi_make_even_row_col.py
+++ b/python/tests/test_oi_make_even_row_col.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from isetcam.opticalimage import OpticalImage, oi_make_even_row_col
+
+
+def _simple_oi(width: int, height: int, n_wave: int = 1) -> OpticalImage:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    oi = OpticalImage(photons=photons, wave=wave)
+    oi.sample_spacing = 1e-3  # 1 mm per pixel
+    return oi
+
+
+def test_make_even_no_change():
+    oi = _simple_oi(4, 4, 1)
+    out = oi_make_even_row_col(oi)
+    assert out.photons.shape == oi.photons.shape
+    assert getattr(out, "sample_spacing") == getattr(oi, "sample_spacing")
+
+
+def test_make_even_pad_and_spacing():
+    oi = _simple_oi(5, 3, 1)
+    out = oi_make_even_row_col(oi)
+    assert out.photons.shape[:2] == (4, 6)
+    old_width = oi.photons.shape[1] * oi.sample_spacing
+    new_width = out.photons.shape[1] * out.sample_spacing
+    assert np.isclose(old_width, new_width)
+    assert np.array_equal(out.photons[:-1, :-1, :], oi.photons)


### PR DESCRIPTION
## Summary
- add oi_make_even_row_col to pad optical images to even dimensions and adjust sample spacing
- expose new utility through opticalimage package
- test padding and sample spacing update

## Testing
- `PYTHONPATH=python pytest -q -o addopts='' python/tests/test_oi_make_even_row_col.py`

------
https://chatgpt.com/codex/tasks/task_e_683d391db1d883239b37de560c7d92c5