### PR TITLE
Add web image retrieval utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -171,6 +171,7 @@ from .illuminant import (
 from .ip import ip_to_file, ip_from_file, ip_plot
 from .io import openexr_read, openexr_write, pfm_read, pfm_write, dng_read, dng_write
 from .ie_scp import ie_scp
+from .web import web_flickr, web_pixabay
 
 __all__ = [
     '__version__',
@@ -332,6 +333,8 @@ __all__ = [
     'dng_read',
     'dng_write',
     'ie_scp',
+    'web_flickr',
+    'web_pixabay',
     'vc_add_and_select_object',
     'vc_get_object',
     'vc_replace_object',

--- a/python/isetcam/web/__init__.py
+++ b/python/isetcam/web/__init__.py
@@ -1,0 +1,106 @@
+"""Utilities for retrieving images from web APIs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import requests
+
+__all__ = ["web_flickr", "web_pixabay"]
+
+
+def _write_image(content: bytes, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(content)
+
+
+def web_flickr(query: str, api_key: str, n_images: int, out_dir: str | Path) -> List[str]:
+    """Download images from Flickr.
+
+    Parameters
+    ----------
+    query:
+        Search string.
+    api_key:
+        Flickr API key.
+    n_images:
+        Number of images to fetch.
+    out_dir:
+        Directory where images will be saved.
+
+    Returns
+    -------
+    list of str
+        Paths to the downloaded images.
+    """
+
+    params = {
+        "method": "flickr.photos.search",
+        "text": query,
+        "per_page": n_images,
+        "page": 1,
+        "api_key": api_key,
+        "format": "json",
+        "nojsoncallback": 1,
+        "media": "photos",
+    }
+    resp = requests.get("https://api.flickr.com/services/rest/", params=params)
+    resp.raise_for_status()
+    data = resp.json()
+    photos = data.get("photos", {}).get("photo", [])[:n_images]
+    out_paths = []
+    out_dir = Path(out_dir)
+    for idx, p in enumerate(photos):
+        url = f"https://live.staticflickr.com/{p['server']}/{p['id']}_{p['secret']}.jpg"
+        img_resp = requests.get(url)
+        img_resp.raise_for_status()
+        path = out_dir / f"flickr_{idx}.jpg"
+        _write_image(img_resp.content, path)
+        out_paths.append(str(path))
+    return out_paths
+
+
+def web_pixabay(query: str, api_key: str, n_images: int, out_dir: str | Path) -> List[str]:
+    """Download images from Pixabay.
+
+    Parameters
+    ----------
+    query:
+        Search string.
+    api_key:
+        Pixabay API key.
+    n_images:
+        Number of images to fetch.
+    out_dir:
+        Directory where images will be saved.
+
+    Returns
+    -------
+    list of str
+        Paths to the downloaded images.
+    """
+
+    params = {
+        "key": api_key,
+        "q": query,
+        "per_page": n_images,
+        "image_type": "photo",
+    }
+    resp = requests.get("https://pixabay.com/api/", params=params)
+    resp.raise_for_status()
+    data = resp.json()
+    hits = data.get("hits", [])[:n_images]
+    out_paths = []
+    out_dir = Path(out_dir)
+    for idx, h in enumerate(hits):
+        url = h.get("largeImageURL") or h.get("webformatURL")
+        if not url:
+            continue
+        img_resp = requests.get(url)
+        img_resp.raise_for_status()
+        path = out_dir / f"pixabay_{idx}.jpg"
+        _write_image(img_resp.content, path)
+        out_paths.append(str(path))
+    return out_paths

--- a/python/tests/test_web_retrieval.py
+++ b/python/tests/test_web_retrieval.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+from isetcam.web import web_flickr, web_pixabay
+
+
+class FakeResponse:
+    def __init__(self, *, json_data=None, content=b"", status=200):
+        self._json_data = json_data
+        self.content = content
+        self.status_code = status
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"status {self.status_code}")
+
+
+def test_web_flickr(mocker, tmp_path):
+    api_json = {
+        "photos": {
+            "photo": [
+                {"id": "1", "secret": "s1", "server": "srv1"},
+                {"id": "2", "secret": "s2", "server": "srv2"},
+            ]
+        }
+    }
+
+    mock_get = mocker.patch("requests.get")
+    mock_get.side_effect = [
+        FakeResponse(json_data=api_json),
+        FakeResponse(content=b"img1"),
+        FakeResponse(content=b"img2"),
+    ]
+
+    paths = web_flickr("cats", "KEY", 2, tmp_path)
+    assert mock_get.call_count == 3
+
+    # check API call parameters
+    url, kwargs = mock_get.call_args_list[0]
+    assert url[0] == "https://api.flickr.com/services/rest/"
+    assert kwargs["params"]["text"] == "cats"
+    assert len(paths) == 2
+    for idx, p in enumerate(paths):
+        assert Path(p).exists()
+        assert Path(p).read_bytes() == f"img{idx+1}".encode()
+
+
+def test_web_pixabay(mocker, tmp_path):
+    api_json = {
+        "hits": [
+            {"largeImageURL": "http://img1"},
+            {"largeImageURL": "http://img2"},
+        ]
+    }
+
+    mock_get = mocker.patch("requests.get")
+    mock_get.side_effect = [
+        FakeResponse(json_data=api_json),
+        FakeResponse(content=b"img1"),
+        FakeResponse(content=b"img2"),
+    ]
+
+    paths = web_pixabay("dogs", "KEY", 2, tmp_path)
+    assert mock_get.call_count == 3
+
+    url, kwargs = mock_get.call_args_list[0]
+    assert url[0] == "https://pixabay.com/api/"
+    assert kwargs["params"]["q"] == "dogs"
+    assert len(paths) == 2
+    for idx, p in enumerate(paths):
+        assert Path(p).exists()
+        assert Path(p).read_bytes() == f"img{idx+1}".encode()


### PR DESCRIPTION
## Summary
- add Flickr and Pixabay download helpers using `requests`
- export helpers from the main package
- add tests with mocked HTTP requests

## Testing
- `flake8 python/isetcam/web/__init__.py python/isetcam/__init__.py python/tests/test_web_retrieval.py`
- `pytest -q python/tests/test_web_retrieval.py` *(fails: unrecognized arguments `--cov=python/isetcam`)*

------
https://chatgpt.com/codex/tasks/task_e_683d59993d648323aa3a00122f78a10d