### PR TITLE
Add optics_dof Python equivalent

### DIFF
--- a/python/isetcam/optics/__init__.py
+++ b/python/isetcam/optics/__init__.py
@@ -12,6 +12,7 @@ from .optics_otf import optics_otf
 from .optics_cos4th import optics_cos4th
 from .optics_defocused_mtf import optics_defocused_mtf, optics_defocus_core
 from .optics_coc import optics_coc
+from .optics_dof import optics_dof
 
 __all__ = [
     "Optics",
@@ -26,4 +27,5 @@ __all__ = [
     "optics_defocused_mtf",
     "optics_defocus_core",
     "optics_coc",
+    "optics_dof",
 ]

--- a/python/isetcam/optics/optics_dof.py
+++ b/python/isetcam/optics/optics_dof.py
@@ -1,0 +1,32 @@
+# mypy: ignore-errors
+"""Compute depth of field for a thin lens."""
+
+from __future__ import annotations
+
+from .optics_class import Optics
+from .optics_get import optics_get
+
+
+def optics_dof(optics: Optics, o_dist: float, coc_diam: float = 10e-6) -> float:
+    """Return depth of field in meters.
+
+    Parameters
+    ----------
+    optics : Optics
+        Lens description.
+    o_dist : float
+        Object distance from lens in meters.
+    coc_diam : float, optional
+        Acceptable circle of confusion diameter in meters. Default ``10e-6``.
+
+    Returns
+    -------
+    float
+        Depth of field corresponding to ``o_dist``.
+    """
+    if optics is None:
+        raise ValueError("optics is required")
+
+    f_num = optics_get(optics, "fnumber")
+    f_len = optics_get(optics, "focal length")
+    return 2.0 * f_num * coc_diam * (o_dist ** 2) / (f_len ** 2)

--- a/python/tests/test_optics_dof.py
+++ b/python/tests/test_optics_dof.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from isetcam.optics import Optics, optics_dof
+
+
+def test_optics_dof_basic():
+    opt = Optics(f_number=4.0, f_length=0.05)
+    o_dist = 2.0
+    coc = 20e-6
+    expected = 2.0 * opt.f_number * coc * (o_dist ** 2) / (opt.f_length ** 2)
+    out = optics_dof(opt, o_dist, coc)
+    assert np.isclose(out, expected)
+
+
+def test_optics_dof_default_coc():
+    opt = Optics(f_number=2.8, f_length=0.035)
+    o_dist = 1.5
+    expected = 2.0 * opt.f_number * 10e-6 * (o_dist ** 2) / (opt.f_length ** 2)
+    out = optics_dof(opt, o_dist)
+    assert np.isclose(out, expected)


### PR DESCRIPTION
## Summary
- port `opticalimage/optics/opticsDoF.m` to Python
- expose new `optics_dof` through the optics package
- test DOF calculations

## Testing
- `pytest -q python/tests/test_optics_dof.py -o addopts=`
- `pytest -q -o addopts=` *(fails: iso_speed_saturation tests & web retrieval failures)*

------
https://chatgpt.com/codex/tasks/task_e_683da9bcfc908323ac4f2ccbeacadd1a