### PR TITLE
Add sensor_show_cfa_weights

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -28,6 +28,7 @@ from .sensor_dng_read import sensor_dng_read
 from .sensor_show_image import sensor_show_image
 from .sensor_rotate import sensor_rotate
 from .sensor_show_cfa import sensor_show_cfa
+from .sensor_show_cfa_weights import sensor_show_cfa_weights
 from .sensor_stats import sensor_stats
 from .sensor_clear_data import sensor_clear_data
 from .sensor_iso_speed import sensor_iso_speed
@@ -92,6 +93,7 @@ __all__ = [
     "sensor_dng_read",
     "sensor_show_image",
     "sensor_show_cfa",
+    "sensor_show_cfa_weights",
     "sensor_rotate",
     "sensor_stats",
     "sensor_clear_data",

--- a/python/isetcam/sensor/sensor_show_cfa_weights.py
+++ b/python/isetcam/sensor/sensor_show_cfa_weights.py
@@ -1,0 +1,75 @@
+"""Visualize weights using the sensor's CFA colors."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from .sensor_class import Sensor
+from .sensor_show_cfa import _COLOR_MAP, _parse_pattern
+from ..ie_scale import ie_scale
+
+
+def sensor_show_cfa_weights(
+    weights: np.ndarray,
+    sensor: Sensor,
+    c_pos: Tuple[int, int] | None = None,
+    *,
+    img_scale: int = 32,
+) -> np.ndarray:
+    """Return an RGB image of ``weights`` colored by the sensor CFA."""
+
+    w = np.asarray(weights, dtype=float)
+    if w.ndim != 2:
+        raise ValueError("weights must be a 2-D array")
+
+    patch_size = w.shape
+    if c_pos is None:
+        c_pos = (patch_size[0] // 2, patch_size[1] // 2)
+    if len(c_pos) != 2:
+        raise ValueError("c_pos must have length 2")
+    c_row, c_col = int(c_pos[0]), int(c_pos[1])
+
+    letters = getattr(sensor, "filter_color_letters", None)
+    if letters is None:
+        raise ValueError("sensor has no 'filter_color_letters' attribute")
+    pattern = _parse_pattern(letters)
+    if pattern is None:
+        raise ValueError("filter_color_letters must form a square CFA pattern")
+    pattern = np.asarray(pattern)
+
+    pr, pc = pattern.shape
+    rr = patch_size[0] // pr + 21
+    cc = patch_size[1] // pc + 21
+    mosaic = np.tile(pattern, (rr, cc))
+
+    center_row = pr * 10 + c_row
+    center_col = pc * 10 + c_col
+    h_row = patch_size[0] // 2
+    h_col = patch_size[1] // 2
+    start_r = center_row - h_row
+    start_c = center_col - h_col
+    patch_letters = mosaic[
+        start_r : start_r + patch_size[0], start_c : start_c + patch_size[1]
+    ]
+
+    cfa_img = np.zeros(patch_letters.shape + (3,), dtype=float)
+    for ltr, color in _COLOR_MAP.items():
+        mask = patch_letters == ltr
+        cfa_img[mask, :] = color
+
+    if np.max(w) == np.min(w):
+        w_scaled = np.ones_like(w)
+    else:
+        w_scaled, _, _ = ie_scale(w, 0.0, 1.0)
+
+    img = w_scaled[:, :, None] * cfa_img
+
+    if img_scale > 1:
+        img = np.repeat(np.repeat(img, img_scale, axis=0), img_scale, axis=1)
+
+    return img
+
+
+__all__ = ["sensor_show_cfa_weights"]

--- a/python/tests/test_sensor_show_cfa_weights.py
+++ b/python/tests/test_sensor_show_cfa_weights.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from isetcam.sensor import Sensor, sensor_show_cfa_weights
+
+
+def test_sensor_show_cfa_weights_runs():
+    wgts = np.arange(9, dtype=float).reshape(3, 3)
+    s = Sensor(volts=np.zeros((2, 2)), wave=np.array([500]), exposure_time=0.01)
+    s.filter_color_letters = "rggb"
+    img = sensor_show_cfa_weights(wgts, s)
+    assert img.shape == (3 * 32, 3 * 32, 3)
+    assert img.min() >= 0.0 and img.max() <= 1.0
+
+
+def test_sensor_show_cfa_weights_constant():
+    wgts = np.ones((3, 3), dtype=float)
+    s = Sensor(volts=np.zeros((2, 2)), wave=np.array([500]), exposure_time=0.01)
+    s.filter_color_letters = "rggb"
+    img = sensor_show_cfa_weights(wgts, s, img_scale=1)
+    assert img.shape == (3, 3, 3)
+    assert img.min() >= 0.0 and img.max() <= 1.0


### PR DESCRIPTION
## Summary
- implement `sensor_show_cfa_weights` for visualizing weight kernels using the sensor CFA colors
- export from `isetcam.sensor`
- test `sensor_show_cfa_weights`

## Testing
- `PYTHONPATH=python pytest -q -o addopts='' python/tests/test_sensor_show_cfa_weights.py`
- `PYTHONPATH=python pytest -q -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_683d392050348323adb8ad9732377b53