### PR TITLE
Add EV step control to cp_burst_camera

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -2515,7 +2515,7 @@ scene = CPScene([scene_create('uniform', size=8)])
 module = CPCModule(sensor_create(), optics_create())
 camera = CPCamera([module])
 
-exp_times = cp_burst_camera(3, 0.01, mode='hdr')
+exp_times = cp_burst_camera(3, 0.01, mode='hdr', ev_step=1.0)
 captures = camera.take_picture(scene, exposure_times=exp_times)
 combined = cp_burst_ip(captures, mode='sum')
 ```

--- a/python/isetcam/cp/cp_burst_camera.py
+++ b/python/isetcam/cp/cp_burst_camera.py
@@ -3,16 +3,34 @@ from __future__ import annotations
 from typing import List
 
 
-def cp_burst_camera(n_frames: int, base_exposure: float, mode: str = "burst") -> List[float]:
-    """Return exposure times for a burst or HDR capture."""
+def cp_burst_camera(
+    n_frames: int,
+    base_exposure: float,
+    mode: str = "burst",
+    *,
+    ev_step: float = 1.0,
+) -> List[float]:
+    """Return exposure times for a burst or HDR capture.
+
+    Parameters
+    ----------
+    n_frames:
+        Number of frames in the burst.
+    base_exposure:
+        Reference exposure time for HDR sequences.
+    mode:
+        Either ``"burst"`` or ``"hdr"``.
+    ev_step:
+        Spacing in exposure value (EV) between successive frames when in
+        ``"hdr"`` mode. ``ev_step=1`` corresponds to powers of two.
+    """
+
     mode = mode.lower()
     if n_frames < 1:
         raise ValueError("n_frames must be positive")
     if mode == "hdr":
-        if n_frames > 1 and n_frames % 2 == 0:
-            n_frames += 1
         offset = (n_frames - 1) / 2
-        exp = [base_exposure * (2 ** (i - offset)) for i in range(n_frames)]
+        exp = [base_exposure * (2 ** ((i - offset) * ev_step)) for i in range(n_frames)]
     else:  # burst
         exp = [base_exposure / n_frames for _ in range(n_frames)]
     return exp

--- a/python/tests/test_cp_camera.py
+++ b/python/tests/test_cp_camera.py
@@ -34,3 +34,22 @@ def test_burst_capture_sum():
     combined = cp_burst_ip(sensors, mode="sum")
     expected = sensors[0].volts * 3
     assert np.allclose(combined, expected)
+
+
+def test_burst_camera_hdr_odd():
+    exp = cp_burst_camera(3, 0.01, mode="hdr")
+    expected = [0.01 * 2 ** -1, 0.01, 0.01 * 2 ** 1]
+    assert np.allclose(exp, expected)
+
+
+def test_burst_camera_hdr_even():
+    exp = cp_burst_camera(4, 0.01, mode="hdr")
+    offset = (4 - 1) / 2
+    expected = [0.01 * 2 ** ((i - offset)) for i in range(4)]
+    assert np.allclose(exp, expected)
+
+
+def test_burst_camera_hdr_ev_step():
+    exp = cp_burst_camera(3, 0.01, mode="hdr", ev_step=0.5)
+    expected = [0.01 * 2 ** (-0.5), 0.01, 0.01 * 2 ** (0.5)]
+    assert np.allclose(exp, expected)


### PR DESCRIPTION
## Summary
- add `ev_step` to `cp_burst_camera` and ensure HDR sequences are symmetric
- document new argument in migration guide
- expand unit tests for HDR exposures

## Testing
- `pytest -q -c /dev/null python/tests/test_cp_camera.py`

------
https://chatgpt.com/codex/tasks/task_e_683d4a618bbc83239811c6c96e3e67d9