### PR TITLE
Implement sensor pixel coordinate and jiggle

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -43,6 +43,8 @@ from .sensor_replace_filter import sensor_replace_filter
 from .sensor_set_size_to_fov import sensor_set_size_to_fov
 from .sensor_wb_compute import sensor_wb_compute
 from .sensor_vignetting import sensor_vignetting
+from .sensor_pixel_coord import sensor_pixel_coord
+from .sensor_jiggle import sensor_jiggle
 
 
 def get_volts(sensor: Sensor) -> np.ndarray:
@@ -110,4 +112,6 @@ __all__ = [
     "sensor_set_size_to_fov",
     "sensor_wb_compute",
     "sensor_vignetting",
+    "sensor_pixel_coord",
+    "sensor_jiggle",
 ]

--- a/python/isetcam/sensor/sensor_jiggle.py
+++ b/python/isetcam/sensor/sensor_jiggle.py
@@ -1,0 +1,58 @@
+# mypy: ignore-errors
+"""Shift sensor voltage data by integer pixel offsets."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .sensor_class import Sensor
+
+
+def sensor_jiggle(sensor: Sensor, dx: int, dy: int, fill: float = 0) -> Sensor:
+    """Return ``sensor`` shifted by ``dx`` and ``dy`` pixels.
+
+    Positive ``dx`` values move the image to the right and positive ``dy``
+    values move it down.  Areas exposed by the shift are filled with
+    ``fill``.  The jiggle offsets are accumulated on the returned sensor
+    using the ``jiggle_dx`` and ``jiggle_dy`` attributes so that
+    :func:`sensor_pixel_coord` reflects the new pixel positions.
+    """
+
+    volts = np.asarray(sensor.volts)
+    h, w = volts.shape[:2]
+    shifted = np.full_like(volts, fill, dtype=volts.dtype)
+
+    if abs(dx) < w and abs(dy) < h:
+        if dx >= 0:
+            src_x = slice(0, w - dx)
+            dst_x = slice(dx, dx + (w - dx))
+        else:
+            src_x = slice(-dx, w)
+            dst_x = slice(0, w + dx)
+
+        if dy >= 0:
+            src_y = slice(0, h - dy)
+            dst_y = slice(dy, dy + (h - dy))
+        else:
+            src_y = slice(-dy, h)
+            dst_y = slice(0, h + dy)
+
+        shifted[dst_y, dst_x, ...] = volts[src_y, src_x, ...]
+
+    out = Sensor(
+        volts=shifted,
+        wave=sensor.wave,
+        exposure_time=sensor.exposure_time,
+        name=sensor.name,
+    )
+
+    for attr in ("pixel_size", "filter_color_letters", "n_colors"):
+        if hasattr(sensor, attr):
+            setattr(out, attr, getattr(sensor, attr))
+
+    out.jiggle_dx = getattr(sensor, "jiggle_dx", 0) + int(dx)
+    out.jiggle_dy = getattr(sensor, "jiggle_dy", 0) + int(dy)
+    return out
+
+
+__all__ = ["sensor_jiggle"]

--- a/python/isetcam/sensor/sensor_pixel_coord.py
+++ b/python/isetcam/sensor/sensor_pixel_coord.py
@@ -1,0 +1,37 @@
+# mypy: ignore-errors
+"""Return pixel center coordinates for a :class:`Sensor`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .sensor_class import Sensor
+
+
+def sensor_pixel_coord(sensor: Sensor) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(x, y)`` coordinate arrays for pixel centers.
+
+    The coordinates are measured relative to the sensor centre.  When
+    ``sensor`` has ``pixel_size`` defined the coordinates are returned in
+    metres, otherwise they are in pixel units.  Any accumulated jiggle
+    offsets stored on ``sensor`` are applied.
+    """
+
+    rows, cols = sensor.volts.shape[:2]
+    pixel_size = float(getattr(sensor, "pixel_size", 1.0))
+    cx = (cols - 1) / 2.0
+    cy = (rows - 1) / 2.0
+
+    x = (np.arange(cols) - cx) * pixel_size
+    y = (np.arange(rows) - cy) * pixel_size
+
+    X, Y = np.meshgrid(x, y)
+
+    dx = float(getattr(sensor, "jiggle_dx", 0)) * pixel_size
+    dy = float(getattr(sensor, "jiggle_dy", 0)) * pixel_size
+    X += dx
+    Y += dy
+    return X, Y
+
+
+__all__ = ["sensor_pixel_coord"]

--- a/python/tests/test_sensor_jiggle.py
+++ b/python/tests/test_sensor_jiggle.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from isetcam.sensor import Sensor, sensor_jiggle, sensor_pixel_coord
+
+
+def _simple_sensor(width: int = 3, height: int = 3) -> Sensor:
+    volts = np.arange(width * height, dtype=float).reshape(height, width)
+    s = Sensor(volts=volts, wave=np.array([500]), exposure_time=0.01)
+    s.pixel_size = 1.0
+    return s
+
+
+def _shift(arr: np.ndarray, dx: int, dy: int, fill: float = 0) -> np.ndarray:
+    h, w = arr.shape[:2]
+    out = np.full_like(arr, fill)
+    if abs(dx) < w and abs(dy) < h:
+        if dx >= 0:
+            src_x = slice(0, w - dx)
+            dst_x = slice(dx, dx + (w - dx))
+        else:
+            src_x = slice(-dx, w)
+            dst_x = slice(0, w + dx)
+
+        if dy >= 0:
+            src_y = slice(0, h - dy)
+            dst_y = slice(dy, dy + (h - dy))
+        else:
+            src_y = slice(-dy, h)
+            dst_y = slice(0, h + dy)
+
+        out[dst_y, dst_x, ...] = arr[src_y, src_x, ...]
+    return out
+
+
+def test_sensor_jiggle_offsets_and_alignment():
+    s = _simple_sensor(3, 3)
+    dx, dy = 1, -1
+    out = sensor_jiggle(s, dx, dy)
+
+    expected = _shift(s.volts, dx, dy, fill=0)
+    assert np.array_equal(out.volts, expected)
+
+    x0, y0 = sensor_pixel_coord(s)
+    x1, y1 = sensor_pixel_coord(out)
+    assert np.allclose(x1, x0 + dx * s.pixel_size)
+    assert np.allclose(y1, y0 + dy * s.pixel_size)
+
+
+def test_sensor_jiggle_outside():
+    s = _simple_sensor(2, 2)
+    out = sensor_jiggle(s, 5, 0, fill=-1)
+    assert np.array_equal(out.volts, np.full_like(s.volts, -1))


### PR DESCRIPTION
## Summary
- add `sensor_pixel_coord` for pixel center coordinates
- add `sensor_jiggle` to translate sensor voltages and update pixel offsets
- export new helpers in `isetcam.sensor`
- test jiggled image alignment and coordinate offsets

## Testing
- `flake8 python/isetcam/sensor/sensor_pixel_coord.py python/isetcam/sensor/sensor_jiggle.py python/isetcam/sensor/__init__.py python/tests/test_sensor_jiggle.py`
- `PYTHONPATH=python pytest -q -c /dev/null python/tests/test_sensor_jiggle.py`

------
https://chatgpt.com/codex/tasks/task_e_683e2373b22883238d9bc4454ea1e7b3