### PR TITLE
Add multispectral image IO utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -181,7 +181,16 @@ from .illuminant import (
 )
 from .fonts import font_create, font_get, font_set, font_bitmap_get
 from .ip import ip_to_file, ip_from_file, ip_plot
-from .io import openexr_read, openexr_write, pfm_read, pfm_write, dng_read, dng_write
+from .io import (
+    openexr_read,
+    openexr_write,
+    pfm_read,
+    pfm_write,
+    dng_read,
+    dng_write,
+    ie_save_multispectral_image,
+    ie_load_multispectral_image,
+)
 from .animated_gif import animated_gif
 from .ie_scp import ie_scp
 from .web import web_flickr, web_pixabay, WebLOC
@@ -348,6 +357,8 @@ __all__ = [
     'pfm_write',
     'dng_read',
     'dng_write',
+    'ie_save_multispectral_image',
+    'ie_load_multispectral_image',
     'animated_gif',
     'ie_scp',
     'web_flickr',

--- a/python/isetcam/io/__init__.py
+++ b/python/isetcam/io/__init__.py
@@ -7,5 +7,16 @@ from .pfm_read import pfm_read
 from .dng_read import dng_read
 from .dng_write import dng_write
 from .pfm_write import pfm_write
+from .ie_save_multispectral_image import ie_save_multispectral_image
+from .ie_load_multispectral_image import ie_load_multispectral_image
 
-__all__ = ["openexr_read", "openexr_write", "pfm_read", "pfm_write", "dng_read", "dng_write"]
+__all__ = [
+    "openexr_read",
+    "openexr_write",
+    "pfm_read",
+    "pfm_write",
+    "dng_read",
+    "dng_write",
+    "ie_save_multispectral_image",
+    "ie_load_multispectral_image",
+]

--- a/python/isetcam/io/ie_load_multispectral_image.py
+++ b/python/isetcam/io/ie_load_multispectral_image.py
@@ -1,0 +1,39 @@
+# mypy: ignore-errors
+"""Load multispectral image data saved by :func:`ie_save_multispectral_image`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+from scipy.io import loadmat
+
+
+def ie_load_multispectral_image(path: str | Path) -> Dict[str, Any]:
+    """Load ``path`` and return a dictionary of multispectral image data."""
+    mat = loadmat(str(Path(path)), squeeze_me=True, struct_as_record=False)
+    data: Dict[str, Any] = {}
+    if "coefficients" in mat:
+        data["coefficients"] = np.asarray(mat["coefficients"])
+    if "basis" in mat:
+        data["basis"] = np.asarray(mat["basis"])
+    if "comment" in mat:
+        value = mat["comment"]
+        if isinstance(value, np.ndarray):
+            value = str(value.squeeze())
+        data["comment"] = value
+    if "img_mean" in mat:
+        data["img_mean"] = np.asarray(mat["img_mean"])
+    if "illuminant" in mat:
+        data["illuminant"] = mat["illuminant"]
+    if "fov" in mat:
+        data["fov"] = float(mat["fov"])
+    if "distance" in mat:
+        data["distance"] = float(mat["distance"])
+    if "name" in mat:
+        value = mat["name"]
+        if isinstance(value, np.ndarray):
+            value = str(value.squeeze())
+        data["name"] = value
+    return data

--- a/python/isetcam/io/ie_save_multispectral_image.py
+++ b/python/isetcam/io/ie_save_multispectral_image.py
@@ -1,0 +1,65 @@
+# mypy: ignore-errors
+"""Save multispectral image data to MATLAB MAT-files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from scipy.io import savemat
+
+
+def ie_save_multispectral_image(
+    path: str | Path,
+    coefficients: np.ndarray,
+    basis: np.ndarray,
+    *,
+    comment: str | None = None,
+    img_mean: np.ndarray | None = None,
+    illuminant: Any | None = None,
+    fov: float | None = None,
+    distance: float | None = None,
+    name: str | None = None,
+) -> None:
+    """Save multispectral image data to ``path``.
+
+    Parameters
+    ----------
+    path:
+        Destination file.
+    coefficients:
+        Coefficient array describing each pixel.
+    basis:
+        Basis matrix with spectra in rows.
+    comment:
+        Optional text description.
+    img_mean:
+        Mean spectrum used when computing the coefficients.
+    illuminant:
+        Illuminant information.
+    fov:
+        Field of view in degrees.
+    distance:
+        Distance to the scene in meters.
+    name:
+        Optional scene name.
+    """
+    data: dict[str, Any] = {
+        "coefficients": np.asarray(coefficients, dtype=float),
+        "basis": np.asarray(basis, dtype=float),
+    }
+    if comment is not None:
+        data["comment"] = str(comment)
+    if img_mean is not None:
+        data["img_mean"] = np.asarray(img_mean, dtype=float)
+    if illuminant is not None:
+        data["illuminant"] = illuminant
+    if fov is not None:
+        data["fov"] = float(fov)
+    if distance is not None:
+        data["distance"] = float(distance)
+    if name is not None:
+        data["name"] = str(name)
+
+    savemat(str(Path(path)), data)

--- a/python/tests/test_multispectral_io.py
+++ b/python/tests/test_multispectral_io.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from isetcam.io import ie_save_multispectral_image, ie_load_multispectral_image
+
+
+def test_multispectral_roundtrip(tmp_path):
+    coefficients = np.random.rand(2, 3, 4).astype(np.float32)
+    basis = np.random.rand(5, 4).astype(np.float32)
+    comment = "demo"
+    img_mean = np.random.rand(5).astype(np.float32)
+    illuminant = np.random.rand(5).astype(np.float32)
+    fov = 12.5
+    distance = 1.0
+    name = "cube"
+
+    path = tmp_path / "cube.mat"
+    ie_save_multispectral_image(
+        path,
+        coefficients,
+        basis,
+        comment=comment,
+        img_mean=img_mean,
+        illuminant=illuminant,
+        fov=fov,
+        distance=distance,
+        name=name,
+    )
+
+    loaded = ie_load_multispectral_image(path)
+    assert np.allclose(loaded["coefficients"], coefficients)
+    assert np.allclose(loaded["basis"], basis)
+    assert loaded["comment"] == comment
+    assert np.allclose(loaded["img_mean"], img_mean)
+    assert np.allclose(loaded["illuminant"], illuminant)
+    assert loaded["fov"] == fov
+    assert loaded["distance"] == distance
+    assert loaded["name"] == name


### PR DESCRIPTION
## Summary
- add `ie_save_multispectral_image`/`ie_load_multispectral_image` for MAT files
- expose the new functions in package init files
- test multispectral image roundtrip

## Testing
- `PYTHONPATH=python pytest -q -o addopts='' python/tests/test_multispectral_io.py`
- `flake8` *(fails: numerous existing style errors)*
- `mypy python/isetcam/io/ie_save_multispectral_image.py python/isetcam/io/ie_load_multispectral_image.py` *(fails: existing type errors in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_683e1560e1708323ac852ad37a906e0b