### PR TITLE
Add human_cone_plot visualization

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -135,6 +135,7 @@ from .human import (
     human_cone_isolating,
     human_cones,
     human_cone_mosaic,
+    human_cone_plot,
     watson_impulse_response,
     watson_rgc_spacing,
 )
@@ -293,6 +294,7 @@ __all__ = [
     'human_cone_isolating',
     'human_cones',
     'human_cone_mosaic',
+    'human_cone_plot',
     'watson_impulse_response',
     'watson_rgc_spacing',
     'iset_root_path',

--- a/python/isetcam/human/__init__.py
+++ b/python/isetcam/human/__init__.py
@@ -16,6 +16,7 @@ from .human_cone_contrast import human_cone_contrast
 from .human_cone_isolating import human_cone_isolating
 from .human_cones import human_cones
 from .human_cone_mosaic import human_cone_mosaic
+from .human_cone_plot import human_cone_plot
 from .human_oi import human_oi
 from .human_uv_safety import human_uv_safety
 from .watson_impulse_response import watson_impulse_response
@@ -38,6 +39,7 @@ __all__ = [
     'human_cone_isolating',
     'human_cones',
     'human_cone_mosaic',
+    'human_cone_plot',
     'human_oi',
     'human_uv_safety',
     'watson_impulse_response',

--- a/python/isetcam/human/human_cone_plot.py
+++ b/python/isetcam/human/human_cone_plot.py
@@ -1,0 +1,96 @@
+# mypy: ignore-errors
+"""Visualize a cone mosaic using a gaussian blurred RGB image."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import gaussian_filter
+
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+
+def human_cone_plot(
+    positions: np.ndarray,
+    cone_types: np.ndarray,
+    support: tuple[int, int] | None = None,
+    spread: float | None = None,
+    delta: float = 0.4,
+    ax: "plt.Axes | None" = None,
+) -> "plt.Axes":
+    """Return axis with gaussian blurred cone mosaic image.
+
+    Parameters
+    ----------
+    positions : np.ndarray
+        ``(N, 2)`` array of cone ``x``/``y`` coordinates in microns.
+    cone_types : np.ndarray
+        Integer array of cone types using ``1`` for empty, ``2`` for L,
+        ``3`` for M and ``4`` for S cones.  May have shape ``(N,)`` or the
+        original mosaic shape.
+    support : tuple[int, int], optional
+        Kernel size used for the gaussian blur.  When ``None`` the kernel
+        size is ``(round(3 * spread), round(3 * spread))``.
+    spread : float, optional
+        Standard deviation in pixels of the gaussian blur.  When ``None``
+        it is estimated from the grid spacing of the mosaic.
+    delta : float, optional
+        Spatial sampling for mapping positions to pixels in microns.
+        Defaults to ``0.4`` which mimics the MATLAB implementation.
+    ax : matplotlib.axes.Axes, optional
+        Axis to draw into.  When ``None`` a new figure and axis are created.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        Axis containing the plotted cone mosaic.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for human_cone_plot")
+
+    positions = np.asarray(positions, dtype=float)
+    cone_types = np.asarray(cone_types)
+    if cone_types.ndim > 1:
+        cone_types = cone_types.ravel()
+    if positions.shape[0] != cone_types.size:
+        raise ValueError("positions and cone_types must have compatible sizes")
+
+    x = positions[:, 0]
+    y = positions[:, 1]
+    x0 = x.min()
+    y0 = y.min()
+    col = np.round((x - x0) / delta).astype(int)
+    row = np.round((y - y0) / delta).astype(int)
+    n_rows = row.max() + 1
+    n_cols = col.max() + 1
+
+    grid = np.zeros((n_rows, n_cols), dtype=int)
+    grid[row, col] = cone_types
+
+    if spread is None:
+        first_row = np.where(grid[0, :] > 0)[0]
+        if first_row.size >= 2:
+            spread = (first_row[1] - first_row[0]) / 3.0
+        else:
+            spread = 1.0
+    if support is None:
+        s = int(round(3 * spread))
+        support = (s, s)
+
+    cone_image = np.zeros((n_rows, n_cols, 3), dtype=float)
+    cone_image[grid == 2, 0] = 1.0
+    cone_image[grid == 3, 1] = 1.0
+    cone_image[grid == 4, 2] = 1.0
+
+    sigma = spread
+    blurred = np.empty_like(cone_image)
+    for c in range(3):
+        blurred[:, :, c] = gaussian_filter(cone_image[:, :, c], sigma=sigma)
+
+    if ax is None:
+        _, ax = plt.subplots()
+    ax.imshow(blurred)
+    ax.axis("off")
+    return ax

--- a/python/tests/test_human_cone_plot.py
+++ b/python/tests/test_human_cone_plot.py
@@ -1,0 +1,10 @@
+import matplotlib
+matplotlib.use("Agg")
+
+from isetcam.human import human_cone_mosaic, human_cone_plot
+
+
+def test_human_cone_plot_runs():
+    xy, cone_type, _, _ = human_cone_mosaic((5, 5), r_seed=1)
+    ax = human_cone_plot(xy, cone_type)
+    assert ax is not None


### PR DESCRIPTION
## Summary
- add `human_cone_plot` for displaying Gaussian blurred cone mosaics
- export the function in `isetcam.human`
- test that `human_cone_plot` runs

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_human_cone_plot.py -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_683da9c3b06c83239995034cd357eb29