### PR TITLE
Add oi_frequency_resolution helper

### DIFF
--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -19,6 +19,7 @@ from .oi_camera_motion import oi_camera_motion
 from .oi_spatial_support import oi_spatial_support
 from .oi_spatial_resample import oi_spatial_resample
 from .oi_frequency_support import oi_frequency_support
+from .oi_frequency_resolution import oi_frequency_resolution
 from .oi_frequency_resample import oi_frequency_resample
 from .oi_interpolate_w import oi_interpolate_w
 from .oi_adjust_illuminance import oi_adjust_illuminance
@@ -55,6 +56,7 @@ __all__ = [
     "oi_spatial_support",
     "oi_spatial_resample",
     "oi_frequency_support",
+    "oi_frequency_resolution",
     "oi_frequency_resample",
     "oi_interpolate_w",
     "oi_photon_noise",

--- a/python/isetcam/opticalimage/oi_frequency_resolution.py
+++ b/python/isetcam/opticalimage/oi_frequency_resolution.py
@@ -1,0 +1,96 @@
+"""Frequency resolution for :class:`OpticalImage` objects."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .oi_class import OpticalImage
+from .oi_frequency_support import _unit_frequency_list
+
+
+def _deg_per_unit(oi: OpticalImage, units: str) -> float:
+    """Return degrees per spatial unit for ``oi``."""
+    spacing = float(getattr(oi, "sample_spacing", 1.0))
+    width_m = oi.photons.shape[1] * spacing
+    wangular = getattr(oi, "wangular", None)
+    if wangular is None:
+        raise ValueError("oi must define 'wangular' field of view")
+    deg_per_meter = float(wangular) / width_m
+    u = units.lower()
+    if u in {"m", "meter", "meters"}:
+        return deg_per_meter
+    if u in {"mm", "millimeter", "millimeters"}:
+        return deg_per_meter * 1e-3
+    if u in {"um", "micron", "microns", "micrometer", "micrometers"}:
+        return deg_per_meter * 1e-6
+    raise ValueError(f"Unknown spatial unit '{units}'")
+
+
+def oi_frequency_resolution(
+    oi: OpticalImage, units: str = "cyclesPerDegree"
+) -> dict[str, np.ndarray]:
+    """Return frequency resolution of ``oi``.
+
+    Parameters
+    ----------
+    oi : OpticalImage
+        Input optical image.
+    units : str, optional
+        Output units. Supported values are "cyclesPerDegree"/"cpd",
+        "cyclesPerMeter"/"cpm", "cyclesPerMillimeter"/"mm", and
+        "cyclesPerMicron"/"um".
+
+    Returns
+    -------
+    dict
+        ``{"fx": fx, "fy": fy}`` arrays giving spatial frequency coordinates.
+    """
+    spacing = float(getattr(oi, "sample_spacing", 1.0))
+    height, width = oi.photons.shape[:2]
+
+    width_m = width * spacing
+    height_m = height * spacing
+
+    wangular = getattr(oi, "wangular", None)
+    if wangular is None:
+        raise ValueError("oi must define 'wangular' field of view")
+    wangular = float(wangular)
+
+    dist = width_m / (2.0 * np.tan(np.deg2rad(wangular) / 2.0))
+    hangular = np.degrees(2.0 * np.arctan((height_m / 2.0) / dist))
+
+    max_fx_cpd = (width / 2.0) / wangular
+    max_fy_cpd = (height / 2.0) / hangular
+
+    u = units.lower()
+    if u in {"cyclesperdegree", "cycperdeg", "cpd"}:
+        max_fx = max_fx_cpd
+        max_fy = max_fy_cpd
+    elif u in {"cyclespermeter", "cpm", "m", "meter", "meters"}:
+        scale = _deg_per_unit(oi, "m")
+        max_fx = max_fx_cpd * scale
+        max_fy = max_fy_cpd * scale
+    elif u in {"cyclespermillimeter", "mm", "millimeter", "millimeters"}:
+        scale = _deg_per_unit(oi, "mm")
+        max_fx = max_fx_cpd * scale
+        max_fy = max_fy_cpd * scale
+    elif u in {
+        "cyclespermicron",
+        "um",
+        "micron",
+        "microns",
+        "micrometer",
+        "micrometers",
+    }:
+        scale = _deg_per_unit(oi, "um")
+        max_fx = max_fx_cpd * scale
+        max_fy = max_fy_cpd * scale
+    else:
+        raise ValueError(f"Unknown frequency unit '{units}'")
+
+    fx = _unit_frequency_list(width) * max_fx
+    fy = _unit_frequency_list(height) * max_fy
+    return {"fx": fx, "fy": fy}
+
+
+__all__ = ["oi_frequency_resolution"]

--- a/python/tests/test_oi_frequency_resolution.py
+++ b/python/tests/test_oi_frequency_resolution.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from isetcam.opticalimage import (
+    OpticalImage,
+    oi_frequency_resolution,
+)
+
+
+def _simple_oi() -> OpticalImage:
+    wave = np.array([550], dtype=float)
+    photons = np.ones((4, 4, 1), dtype=float)
+    oi = OpticalImage(photons=photons, wave=wave)
+    oi.sample_spacing = 2e-3
+    oi.wangular = 10.0
+    return oi
+
+
+def _unit_frequency_list(n: int) -> np.ndarray:
+    idx = np.arange(n)
+    mid = n // 2 if n % 2 == 0 else (n - 1) // 2
+    c = idx - mid
+    if c.max() == 0:
+        return c.astype(float)
+    return c / np.max(np.abs(c))
+
+
+def test_resolution_cpd_values():
+    oi = _simple_oi()
+    res = oi_frequency_resolution(oi)
+    max_fx = (oi.photons.shape[1] / 2) / oi.wangular
+    expected_fx = _unit_frequency_list(oi.photons.shape[1]) * max_fx
+    assert np.allclose(res["fx"], expected_fx)
+    assert np.allclose(res["fy"], expected_fx)
+
+
+def test_resolution_units_mm():
+    oi = _simple_oi()
+    res_cpd = oi_frequency_resolution(oi)
+    res_mm = oi_frequency_resolution(oi, "mm")
+    scale = (oi.wangular / (oi.sample_spacing * oi.photons.shape[1])) * 1e-3
+    assert np.allclose(res_mm["fx"], res_cpd["fx"] * scale)
+    assert np.allclose(res_mm["fy"], res_cpd["fy"] * scale)


### PR DESCRIPTION
## Summary
- implement `oi_frequency_resolution` to compute frequency grid from sample spacing and field of view
- export the helper from `isetcam.opticalimage`
- add regression tests

## Testing
- `PYTHONPATH=python pytest python/tests/test_oi_frequency_resolution.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_683da460b1908323af576d728b72748c