### PR TITLE
Add metrics_camera dispatcher and tests

### DIFF
--- a/python/isetcam/metrics/__init__.py
+++ b/python/isetcam/metrics/__init__.py
@@ -14,6 +14,7 @@ from .iso_acutance import iso_acutance
 from .iso12233_sfr import iso12233_sfr
 from .iso_speed_saturation import iso_speed_saturation
 from .metrics_compute import metrics_compute
+from .metrics_camera import metrics_camera
 
 __all__ = [
     "ie_psnr",
@@ -31,4 +32,5 @@ __all__ = [
     "iso12233_sfr",
     "iso_speed_saturation",
     "metrics_compute",
+    "metrics_camera",
 ]

--- a/python/isetcam/metrics/metrics_camera.py
+++ b/python/isetcam/metrics/metrics_camera.py
@@ -1,0 +1,60 @@
+# mypy: ignore-errors
+"""Compute camera metrics by name."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ..camera import (
+    Camera,
+    camera_color_accuracy,
+    camera_mtf,
+    camera_full_reference,
+    camera_moire,
+    camera_vsnr_sl,
+    camera_acutance,
+)
+from ..ie_param_format import ie_param_format
+
+
+_METRIC_FUNCS: dict[str, Callable[..., Any]] = {
+    "mcccolor": camera_color_accuracy,
+    "slantededge": camera_mtf,
+    "fullreference": camera_full_reference,
+    "moire": camera_moire,
+    "vsnr": camera_vsnr_sl,
+    "acutance": camera_acutance,
+}
+
+
+def metrics_camera(camera: Camera, metric_name: str, *args: Any, **kwargs: Any) -> Any:
+    """Return a camera metric specified by ``metric_name``.
+
+    Parameters
+    ----------
+    camera : :class:`~isetcam.camera.Camera`
+        Camera object to evaluate.
+    metric_name : str
+        Name identifying which metric to compute.
+    *args, **kwargs : Any
+        Additional parameters forwarded to the specific metric function.
+
+    Returns
+    -------
+    Any
+        Result produced by the selected metric function.
+    """
+    if camera is None:
+        raise ValueError("camera is required")
+    if not metric_name:
+        raise ValueError("metric_name must be defined")
+
+    key = ie_param_format(metric_name)
+    func = _METRIC_FUNCS.get(key)
+    if func is None:
+        raise ValueError(f"Unknown metric '{metric_name}'")
+    return func(camera, *args, **kwargs)
+
+
+__all__ = ["metrics_camera"]
+

--- a/python/tests/test_metrics_camera.py
+++ b/python/tests/test_metrics_camera.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+
+from isetcam.camera import (
+    camera_create,
+    camera_color_accuracy,
+    camera_mtf,
+    camera_moire,
+    camera_vsnr_sl,
+    camera_full_reference,
+)
+from isetcam.camera.camera_vsnr_sl import VSNRSLResult
+from isetcam.scene import Scene
+from isetcam.metrics import metrics_camera
+
+
+def _gray_scene(w: int = 4, h: int = 4, n_wave: int = 3) -> Scene:
+    wave = np.arange(500, 500 + 10 * n_wave, 10)
+    photons = np.ones((h, w, n_wave), dtype=float)
+    return Scene(photons=photons, wave=wave)
+
+
+def test_metrics_camera_mcccolor():
+    cam1 = camera_create()
+    cam2 = camera_create()
+    metric = metrics_camera(cam1, "mcccolor", lum=20, patch_size=4)
+    expected = camera_color_accuracy(cam2, lum=20, patch_size=4)
+    assert np.allclose(metric[0]["deltaE"], expected[0]["deltaE"])
+    assert metric[1] is cam1
+
+
+def test_metrics_camera_slantededge():
+    cam1 = camera_create()
+    cam2 = camera_create()
+    freqs, mtf = metrics_camera(cam1, "slantededge")
+    efreqs, emtf = camera_mtf(cam2)
+    assert np.allclose(freqs, efreqs)
+    assert np.allclose(mtf, emtf)
+
+
+def test_metrics_camera_moire():
+    cam1 = camera_create()
+    cam2 = camera_create()
+    pattern, returned = metrics_camera(cam1, "moire", size=16)
+    expected_pattern, _ = camera_moire(cam2, size=16)
+    assert returned is cam1
+    assert np.allclose(pattern, expected_pattern)
+
+
+def test_metrics_camera_vsnr():
+    cam1 = camera_create()
+    cam2 = camera_create()
+    levels = [1.0, 2.0]
+    res = metrics_camera(cam1, "vsnr", mean_luminances=levels)
+    expected = camera_vsnr_sl(cam2, levels)
+    assert isinstance(res, VSNRSLResult)
+    assert np.allclose(res.vsnr, expected.vsnr)
+
+
+def test_metrics_camera_fullreference():
+    cam1 = camera_create()
+    cam2 = camera_create()
+    sc = _gray_scene()
+    res = metrics_camera(cam1, "fullreference", scene=sc)
+    expected = camera_full_reference(cam2, sc)
+    assert np.allclose(res["deltaE"], expected["deltaE"])
+
+
+def test_metrics_camera_unknown():
+    cam = camera_create()
+    with pytest.raises(ValueError):
+        metrics_camera(cam, "unknown")


### PR DESCRIPTION
## Summary
- add `metrics_camera` to select camera metrics by name
- expose the new function from the metrics package
- test `metrics_camera` with several metric types

## Testing
- `PYTHONPATH=python pytest -q -o addopts="" python/tests/test_metrics_camera.py`

------
https://chatgpt.com/codex/tasks/task_e_683da9c8342483238fd9c16c0d1d9ef2