### PR TITLE
Add optical image mask utilities

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -23,6 +23,8 @@ from .oi_frequency_resample import oi_frequency_resample
 from .oi_interpolate_w import oi_interpolate_w
 from .oi_adjust_illuminance import oi_adjust_illuminance
 from .oi_extract_waveband import oi_extract_waveband
+from .oi_extract_bright import oi_extract_bright
+from .oi_extract_mask import oi_extract_mask
 from .oi_calculate_irradiance import oi_calculate_irradiance
 from .oi_calculate_illuminance import oi_calculate_illuminance
 from .oi_show_image import oi_show_image
@@ -61,6 +63,8 @@ __all__ = [
     "oi_to_file",
     "oi_adjust_illuminance",
     "oi_extract_waveband",
+    "oi_extract_bright",
+    "oi_extract_mask",
     "oi_calculate_irradiance",
     "oi_calculate_illuminance",
     "oi_show_image",

--- a/python/isetcam/opticalimage/oi_extract_bright.py
+++ b/python/isetcam/opticalimage/oi_extract_bright.py
@@ -1,0 +1,27 @@
+"""Extract pixels above a threshold from an :class:`OpticalImage`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+def oi_extract_bright(oi: OpticalImage, threshold: float) -> OpticalImage:
+    """Return a new optical image with low photon values removed.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image to subset.
+    threshold : float
+        Photon values below this threshold are set to zero.
+
+    Returns
+    -------
+    OpticalImage
+        Optical image with photon data masked by ``threshold``.
+    """
+    photons = np.asarray(oi.photons, dtype=float)
+    masked = np.where(photons >= float(threshold), photons, 0.0)
+    return OpticalImage(photons=masked, wave=oi.wave, name=oi.name)

--- a/python/isetcam/opticalimage/oi_extract_mask.py
+++ b/python/isetcam/opticalimage/oi_extract_mask.py
@@ -1,0 +1,35 @@
+"""Extract a masked region from an :class:`OpticalImage`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+
+
+def oi_extract_mask(oi: OpticalImage, mask: np.ndarray) -> OpticalImage:
+    """Return a new optical image with photon data outside ``mask`` removed.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image to subset.
+    mask : array_like
+        Boolean array identifying pixels to keep. May be 2-D or 3-D.
+        If 2-D, the same mask is applied to all wavelength planes.
+
+    Returns
+    -------
+    OpticalImage
+        Optical image with photon data masked by ``mask``.
+    """
+    photons = np.asarray(oi.photons, dtype=float)
+    m = np.asarray(mask, dtype=bool)
+    if m.ndim == 2:
+        m = m[:, :, None]
+    try:
+        m = np.broadcast_to(m, photons.shape)
+    except ValueError:
+        raise ValueError("mask shape does not match photon data")
+    masked = np.where(m, photons, 0.0)
+    return OpticalImage(photons=masked, wave=oi.wave, name=oi.name)

--- a/python/tests/test_oi_extract_utils.py
+++ b/python/tests/test_oi_extract_utils.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+from isetcam.opticalimage import (
+    OpticalImage,
+    oi_extract_bright,
+    oi_extract_mask,
+)
+
+
+def _simple_oi(width: int = 3, height: int = 3, n_wave: int = 2) -> OpticalImage:
+    wave = np.arange(400, 400 + 10 * n_wave, 10)
+    photons = np.arange(width * height * n_wave, dtype=float).reshape(
+        (height, width, n_wave)
+    )
+    return OpticalImage(photons=photons, wave=wave)
+
+
+def test_oi_extract_bright():
+    oi = _simple_oi(2, 2, 1)
+    out = oi_extract_bright(oi, 2)
+    expected = np.where(oi.photons >= 2, oi.photons, 0)
+    assert np.array_equal(out.photons, expected)
+    assert np.array_equal(out.wave, oi.wave)
+
+
+def test_oi_extract_mask_2d():
+    oi = _simple_oi(2, 2, 2)
+    mask = np.array([[True, False], [False, True]])
+    out = oi_extract_mask(oi, mask)
+    expected = np.where(mask[:, :, None], oi.photons, 0)
+    assert np.array_equal(out.photons, expected)
+
+
+def test_oi_extract_mask_invalid():
+    oi = _simple_oi(2, 2, 1)
+    mask = np.ones((3, 3), dtype=bool)
+    with pytest.raises(ValueError):
+        oi_extract_mask(oi, mask)


### PR DESCRIPTION
## Summary
- implement `oi_extract_bright` and `oi_extract_mask`
- export via `opticalimage.__init__`
- test the new extraction helpers

## Testing
- `pytest -q` *(fails: unrecognized arguments --cov=python/isetcam)*

------
https://chatgpt.com/codex/tasks/task_e_683da45f5e408323bd93ad94de777501