### PR TITLE
Add OI preview video writer

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -27,6 +27,7 @@ from .oi_calculate_irradiance import oi_calculate_irradiance
 from .oi_calculate_illuminance import oi_calculate_illuminance
 from .oi_show_image import oi_show_image
 from .oi_save_image import oi_save_image
+from .oi_preview_video import oi_preview_video
 from .oi_thumbnail import oi_thumbnail
 from .oi_illuminant_pattern import oi_illuminant_pattern
 from .oi_illuminant_ss import oi_illuminant_ss
@@ -66,6 +67,7 @@ __all__ = [
     "oi_show_image",
     "oi_plot",
     "oi_save_image",
+    "oi_preview_video",
     "oi_thumbnail",
     "oi_illuminant_pattern",
     "oi_illuminant_ss",

--- a/python/isetcam/opticalimage/oi_preview_video.py
+++ b/python/isetcam/opticalimage/oi_preview_video.py
@@ -1,0 +1,40 @@
+"""Encode optical images as a preview video."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import imageio.v2 as imageio
+
+from .oi_class import OpticalImage
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def oi_preview_video(
+    ois: Sequence[OpticalImage],
+    output_path: str | Path,
+    fps: int = 30,
+) -> None:
+    """Write ``ois`` to ``output_path`` as a video or GIF.
+
+    Parameters
+    ----------
+    ois:
+        Sequence of optical images to render.
+    output_path:
+        Destination video file path (e.g. ``.mp4`` or ``.gif``).
+    fps:
+        Frames per second of the output. Defaults to ``30``.
+    """
+    writer = imageio.get_writer(str(Path(output_path)), fps=int(fps))
+    try:
+        for oi in ois:
+            xyz = ie_xyz_from_photons(oi.photons, oi.wave)
+            srgb, _, _ = xyz_to_srgb(xyz)
+            arr = np.clip(srgb, 0.0, 1.0)
+            writer.append_data((arr * 255).round().astype(np.uint8))
+    finally:
+        writer.close()

--- a/python/tests/requests.py
+++ b/python/tests/requests.py
@@ -1,0 +1,2 @@
+def get(*args, **kwargs):
+    raise RuntimeError('network access disabled')

--- a/python/tests/test_oi_preview_video.py
+++ b/python/tests/test_oi_preview_video.py
@@ -1,0 +1,50 @@
+import io
+import numpy as np
+import pytest
+import imageio.v2 as imageio
+
+from isetcam.opticalimage import OpticalImage, oi_preview_video
+
+
+def _ffmpeg_available() -> bool:
+    try:
+        with imageio.get_writer(io.BytesIO(), format="ffmpeg", fps=1):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+def _gif_available() -> bool:
+    try:
+        with imageio.get_writer(io.BytesIO(), format="GIF", fps=1):
+            pass
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _ffmpeg_available(), reason="ffmpeg not available")
+def test_oi_preview_video_mp4(tmp_path):
+    wave = np.array([500, 600, 700])
+    oi1 = OpticalImage(photons=np.ones((2, 2, 3)) * 1e20, wave=wave)
+    oi2 = OpticalImage(photons=np.zeros((2, 2, 3)), wave=wave)
+    path = tmp_path / "movie.mp4"
+    oi_preview_video([oi1, oi2], path, fps=2)
+    reader = imageio.get_reader(path)
+    frames = [frame for frame in reader]
+    reader.close()
+    assert len(frames) == 2
+    assert frames[0].shape == (2, 2, 3)
+
+
+@pytest.mark.skipif(not _gif_available(), reason="GIF support not available")
+def test_oi_preview_video_gif(tmp_path):
+    wave = np.array([500, 600, 700])
+    oi1 = OpticalImage(photons=np.ones((1, 1, 3)) * 1e20, wave=wave)
+    oi2 = OpticalImage(photons=np.zeros((1, 1, 3)), wave=wave)
+    path = tmp_path / "movie.gif"
+    oi_preview_video([oi1, oi2], path, fps=5)
+    frames = imageio.mimread(path)
+    assert len(frames) == 2
+    assert frames[0].shape == (1, 1, 3)


### PR DESCRIPTION
## Summary
- implement `oi_preview_video` to save OIs as an MP4 or GIF
- expose new function in `opticalimage` package
- test MP4/GIF export with synthetic optical images
- provide a stub `requests` module for tests

## Testing
- `PYTHONPATH=python:python/tests pytest python/tests/test_oi_preview_video.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_683da45d488c832381362925c91a0f64