### PR TITLE
Add font utilities and scene_from_font

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -140,7 +140,7 @@ from .human import (
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip, cp  # noqa: E501
+from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip, cp, fonts  # noqa: E501
 from .opticalimage import oi_to_file, oi_plot
 from .sensor import sensor_to_file
 from .display import (
@@ -161,6 +161,7 @@ from .camera import (
 )
 from .optics import optics_to_file, optics_from_file
 from .scene import scene_plot
+from .scene import scene_from_font
 from .illuminant import (
     illuminant_to_file,
     illuminant_from_file,
@@ -168,6 +169,7 @@ from .illuminant import (
     illuminant_set,
     illuminant_list,
 )
+from .fonts import font_create, font_get, font_set, font_bitmap_get
 from .ip import ip_to_file, ip_from_file, ip_plot
 from .io import openexr_read, openexr_write, pfm_read, pfm_write, dng_read, dng_write
 from .ie_scp import ie_scp
@@ -299,6 +301,7 @@ __all__ = [
     'human',
     'ip',
     'cp',
+    'fonts',
     'oi_to_file',
     'sensor_to_file',
     'display_to_file',
@@ -346,4 +349,9 @@ __all__ = [
     'vc_set_selected_object',
     'vc_new_object_name',
     'vc_new_object_value',
+    'font_create',
+    'font_get',
+    'font_set',
+    'font_bitmap_get',
+    'scene_from_font',
 ]

--- a/python/isetcam/fonts/__init__.py
+++ b/python/isetcam/fonts/__init__.py
@@ -1,0 +1,15 @@
+"""Font-related utilities."""
+
+from .font_class import Font
+from .font_bitmap_get import font_bitmap_get
+from .font_create import font_create
+from .font_get import font_get
+from .font_set import font_set
+
+__all__ = [
+    "Font",
+    "font_bitmap_get",
+    "font_create",
+    "font_get",
+    "font_set",
+]

--- a/python/isetcam/fonts/font_bitmap_get.py
+++ b/python/isetcam/fonts/font_bitmap_get.py
@@ -1,0 +1,64 @@
+"""Return a bitmap for a :class:`Font`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from scipy.io import loadmat
+from PIL import Image, ImageDraw, ImageFont
+
+from ..data_path import data_path
+
+
+_DEF_PAD = 3
+
+
+def _bitmap_from_file(font: "Font") -> np.ndarray:
+    path = data_path(Path("fonts") / f"{font.name}.mat")
+    if not path.exists():
+        raise FileNotFoundError
+    mat = loadmat(path)
+    bm_src = mat["bmSrc"][0, 0]
+    b = 1 - bm_src["dataIndex"]
+    padsize = 3 * int(np.ceil(b.shape[1] / 3)) - b.shape[1]
+    if padsize > 0:
+        b = np.pad(b, ((0, 0), (padsize, 0)), constant_values=1)
+    width = int(np.ceil(b.shape[1] / 3))
+    bitmap = np.ones((b.shape[0], width, 3), dtype=float)
+    for ii in range(3):
+        bitmap[:, :, ii] = b[:, ii::3]
+    return bitmap
+
+
+def _bitmap_from_pillow(font: "Font") -> np.ndarray:
+    size = int(font.size * 2)
+    try:
+        pil_font = ImageFont.truetype(font.family, font.size, layout_engine=ImageFont.LAYOUT_BASIC)
+    except Exception:
+        pil_font = ImageFont.load_default()
+    img = Image.new("L", (size, size), color=255)
+    draw = ImageDraw.Draw(img)
+    bbox = draw.textbbox((0, 0), font.character, font=pil_font)
+    w = bbox[2] - bbox[0]
+    h = bbox[3] - bbox[1]
+    draw.text(((size - w) / 2, (size - h) / 2), font.character, fill=0, font=pil_font)
+    arr = np.array(img)
+    mask = arr < 255
+    if mask.any():
+        rows = np.where(mask.any(axis=1))[0]
+        cols = np.where(mask.any(axis=0))[0]
+        arr = arr[rows[0] : rows[-1] + 1, cols[0] : cols[-1] + 1]
+    bitmap = (arr <= 127).astype(float)
+    return np.repeat(bitmap[:, :, None], 3, axis=2)
+
+
+def font_bitmap_get(font: "Font") -> np.ndarray:
+    """Return the bitmap image for ``font``."""
+    try:
+        return _bitmap_from_file(font)
+    except Exception:
+        return _bitmap_from_pillow(font)
+
+
+__all__ = ["font_bitmap_get"]

--- a/python/isetcam/fonts/font_class.py
+++ b/python/isetcam/fonts/font_class.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class Font:
+    """Simple font description used for rendering text."""
+
+    character: str = "g"
+    family: str = "DejaVuSans"
+    size: int = 14
+    dpi: int = 96
+    style: str = "NORMAL"
+    bitmap: np.ndarray | None = None
+    name: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.name is None:
+            self.name = f"{self.character}-{self.family}-{self.size}-{self.dpi}".lower()
+        if self.bitmap is None:
+            from .font_bitmap_get import font_bitmap_get
+
+            self.bitmap = font_bitmap_get(self)

--- a/python/isetcam/fonts/font_create.py
+++ b/python/isetcam/fonts/font_create.py
@@ -1,0 +1,30 @@
+"""Create a :class:`Font` description."""
+
+from __future__ import annotations
+
+from .font_class import Font
+
+
+def font_create(
+    letter: str | None = None,
+    family: str | None = None,
+    size: int | None = None,
+    dpi: int | None = None,
+    style: str | None = None,
+) -> Font:
+    """Return a :class:`Font` instance."""
+    if letter is None:
+        letter = "g"
+    if family is None:
+        family = "DejaVuSans"
+    if size is None:
+        size = 14
+    if dpi is None:
+        dpi = 96
+    if style is None:
+        style = "NORMAL"
+    f = Font(character=letter, family=family, size=size, dpi=dpi, style=style)
+    return f
+
+
+__all__ = ["font_create"]

--- a/python/isetcam/fonts/font_get.py
+++ b/python/isetcam/fonts/font_get.py
@@ -1,0 +1,58 @@
+"""Retrieve parameters from :class:`Font` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .font_class import Font
+from ..ie_param_format import ie_param_format
+
+
+def font_get(font: Font, param: str, *args) -> Any:
+    """Return a parameter value from ``font``."""
+    key = ie_param_format(param)
+    if key == "type":
+        return "font"
+    if key == "name":
+        return font.name
+    if key == "character":
+        return font.character
+    if key == "size":
+        return font.size
+    if key == "family":
+        return font.family
+    if key == "style":
+        return font.style
+    if key == "dpi":
+        return font.dpi
+    if key == "bitmap":
+        return font.bitmap
+    if key == "ibitmap":
+        return 1 - font.bitmap
+    if key == "paddedbitmap":
+        padsize = args[0] if len(args) > 0 else (7, 7)
+        padval = args[1] if len(args) > 1 else 1
+        bitmap = np.asarray(font.bitmap)
+        out = np.full(
+            (
+                bitmap.shape[0] + 2 * padsize[0],
+                bitmap.shape[1] + 2 * padsize[1],
+                bitmap.shape[2],
+            ),
+            padval,
+            dtype=bitmap.dtype,
+        )
+        out[
+            padsize[0] : padsize[0] + bitmap.shape[0],
+            padsize[1] : padsize[1] + bitmap.shape[1],
+            :,
+        ] = bitmap
+        return out
+    if key == "ipaddedbitmap":
+        return 1 - font_get(font, "padded bitmap", *args)
+    raise KeyError(f"Unknown font parameter '{param}'")
+
+
+__all__ = ["font_get"]

--- a/python/isetcam/fonts/font_set.py
+++ b/python/isetcam/fonts/font_set.py
@@ -1,0 +1,40 @@
+"""Assign parameters on :class:`Font` objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .font_class import Font
+from ..ie_param_format import ie_param_format
+from .font_bitmap_get import font_bitmap_get
+
+
+def font_set(font: Font, param: str, val: Any) -> Font:
+    """Set a parameter value on ``font``."""
+    key = ie_param_format(param)
+    if key == "type":
+        return font
+    if key == "name":
+        font.name = str(val)
+    elif key == "character":
+        font.character = str(val)
+    elif key == "size":
+        font.size = int(val)
+    elif key == "family":
+        font.family = str(val)
+    elif key == "style":
+        font.style = str(val)
+    elif key == "dpi":
+        font.dpi = int(val)
+    elif key == "bitmap":
+        font.bitmap = val
+        return font
+    else:
+        raise KeyError(f"Unknown font parameter '{param}'")
+
+    font.name = f"{font.character}-{font.family}-{font.size}-{font.dpi}".lower()
+    font.bitmap = font_bitmap_get(font)
+    return font
+
+
+__all__ = ["font_set"]

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -5,6 +5,7 @@ from .scene_add import scene_add
 from .scene_utils import get_photons, set_photons, get_n_wave
 from .scene_from_file import scene_from_file
 from .scene_from_ddf_file import scene_from_ddf_file
+from .scene_from_font import scene_from_font
 from .scene_get import scene_get
 from .scene_set import scene_set
 from .scene_adjust_luminance import scene_adjust_luminance
@@ -66,6 +67,7 @@ __all__ = [
     "get_n_wave",
     "scene_from_file",
     "scene_from_ddf_file",
+    "scene_from_font",
     "scene_get",
     "scene_set",
     "scene_adjust_luminance",

--- a/python/isetcam/scene/scene_from_font.py
+++ b/python/isetcam/scene/scene_from_font.py
@@ -1,0 +1,62 @@
+"""Create a simple :class:`Scene` from text rendered with a :class:`Font`."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .scene_class import Scene
+from ..fonts import Font, font_create, font_bitmap_get
+
+
+_DEF_SPACING = 1
+
+
+def scene_from_font(text: str, font: Optional[Font] = None, spacing: int = _DEF_SPACING) -> Scene:
+    """Return a :class:`Scene` built from ``text`` using ``font``.
+
+    Parameters
+    ----------
+    text:
+        Text string to render.
+    font:
+        Base :class:`Font` describing size and family. The ``character`` field is
+        ignored and each character from ``text`` is rendered individually.
+    spacing:
+        Number of blank columns inserted between characters.
+    """
+    if spacing < 0:
+        raise ValueError("spacing must be non-negative")
+    if font is None:
+        font = font_create()
+
+    char_fonts = []
+    for ch in text:
+        f = Font(
+            character=ch,
+            family=font.family,
+            size=font.size,
+            dpi=font.dpi,
+            style=font.style,
+        )
+        f.bitmap = font_bitmap_get(f)
+        char_fonts.append(f)
+
+    height = max(f.bitmap.shape[0] for f in char_fonts)
+    width = sum(f.bitmap.shape[1] for f in char_fonts) + spacing * (len(char_fonts) - 1)
+    img = np.ones((height, width, 3), dtype=float)
+
+    col = 0
+    for f in char_fonts:
+        bm = f.bitmap
+        top = (height - bm.shape[0]) // 2
+        img[top : top + bm.shape[0], col : col + bm.shape[1], :] = bm
+        col += bm.shape[1] + spacing
+
+    wave = np.arange(3)
+    scene = Scene(photons=img, wave=wave, name=text)
+    return scene
+
+
+__all__ = ["scene_from_font"]

--- a/python/tests/test_scene_from_font.py
+++ b/python/tests/test_scene_from_font.py
@@ -1,0 +1,22 @@
+from isetcam.scene import scene_from_font
+from isetcam.fonts import font_create
+from isetcam.scene import Scene
+import numpy as np
+import pytest
+
+
+def test_scene_from_font_basic():
+    f = font_create("A", size=20)
+    sc = scene_from_font("AB", f, spacing=1)
+    assert isinstance(sc, Scene)
+    assert sc.photons.ndim == 3
+    assert sc.photons.shape[2] == 3
+    # width should be larger than single character
+    sc_single = scene_from_font("A", f, spacing=1)
+    assert sc.photons.shape[1] > sc_single.photons.shape[1]
+
+
+def test_scene_from_font_invalid_spacing():
+    f = font_create("A")
+    with pytest.raises(ValueError):
+        scene_from_font("A", f, spacing=-1)


### PR DESCRIPTION
## Summary
- implement font dataclass and utility functions
- implement `scene_from_font` for rendering text into a scene
- export new functionality through package initializers
- add tests for basic scene creation from fonts

## Testing
- `PYTHONPATH=python pytest python/tests/test_scene_from_font.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_683d5997a0188323b73ad7c5ca578958