### PR TITLE
Implement vc object copy and rename

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -54,6 +54,8 @@ from .vc_set_objects import vc_set_objects
 from .vc_set_selected_object import vc_set_selected_object
 from .vc_new_object_name import vc_new_object_name
 from .vc_new_object_value import vc_new_object_value
+from .vc_copy_object import vc_copy_object
+from .vc_rename_object import vc_rename_object
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 from .xyz_to_lab import xyz_to_lab
@@ -367,6 +369,8 @@ __all__ = [
     'vc_set_selected_object',
     'vc_new_object_name',
     'vc_new_object_value',
+    'vc_copy_object',
+    'vc_rename_object',
     'font_create',
     'font_get',
     'font_set',

--- a/python/isetcam/vc_copy_object.py
+++ b/python/isetcam/vc_copy_object.py
@@ -1,0 +1,45 @@
+# mypy: ignore-errors
+"""Copy an object entry from ``vcSESSION``."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+import copy
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_copy_object(obj_type: str, index: Optional[int] = None) -> int:
+    """Duplicate an object stored in ``vcSESSION``.
+
+    Parameters
+    ----------
+    obj_type : str
+        Type of object to copy.
+    index : int, optional
+        1-based index of the object to copy.  When omitted the currently
+        selected object is duplicated.
+
+    Returns
+    -------
+    int
+        The index of the newly inserted copy.
+    """
+    field = _norm_objtype(obj_type)
+
+    if index is None:
+        index = vcSESSION.get("SELECTED", {}).get(field)
+        if index is None:
+            raise IndexError("No selected object to copy")
+
+    lst = vcSESSION.get(field)
+    if not lst or index <= 0 or index >= len(lst):
+        raise IndexError("Index out of range")
+
+    obj = lst[index]
+    copied = copy.deepcopy(obj)
+    lst.append(copied)
+    new_idx = len(lst) - 1
+    vcSESSION[field] = lst
+    return new_idx

--- a/python/isetcam/vc_rename_object.py
+++ b/python/isetcam/vc_rename_object.py
@@ -1,0 +1,39 @@
+# mypy: ignore-errors
+"""Rename an object stored in ``vcSESSION``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .ie_init_session import vcSESSION
+from .vc_add_and_select_object import _norm_objtype
+
+
+def vc_rename_object(obj_type: str, new_name: str, index: Optional[int] = None) -> None:
+    """Change the ``name`` attribute for a stored object.
+
+    Parameters
+    ----------
+    obj_type : str
+        Type of the object to rename.
+    new_name : str
+        The new name to assign.
+    index : int, optional
+        1-based index of the object.  When omitted the currently selected
+        object is renamed.
+    """
+    field = _norm_objtype(obj_type)
+
+    if index is None:
+        index = vcSESSION.get("SELECTED", {}).get(field)
+        if index is None:
+            raise IndexError("No selected object to rename")
+
+    lst = vcSESSION.get(field)
+    if not lst or index <= 0 or index >= len(lst):
+        raise IndexError("Index out of range")
+
+    obj = lst[index]
+    if not hasattr(obj, "name"):
+        raise AttributeError("Object has no name attribute")
+    setattr(obj, "name", new_name)

--- a/python/tests/test_vc_object_management.py
+++ b/python/tests/test_vc_object_management.py
@@ -16,6 +16,8 @@ from isetcam import (
     vc_set_selected_object,
     vc_new_object_name,
     vc_new_object_value,
+    vc_copy_object,
+    vc_rename_object,
 )
 from isetcam.scene import Scene
 from isetcam.opticalimage import OpticalImage
@@ -159,4 +161,29 @@ def test_vc_new_object_helpers():
 
     vals = vc_new_object_value("camera")
     assert isinstance(vals, tuple) and len(vals) == 3
+
+
+def test_vc_copy_object():
+    ie_init()
+    sc = Scene(photons=np.zeros((1, 1, 1)), name="orig")
+    idx = vc_add_and_select_object("scene", sc)
+
+    new_idx = vc_copy_object("scene")
+    assert vcSESSION["SCENE"][idx] is sc
+    assert vcSESSION["SCENE"][new_idx] is not sc
+    assert vcSESSION["SELECTED"]["SCENE"] == idx
+    assert vc_count_objects("scene") == 2
+
+
+def test_vc_rename_object():
+    ie_init()
+    sc = Scene(photons=np.zeros((1, 1, 1)), name="orig")
+    idx = vc_add_and_select_object("scene", sc)
+
+    vc_rename_object("scene", "newname")
+    assert sc.name == "newname"
+
+    idx2 = vc_copy_object("scene")
+    vc_rename_object("scene", "copy", index=idx2)
+    assert vcSESSION["SCENE"][idx2].name == "copy"
 


### PR DESCRIPTION
## Summary
- add vc_copy_object/vc_rename_object utilities
- export the new functions in the package
- test copying and renaming of vc objects

## Testing
- `PYTHONPATH=$PWD/python pytest -o addopts='' python/tests/test_vc_object_management.py::test_vc_copy_object python/tests/test_vc_object_management.py::test_vc_rename_object -q`

------
https://chatgpt.com/codex/tasks/task_e_683e1564cce88323a906e337880b2f08