### PR TITLE
Add ISO speed saturation metric

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -119,6 +119,7 @@ from .metrics.scielab import scielab, sc_params, SCIELABParams
 from .metrics.xyz_to_vsnr import xyz_to_vsnr
 from .metrics.ssim_metric import ssim_metric
 from .metrics.exposure_value import exposure_value
+from .metrics.iso_speed_saturation import iso_speed_saturation
 from .human import (
     human_pupil_size,
     human_macular_transmittance,
@@ -264,6 +265,7 @@ __all__ = [
     'xyz_to_vsnr',
     'ssim_metric',
     'exposure_value',
+    'iso_speed_saturation',
     'human_pupil_size',
     'human_macular_transmittance',
     'human_optical_density',

--- a/python/isetcam/metrics/__init__.py
+++ b/python/isetcam/metrics/__init__.py
@@ -10,6 +10,7 @@ from .xyz_to_vsnr import xyz_to_vsnr
 from .ssim_metric import ssim_metric
 from .exposure_value import exposure_value
 from .iso_acutance import iso_acutance
+from .iso_speed_saturation import iso_speed_saturation
 from .metrics_compute import metrics_compute
 
 __all__ = [
@@ -25,5 +26,6 @@ __all__ = [
     "ssim_metric",
     "exposure_value",
     "iso_acutance",
+    "iso_speed_saturation",
     "metrics_compute",
 ]

--- a/python/isetcam/metrics/iso_speed_saturation.py
+++ b/python/isetcam/metrics/iso_speed_saturation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import numpy as np
+
+from ..illuminant import illuminant_create
+from ..energy_to_quanta import energy_to_quanta
+from ..opticalimage import OpticalImage, oi_calculate_illuminance
+from ..sensor.sensor_compute import sensor_compute
+from ..sensor.sensor_get import sensor_get
+from ..sensor.sensor_class import Sensor
+
+
+def _uniform_d65_oi(wave: np.ndarray) -> OpticalImage:
+    ill = illuminant_create("D65", wave)
+    photons = energy_to_quanta(ill.wave, ill.spd)
+    photons = photons.reshape(1, 1, -1)
+    return OpticalImage(photons=photons, wave=wave, name="Uniform D65")
+
+
+def iso_speed_saturation(sensor: Sensor) -> float:
+    """Return ISO saturation speed for ``sensor`` using a D65 source."""
+    well_capacity = getattr(sensor, "well_capacity", None)
+    if well_capacity is None:
+        raise AttributeError("sensor must have 'well_capacity' attribute")
+
+    wave = sensor.wave
+    oi = _uniform_d65_oi(wave)
+
+    tmp = sensor_compute(sensor, oi)
+    electrons = float(np.mean(tmp.volts))
+
+    lux = float(oi_calculate_illuminance(oi).mean())
+    lux_sec = lux * sensor_get(sensor, "exposure_time")
+
+    sat_lux_sec = lux_sec * (well_capacity / electrons)
+
+    return 10.0 / ((sat_lux_sec / np.sqrt(2.0)) * 0.14)
+
+
+__all__ = ["iso_speed_saturation"]

--- a/python/tests/test_iso_speed_saturation.py
+++ b/python/tests/test_iso_speed_saturation.py
@@ -1,0 +1,52 @@
+import numpy as np
+from scipy.io import loadmat
+
+from isetcam.sensor import Sensor
+from isetcam.metrics import iso_speed_saturation
+from isetcam.illuminant import illuminant_create
+from isetcam.energy_to_quanta import energy_to_quanta
+from isetcam.quanta2energy import quanta_to_energy
+from isetcam.data_path import data_path
+
+
+def _expected_illuminance(wave, photons):
+    energy = quanta_to_energy(wave, photons)
+    mat = loadmat(data_path("human/luminosity.mat"))
+    V = np.interp(wave, mat["wavelength"].ravel(), mat["data"].ravel(), left=0.0, right=0.0)
+    bw = wave[1] - wave[0] if len(wave) > 1 else 10
+    xw = energy.reshape(-1, len(wave))
+    lum = 683 * xw.dot(V) * bw
+    return lum.reshape(1, 1)
+
+
+def _expected_iso(sensor):
+    wave = sensor.wave
+    ill = illuminant_create("D65", wave)
+    photons = energy_to_quanta(wave, ill.spd)
+    qe = getattr(sensor, "qe", np.ones_like(wave))
+    electrons = np.sum(photons * qe) * sensor.exposure_time
+    lux = float(_expected_illuminance(wave, photons))
+    lux_sec = lux * sensor.exposure_time
+    sat = lux_sec * (sensor.well_capacity / electrons)
+    return 10.0 / ((sat / np.sqrt(2.0)) * 0.14)
+
+
+def test_iso_speed_saturation_single_channel():
+    wave = np.array([550.0])
+    s = Sensor(volts=np.zeros((1,)), wave=wave, exposure_time=0.01)
+    s.well_capacity = 5000.0
+    s.qe = np.array([1.0])
+    iso = iso_speed_saturation(s)
+    exp_iso = _expected_iso(s)
+    assert np.isclose(iso, exp_iso)
+
+
+def test_iso_speed_saturation_multi_channel():
+    wave = np.array([500.0, 510.0, 520.0])
+    s = Sensor(volts=np.zeros((1,)), wave=wave, exposure_time=0.02)
+    s.well_capacity = 10000.0
+    s.qe = np.array([0.3, 0.5, 0.9])
+    iso = iso_speed_saturation(s)
+    exp_iso = _expected_iso(s)
+    assert np.isclose(iso, exp_iso)
+


### PR DESCRIPTION
## Summary
- implement saturation-based ISO speed metric
- export from metrics and top-level packages
- test ISO speed saturation against manual calculation

## Testing
- `pytest python/tests/test_iso_speed_saturation.py -q` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_683d4a52bd508323bbbfc55046b4d5da