### PR TITLE
Implement oi_pad_value utility

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -12,6 +12,7 @@ from .oi_photon_noise import oi_photon_noise
 from .oi_to_file import oi_to_file
 from .oi_crop import oi_crop
 from .oi_pad import oi_pad
+from .oi_pad_value import oi_pad_value
 from .oi_make_even_row_col import oi_make_even_row_col
 from .oi_translate import oi_translate
 from .oi_rotate import oi_rotate
@@ -48,6 +49,7 @@ __all__ = [
     "oi_compute",
     "oi_crop",
     "oi_pad",
+    "oi_pad_value",
     "oi_make_even_row_col",
     "oi_translate",
     "oi_rotate",

--- a/python/isetcam/opticalimage/oi_pad_value.py
+++ b/python/isetcam/opticalimage/oi_pad_value.py
@@ -1,0 +1,65 @@
+"""Pad an :class:`OpticalImage` with sample spacing adjustment."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+def oi_pad_value(
+    oi: OpticalImage,
+    pad_size: int | Sequence[int],
+    value: float = 0,
+) -> OpticalImage:
+    """Pad ``oi`` on all sides and adjust ``sample_spacing``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image to pad.
+    pad_size : int or sequence of int
+        Amount of padding. If an integer, the same value is used on all
+        sides. If a sequence of two integers, the first specifies padding
+        for the top and bottom, and the second for the left and right.
+        A sequence of four integers specifies ``(top, bottom, left, right)``.
+    value : float, optional
+        Value used to fill the padded region. Defaults to 0.
+
+    Returns
+    -------
+    OpticalImage
+        Optical image padded with ``value``. The ``sample_spacing``
+        attribute is updated so that the original field of view is
+        preserved.
+    """
+
+    if isinstance(pad_size, Sequence) and not isinstance(pad_size, (int, float)):
+        pad = list(pad_size)
+        if len(pad) == 2:
+            top = bottom = int(pad[0])
+            left = right = int(pad[1])
+        elif len(pad) == 4:
+            top, bottom, left, right = [int(v) for v in pad]
+        else:
+            raise ValueError("pad_size must be a scalar or have length 2 or 4")
+    else:
+        top = bottom = left = right = int(pad_size)
+
+    pad_width = ((top, bottom), (left, right), (0, 0))
+    padded = np.pad(oi.photons, pad_width, mode="constant", constant_values=value)
+
+    out = OpticalImage(photons=padded, wave=oi.wave, name=oi.name)
+
+    old_spacing = getattr(oi, "sample_spacing", 1.0)
+    old_width_m = oi.photons.shape[1] * old_spacing
+    new_width = oi.photons.shape[1] + left + right
+    new_spacing = old_width_m / new_width
+
+    out.sample_spacing = new_spacing
+    return out
+
+
+__all__ = ["oi_pad_value"]

--- a/python/tests/test_oi_pad_value.py
+++ b/python/tests/test_oi_pad_value.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+try:  # pragma: no cover - handle missing requests dependency
+    from isetcam.opticalimage import OpticalImage, oi_pad_value
+except ModuleNotFoundError:  # pragma: no cover - fallback without requests
+    import sys
+    import types
+
+    sys.modules.setdefault("requests", types.ModuleType("requests"))
+    from isetcam.opticalimage import OpticalImage, oi_pad_value
+
+
+def _simple_oi(width: int = 3, height: int = 3, n_wave: int = 1) -> OpticalImage:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    oi = OpticalImage(photons=photons, wave=wave)
+    oi.sample_spacing = 1e-3  # 1 mm per pixel
+    return oi
+
+
+def test_oi_pad_value_scalar():
+    oi = _simple_oi(2, 2, 1)
+    out = oi_pad_value(oi, 1, value=-1)
+
+    expected = np.pad(oi.photons, ((1, 1), (1, 1), (0, 0)), constant_values=-1)
+    assert np.array_equal(out.photons, expected)
+
+    old_width = oi.photons.shape[1] * oi.sample_spacing
+    new_width = out.photons.shape[1] * out.sample_spacing
+    assert np.isclose(old_width, new_width)
+
+
+def test_oi_pad_value_tuple():
+    oi = _simple_oi(2, 2, 1)
+    out = oi_pad_value(oi, (1, 2, 3, 4), value=5)
+
+    expected = np.pad(
+        oi.photons,
+        ((1, 2), (3, 4), (0, 0)),
+        constant_values=5,
+    )
+    assert np.array_equal(out.photons, expected)
+
+    old_width = oi.photons.shape[1] * oi.sample_spacing
+    new_width = out.photons.shape[1] * out.sample_spacing
+    assert np.isclose(old_width, new_width)


### PR DESCRIPTION
## Summary
- add `oi_pad_value` to pad optical images while keeping FOV
- export new helper in `opticalimage.__init__`
- test padding value and sample-spacing update

## Testing
- `flake8 python/isetcam/opticalimage/oi_pad_value.py python/tests/test_oi_pad_value.py python/isetcam/opticalimage/__init__.py`
- `PYTHONPATH=python python -m pytest -c /dev/null python/tests/test_oi_pad_value.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683da45f34a88323b595422ab85c1958