### PR TITLE
Add optics_clear_data utility

### DIFF
--- a/python/isetcam/optics/__init__.py
+++ b/python/isetcam/optics/__init__.py
@@ -12,6 +12,7 @@ from .optics_otf import optics_otf
 from .optics_cos4th import optics_cos4th
 from .optics_defocused_mtf import optics_defocused_mtf, optics_defocus_core
 from .optics_coc import optics_coc
+from .optics_clear_data import optics_clear_data
 
 __all__ = [
     "Optics",
@@ -26,4 +27,5 @@ __all__ = [
     "optics_defocused_mtf",
     "optics_defocus_core",
     "optics_coc",
+    "optics_clear_data",
 ]

--- a/python/isetcam/optics/optics_clear_data.py
+++ b/python/isetcam/optics/optics_clear_data.py
@@ -1,0 +1,35 @@
+# mypy: ignore-errors
+"""Utility to remove optional attributes from an Optics."""
+
+from __future__ import annotations
+
+from .optics_class import Optics
+
+# Attributes that may be attached to Optics instances by various helpers
+# or user interfaces. These are removed by :func:`optics_clear_data`.
+_OPTIONAL_ATTRS = [
+    "otf_data",
+    "cos4th_data",
+]
+
+
+def optics_clear_data(optics: Optics) -> Optics:
+    """Remove cached or optional attributes from ``optics``.
+
+    Parameters
+    ----------
+    optics : Optics
+        Optics object to clean.
+
+    Returns
+    -------
+    Optics
+        The same ``optics`` instance with extraneous attributes removed.
+    """
+    for attr in _OPTIONAL_ATTRS:
+        if hasattr(optics, attr):
+            delattr(optics, attr)
+    return optics
+
+
+__all__ = ["optics_clear_data"]

--- a/python/tests/test_optics_clear_data.py
+++ b/python/tests/test_optics_clear_data.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+from isetcam.optics import Optics, optics_clear_data
+
+
+def _simple_optics() -> Optics:
+    wave = np.array([500, 510])
+    return Optics(f_number=4.0, f_length=0.005, wave=wave)
+
+
+def test_optics_clear_data_removes_fields():
+    opt = _simple_optics()
+    opt.otf_data = np.ones((2, 2), dtype=float)
+    opt.cos4th_data = np.ones(5, dtype=float)
+
+    out = optics_clear_data(opt)
+    assert out is opt
+    for fld in ["otf_data", "cos4th_data"]:
+        assert not hasattr(out, fld)
+
+
+def test_optics_clear_data_no_fields():
+    opt = _simple_optics()
+    out = optics_clear_data(opt)
+    assert out is opt
+    assert np.isclose(out.f_number, opt.f_number)
+    assert np.isclose(out.f_length, opt.f_length)
+    assert np.array_equal(out.wave, opt.wave)
+    assert np.allclose(out.transmittance, opt.transmittance)


### PR DESCRIPTION
## Summary
- add `optics_clear_data` helper to drop optional fields
- export the new helper in `isetcam.optics`
- test removal behaviour for optics

## Testing
- `PYTHONPATH=python pytest python/tests/test_optics_clear_data.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_683da9c02c808323963456432864354e