### PR TITLE
Add hypercube utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -137,10 +137,18 @@ from .human import (
     watson_impulse_response,
     watson_rgc_spacing,
 )
+from .hypercube import (
+    hc_basis,
+    hc_blur,
+    hc_illuminant_scale,
+    hc_image,
+    hc_image_crop,
+    hc_image_rotate_clip,
+)
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip, cp  # noqa: E501
+from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip, cp, hypercube  # noqa: E501
 from .opticalimage import oi_to_file, oi_plot
 from .sensor import sensor_to_file
 from .display import (
@@ -299,6 +307,7 @@ __all__ = [
     'human',
     'ip',
     'cp',
+    'hypercube',
     'oi_to_file',
     'sensor_to_file',
     'display_to_file',
@@ -346,4 +355,10 @@ __all__ = [
     'vc_set_selected_object',
     'vc_new_object_name',
     'vc_new_object_value',
+    'hc_basis',
+    'hc_blur',
+    'hc_illuminant_scale',
+    'hc_image',
+    'hc_image_crop',
+    'hc_image_rotate_clip',
 ]

--- a/python/isetcam/hypercube/__init__.py
+++ b/python/isetcam/hypercube/__init__.py
@@ -1,0 +1,18 @@
+"""Utilities for working with hyperspectral image cubes."""
+
+from .hc_basis import hc_basis
+from .hc_blur import hc_blur
+from .hc_illuminant_scale import hc_illuminant_scale
+from .hc_image import hc_image
+from .hc_image_crop import hc_image_crop
+from .hc_image_rotate_clip import hc_image_rotate_clip
+
+__all__ = [
+    "hc_basis",
+    "hc_blur",
+    "hc_illuminant_scale",
+    "hc_image",
+    "hc_image_crop",
+    "hc_image_rotate_clip",
+]
+

--- a/python/isetcam/hypercube/hc_basis.py
+++ b/python/isetcam/hypercube/hc_basis.py
@@ -1,0 +1,36 @@
+"""Approximate a hyperspectral cube using basis functions."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def hc_basis(cube: np.ndarray, basis: np.ndarray) -> np.ndarray:
+    """Approximate ``cube`` using ``basis`` and reconstruct it.
+
+    Parameters
+    ----------
+    cube : np.ndarray
+        Input hyperspectral cube with shape ``(rows, cols, bands)``.
+    basis : np.ndarray
+        Basis matrix of shape ``(bands, n_basis)``.
+
+    Returns
+    -------
+    np.ndarray
+        Reconstructed cube with the same shape as ``cube``.
+    """
+    cube = np.asarray(cube, dtype=float)
+    basis = np.asarray(basis, dtype=float)
+    if cube.ndim != 3:
+        raise ValueError("cube must be 3-D")
+    if basis.ndim != 2 or basis.shape[0] != cube.shape[2]:
+        raise ValueError("basis must be (bands, n_basis)")
+
+    rows, cols, bands = cube.shape
+    xw = cube.reshape(-1, bands)
+    # Compute coefficients that best approximate the spectra in a
+    # least-squares sense and reconstruct the cube.
+    coef, _, _, _ = np.linalg.lstsq(basis, xw.T, rcond=None)
+    recon = (basis @ coef).T.reshape(rows, cols, bands)
+    return recon

--- a/python/isetcam/hypercube/hc_blur.py
+++ b/python/isetcam/hypercube/hc_blur.py
@@ -1,0 +1,19 @@
+"""Blur a hyperspectral cube with a Gaussian kernel."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import gaussian_filter
+
+
+def hc_blur(cube: np.ndarray, sigma: float) -> np.ndarray:
+    """Return a blurred copy of ``cube`` using a Gaussian kernel."""
+    cube = np.asarray(cube, dtype=float)
+    if cube.ndim != 3:
+        raise ValueError("cube must be 3-D")
+
+    blurred = np.empty_like(cube)
+    for b in range(cube.shape[2]):
+        blurred[:, :, b] = gaussian_filter(cube[:, :, b], sigma)
+    return blurred
+

--- a/python/isetcam/hypercube/hc_illuminant_scale.py
+++ b/python/isetcam/hypercube/hc_illuminant_scale.py
@@ -1,0 +1,31 @@
+"""Scale illuminant so mean cube reflectance is unity."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _expand_illuminant(illuminant: np.ndarray, shape: tuple[int, int, int]) -> np.ndarray:
+    """Return ``illuminant`` expanded to ``shape``."""
+    illuminant = np.asarray(illuminant, dtype=float)
+    if illuminant.ndim == 1:
+        if illuminant.size != shape[2]:
+            raise ValueError("Illuminant vector length must match cube bands")
+        return np.tile(illuminant.reshape(1, 1, -1), (shape[0], shape[1], 1))
+    if illuminant.ndim == 3:
+        if illuminant.shape != shape:
+            raise ValueError("Illuminant cube must match data shape")
+        return illuminant
+    raise ValueError("Illuminant must be 1-D or 3-D")
+
+
+def hc_illuminant_scale(cube: np.ndarray, illuminant: np.ndarray) -> np.ndarray:
+    """Return scaled illuminant with mean cube reflectance equal to one."""
+    cube = np.asarray(cube, dtype=float)
+    ill_cube = _expand_illuminant(illuminant, cube.shape)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        refl = np.divide(cube, ill_cube, out=np.zeros_like(cube), where=ill_cube!=0)
+    avg_refl = float(refl.mean())
+    scale = avg_refl if avg_refl > 0 else 1.0
+    return illuminant * scale
+

--- a/python/isetcam/hypercube/hc_image.py
+++ b/python/isetcam/hypercube/hc_image.py
@@ -1,0 +1,20 @@
+"""Convert a hyperspectral cube to sRGB for display."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def hc_image(cube: np.ndarray, wave: np.ndarray) -> np.ndarray:
+    """Return an sRGB image of ``cube`` sampled at ``wave``."""
+    cube = np.asarray(cube, dtype=float)
+    if cube.ndim != 3:
+        raise ValueError("cube must be 3-D")
+
+    xyz = ie_xyz_from_photons(cube, wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+    return np.clip(srgb, 0.0, 1.0)
+

--- a/python/isetcam/hypercube/hc_image_crop.py
+++ b/python/isetcam/hypercube/hc_image_crop.py
@@ -1,0 +1,26 @@
+"""Crop a region from a hyperspectral cube."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+
+def hc_image_crop(cube: np.ndarray, rect: Sequence[int]) -> np.ndarray:
+    """Return ``cube`` cropped to ``rect``.
+
+    ``rect`` is ``(x, y, width, height)`` using 0-based indexing.
+    """
+    if len(rect) != 4:
+        raise ValueError("rect must have four elements")
+    x, y, w, h = [int(v) for v in rect]
+    if w <= 0 or h <= 0:
+        raise ValueError("width and height must be positive")
+    if cube.ndim != 3:
+        raise ValueError("cube must be 3-D")
+    height, width = cube.shape[:2]
+    if x < 0 or y < 0 or x + w > width or y + h > height:
+        raise ValueError("rect is outside cube bounds")
+    return cube[y : y + h, x : x + w, :].copy()
+

--- a/python/isetcam/hypercube/hc_image_rotate_clip.py
+++ b/python/isetcam/hypercube/hc_image_rotate_clip.py
@@ -1,0 +1,24 @@
+"""Rotate a hyperspectral cube and clip to original size."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import rotate as nd_rotate
+
+
+def hc_image_rotate_clip(cube: np.ndarray, angle: float, fill: float = 0) -> np.ndarray:
+    """Return ``cube`` rotated by ``angle`` degrees clipped to original size."""
+    cube = np.asarray(cube, dtype=float)
+    if cube.ndim != 3:
+        raise ValueError("cube must be 3-D")
+    rotated = nd_rotate(
+        cube,
+        angle,
+        axes=(1, 0),
+        reshape=False,
+        order=1,
+        mode="constant",
+        cval=float(fill),
+    )
+    return rotated
+

--- a/python/tests/test_hypercube.py
+++ b/python/tests/test_hypercube.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+from isetcam.hypercube import (
+    hc_basis,
+    hc_blur,
+    hc_illuminant_scale,
+    hc_image,
+    hc_image_crop,
+    hc_image_rotate_clip,
+)
+
+
+def _simple_cube() -> tuple[np.ndarray, np.ndarray]:
+    wave = np.array([500, 600], dtype=float)
+    cube = np.stack(
+        [np.full((4, 4), 0.5), np.full((4, 4), 1.0)], axis=2
+    )
+    return cube, wave
+
+
+def test_hc_basis_identity():
+    cube, _ = _simple_cube()
+    basis = np.eye(2)
+    recon = hc_basis(cube, basis)
+    assert np.allclose(recon, cube)
+
+
+def test_hc_blur_constant():
+    cube, _ = _simple_cube()
+    out = hc_blur(cube, sigma=1.0)
+    assert np.allclose(out, cube)
+
+
+def test_hc_illuminant_scale_vector():
+    cube, _ = _simple_cube()
+    illum = np.array([1.0, 2.0])
+    new_illum = hc_illuminant_scale(cube, illum)
+    scaled = illum * (cube / illum.reshape(1, 1, -1)).mean()
+    assert np.allclose(new_illum, scaled)
+
+
+def test_hc_image_crop():
+    cube, _ = _simple_cube()
+    cropped = hc_image_crop(cube, (1, 1, 2, 2))
+    assert cropped.shape == (2, 2, 2)
+    assert np.allclose(cropped, cube[1:3, 1:3, :])
+
+
+def test_hc_image_rotate_clip():
+    cube, _ = _simple_cube()
+    rotated = hc_image_rotate_clip(cube, 90)
+    assert rotated.shape == cube.shape
+
+
+def test_hc_image():
+    cube, wave = _simple_cube()
+    rgb = hc_image(cube, wave)
+    assert rgb.shape == (4, 4, 3)
+


### PR DESCRIPTION
## Summary
- add new hypercube subpackage implementing basic cube operations
- expose hypercube utilities at the top level
- test hypercube functions on small synthetic cubes

## Testing
- `PYTHONPATH=python pytest -q -c /dev/null python/tests/test_hypercube.py`

------
https://chatgpt.com/codex/tasks/task_e_683d59964a3c8323a5339ddf49fa5498