### PR TITLE
Add ROI conversion utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -54,6 +54,8 @@ from .vc_set_objects import vc_set_objects
 from .vc_set_selected_object import vc_set_selected_object
 from .vc_new_object_name import vc_new_object_name
 from .vc_new_object_value import vc_new_object_value
+from .vc_rect_to_locs import vc_rect_to_locs
+from .vc_locs_to_rect import vc_locs_to_rect
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 from .xyz_to_lab import xyz_to_lab
@@ -367,6 +369,8 @@ __all__ = [
     'vc_set_selected_object',
     'vc_new_object_name',
     'vc_new_object_value',
+    'vc_rect_to_locs',
+    'vc_locs_to_rect',
     'font_create',
     'font_get',
     'font_set',

--- a/python/isetcam/vc_locs_to_rect.py
+++ b/python/isetcam/vc_locs_to_rect.py
@@ -1,0 +1,48 @@
+# mypy: ignore-errors
+"""Convert row/column indices to a rectangle."""
+
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import numpy as np
+
+
+def vc_locs_to_rect(locs: Sequence[np.ndarray] | np.ndarray) -> Tuple[int, int, int, int]:
+    """Return ``(x, y, width, height)`` from index arrays.
+
+    Parameters
+    ----------
+    locs : tuple of array-like or Nx2 array
+        Row and column indices describing the region. If a tuple is provided it
+        should be ``(rows, cols)`` as returned by :func:`vc_rect_to_locs`. An
+        ``(N, 2)`` array of points is also accepted.
+
+    Returns
+    -------
+    tuple of int
+        ``(x, y, width, height)`` describing the bounding rectangle.
+    """
+    if isinstance(locs, (tuple, list)):
+        if len(locs) != 2:
+            raise ValueError("locs must be a tuple of (rows, cols)")
+        rows = np.asarray(locs[0], dtype=int).reshape(-1)
+        cols = np.asarray(locs[1], dtype=int).reshape(-1)
+    else:
+        arr = np.asarray(locs, dtype=int)
+        if arr.ndim != 2 or arr.shape[1] != 2:
+            raise ValueError("locs must be (rows, cols) or Nx2 array")
+        rows = arr[:, 0]
+        cols = arr[:, 1]
+
+    if rows.size == 0 or cols.size == 0:
+        raise ValueError("locs must contain at least one point")
+
+    y0 = int(rows.min())
+    x0 = int(cols.min())
+    h = int(rows.max() - y0 + 1)
+    w = int(cols.max() - x0 + 1)
+    return (x0, y0, w, h)
+
+
+__all__ = ["vc_locs_to_rect"]

--- a/python/isetcam/vc_rect_to_locs.py
+++ b/python/isetcam/vc_rect_to_locs.py
@@ -1,0 +1,36 @@
+# mypy: ignore-errors
+"""Convert a rectangle ROI to row/column index arrays."""
+
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import numpy as np
+
+
+def vc_rect_to_locs(rect: Sequence[int]) -> Tuple[np.ndarray, np.ndarray]:
+    """Return index arrays corresponding to ``rect``.
+
+    Parameters
+    ----------
+    rect : sequence of int
+        Rectangle given as ``(x, y, width, height)`` using 0-based indexing.
+
+    Returns
+    -------
+    tuple of np.ndarray
+        ``(rows, cols)`` arrays selecting the rectangle.
+    """
+    if len(rect) != 4:
+        raise ValueError("rect must have four elements (x, y, width, height)")
+
+    x, y, w, h = [int(v) for v in rect]
+    if w <= 0 or h <= 0:
+        raise ValueError("width and height must be positive")
+
+    rows = np.arange(y, y + h, dtype=int)
+    cols = np.arange(x, x + w, dtype=int)
+    return rows, cols
+
+
+__all__ = ["vc_rect_to_locs"]

--- a/python/tests/test_vc_roi_conversion.py
+++ b/python/tests/test_vc_roi_conversion.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from isetcam import vc_rect_to_locs, vc_locs_to_rect
+
+
+def test_roundtrip_rect_locs():
+    rect = (2, 1, 3, 2)
+    rows, cols = vc_rect_to_locs(rect)
+    out = vc_locs_to_rect((rows, cols))
+    assert out == rect
+
+
+def test_locs_array_input():
+    rect = (0, 0, 2, 3)
+    rows, cols = vc_rect_to_locs(rect)
+    locs = np.array([(r, c) for r in rows for c in cols])
+    out = vc_locs_to_rect(locs)
+    assert out == rect
+
+
+def test_invalid_inputs():
+    with np.testing.assert_raises(ValueError):
+        vc_rect_to_locs((1, 2, 0, 1))
+    with np.testing.assert_raises(ValueError):
+        vc_locs_to_rect(np.empty((0, 2)))


### PR DESCRIPTION
## Summary
- implement `vc_rect_to_locs` and `vc_locs_to_rect`
- expose them from package
- test round‑trip conversions

## Testing
- `PYTHONPATH=python pytest -q -c /dev/null python/tests/test_vc_roi_conversion.py`

------
https://chatgpt.com/codex/tasks/task_e_683e156853a08323a564f6fdc38b4443