### PR TITLE
Implement WebLOC wrapper

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -183,7 +183,7 @@ from .ip import ip_to_file, ip_from_file, ip_plot
 from .io import openexr_read, openexr_write, pfm_read, pfm_write, dng_read, dng_write
 from .animated_gif import animated_gif
 from .ie_scp import ie_scp
-from .web import web_flickr, web_pixabay
+from .web import web_flickr, web_pixabay, WebLOC
 
 __all__ = [
     '__version__',
@@ -350,6 +350,7 @@ __all__ = [
     'ie_scp',
     'web_flickr',
     'web_pixabay',
+    'WebLOC',
     'vc_add_and_select_object',
     'vc_get_object',
     'vc_replace_object',

--- a/python/isetcam/web/__init__.py
+++ b/python/isetcam/web/__init__.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List
 
+from .web_loc import WebLOC
+
 import requests
 
-__all__ = ["web_flickr", "web_pixabay"]
+__all__ = ["web_flickr", "web_pixabay", "WebLOC"]
 
 
 def _write_image(content: bytes, path: Path) -> None:

--- a/python/isetcam/web/web_loc.py
+++ b/python/isetcam/web/web_loc.py
@@ -1,0 +1,72 @@
+# mypy: ignore-errors
+"""Utilities for retrieving images from the Library of Congress API."""
+
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+import requests
+
+
+class WebLOC:
+    """Simple wrapper around the LOC pictures search API."""
+
+    def __init__(self) -> None:
+        self.search_url = "https://loc.gov/pictures/search/"
+        self.default_per_page = 20
+        self.tag_mode = "all"
+        self.sort = "date_desc"
+
+    def search(self, tags: str) -> List[Dict[str, Any]]:
+        """Search LOC for images matching *tags*.
+
+        Parameters
+        ----------
+        tags:
+            Comma separated keywords.
+        Returns
+        -------
+        list of dict
+            Filtered results returned by the API.
+        """
+        search_padding = 3
+        per_page = self.default_per_page
+        query = tags.replace(",", "+")
+        params = {
+            "fo": "json",
+            "q": query,
+            "c": per_page * search_padding,
+        }
+        resp = requests.get(self.search_url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        results = data.get("results", [])
+        return self.filter_results(results)
+
+    def filter_results(self, list_results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Remove results that do not provide digitized images."""
+        not_digitized = "item not digitized thumbnail"
+        filtered: List[Dict[str, Any]] = []
+        for r in list_results:
+            image = r.get("image", {})
+            if image.get("alt") == not_digitized:
+                continue
+            filtered.append(r)
+        return filtered
+
+    def get_image_url(self, photo: Dict[str, Any], size: str) -> str:
+        """Return the image URL for *photo* of the given *size*."""
+        if size == "thumbnail":
+            url = photo["image"]["thumb"]
+        else:
+            url = photo["image"]["full"]
+        if url.startswith("//"):
+            url = "https:" + url
+        return url
+
+    def get_image(self, photo: Dict[str, Any], size: str) -> bytes:
+        """Download image bytes for *photo* of the given *size*."""
+        url = self.get_image_url(photo, size)
+        resp = requests.get(url)
+        resp.raise_for_status()
+        return resp.content

--- a/python/tests/test_web_loc.py
+++ b/python/tests/test_web_loc.py
@@ -1,0 +1,43 @@
+from isetcam.web import WebLOC
+
+
+class FakeResponse:
+    def __init__(self, *, json_data=None, content=b"", status=200):
+        self._json_data = json_data
+        self.content = content
+        self.status_code = status
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"status {self.status_code}")
+
+
+def test_search_filters_results(mocker):
+    api_json = {
+        "results": [
+            {"image": {"thumb": "//t1", "full": "//f1", "alt": "thumb"}},
+            {"image": {"thumb": "//t2", "full": "//f2", "alt": "item not digitized thumbnail"}},
+        ]
+    }
+
+    mock_get = mocker.patch("requests.get", return_value=FakeResponse(json_data=api_json))
+    loc = WebLOC()
+    results = loc.search("cat,dog")
+    assert mock_get.call_count == 1
+    url, kwargs = mock_get.call_args
+    assert url[0] == loc.search_url
+    assert kwargs["params"]["q"] == "cat+dog"
+    assert len(results) == 1
+
+
+def test_get_image_uses_https_and_returns_bytes(mocker):
+    mock_get = mocker.patch("requests.get", return_value=FakeResponse(content=b"img"))
+    loc = WebLOC()
+    photo = {"image": {"thumb": "//thumb", "full": "//full"}}
+    data = loc.get_image(photo, "thumbnail")
+    assert mock_get.call_count == 1
+    assert mock_get.call_args[0][0] == "https://thumb"
+    assert data == b"img"


### PR DESCRIPTION
## Summary
- port Library of Congress utility to python as `WebLOC`
- expose `WebLOC` in the web package and at package root
- provide unit tests for `WebLOC`

## Testing
- `pytest -q` *(fails: pytest-cov missing)*

------
https://chatgpt.com/codex/tasks/task_e_683da9c4e474832386135cffe409a48a