### PR TITLE
Add ie_tikhonov function

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -96,6 +96,7 @@ from .ie_prctile import ie_prctile
 from .ie_mvnrnd import ie_mvnrnd
 from .ie_poisson import ie_poisson
 from .ie_normpdf import ie_normpdf
+from .ie_tikhonov import ie_tikhonov
 from .ie_format_figure import (
     ie_format_figure,
     set_ie_figure_defaults,
@@ -243,6 +244,7 @@ __all__ = [
     'ie_mvnrnd',
     'ie_poisson',
     'ie_normpdf',
+    'ie_tikhonov',
     'ie_format_figure',
     'set_ie_figure_defaults',
     '_IE_FIGURE_DEFAULTS',

--- a/python/isetcam/ie_tikhonov.py
+++ b/python/isetcam/ie_tikhonov.py
@@ -1,0 +1,59 @@
+"""Solve a Tikhonov regularized least-squares problem."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def ie_tikhonov(
+    A: ArrayLike,
+    b: ArrayLike,
+    *,
+    minnorm: float = 0.0,
+    smoothness: float = 0.0,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Solve ``A x \approx b`` using Tikhonov regularization.
+
+    Parameters
+    ----------
+    A : array-like, shape (m, n)
+        System matrix.
+    b : array-like, shape (m,)
+        Right-hand-side vector.
+    minnorm : float, optional
+        Weight for the minimum-norm term ``||x||^2``.
+    smoothness : float, optional
+        Weight for the smoothness term based on the second difference of ``x``.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        ``x`` : Regularized solution.
+        ``x_ols`` : Ordinary least-squares solution without regularization.
+    """
+    A = np.asarray(A, dtype=float)
+    b = np.asarray(b, dtype=float).reshape(-1)
+
+    m, n = A.shape
+    if b.shape[0] != m:
+        raise ValueError("b must have length matching rows of A")
+
+    # Second-order finite difference matrix enforcing smoothness
+    if smoothness != 0:
+        D2 = np.diff(np.eye(n), 2, axis=0)
+        reg_smooth = smoothness * (D2.T @ D2)
+    else:
+        reg_smooth = 0.0
+
+    reg_min = minnorm * np.eye(n)
+
+    lhs = A.T @ A + reg_min + reg_smooth
+    rhs = A.T @ b
+
+    x = np.linalg.solve(lhs, rhs)
+    x_ols = np.linalg.lstsq(A, b, rcond=None)[0]
+    return x, x_ols
+
+
+__all__ = ["ie_tikhonov"]

--- a/python/tests/test_ie_tikhonov.py
+++ b/python/tests/test_ie_tikhonov.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from isetcam import ie_tikhonov
+
+
+A = np.array([[1.0, 0.0, 2.0],
+              [0.0, 1.0, 1.0],
+              [2.0, 3.0, 0.0],
+              [1.0, 0.0, 1.0]])
+
+b = np.array([1.0, 2.0, 3.0, 4.0])
+
+
+def test_no_regularization():
+    x, x_ols = ie_tikhonov(A, b)
+    expected = np.linalg.solve(A.T @ A, A.T @ b)
+    lstsq = np.linalg.lstsq(A, b, rcond=None)[0]
+    assert np.allclose(x, expected)
+    assert np.allclose(x_ols, lstsq)
+
+
+def test_minnorm():
+    lam = 0.2
+    x, _ = ie_tikhonov(A, b, minnorm=lam)
+    expected = np.linalg.solve(A.T @ A + lam * np.eye(A.shape[1]), A.T @ b)
+    assert np.allclose(x, expected)
+
+
+def test_smoothness():
+    lam = 0.3
+    D2 = np.diff(np.eye(A.shape[1]), 2, axis=0)
+    x, _ = ie_tikhonov(A, b, smoothness=lam)
+    expected = np.linalg.solve(A.T @ A + lam * (D2.T @ D2), A.T @ b)
+    assert np.allclose(x, expected)


### PR DESCRIPTION
## Summary
- port `ieTikhonov.m` to Python as `ie_tikhonov`
- export the new utility in `__init__`
- test Tikhonov regularization on small matrices

## Testing
- `pytest -q -o addopts='' python/tests/test_ie_tikhonov.py`

------
https://chatgpt.com/codex/tasks/task_e_683d4a46448883239467150db7b16d3e