### PR TITLE
Add ip_demosaic wrapper

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -187,7 +187,7 @@ from .illuminant import (
     illuminant_list,
 )
 from .fonts import font_create, font_get, font_set, font_bitmap_get
-from .ip import ip_to_file, ip_from_file, ip_plot
+from .ip import ip_to_file, ip_from_file, ip_plot, ip_demosaic
 from .io import (
     openexr_read,
     openexr_write,
@@ -363,6 +363,7 @@ __all__ = [
     'ip_to_file',
     'ip_from_file',
     'ip_plot',
+    'ip_demosaic',
     'openexr_read',
     'openexr_write',
     'pfm_read',

--- a/python/isetcam/ip/__init__.py
+++ b/python/isetcam/ip/__init__.py
@@ -11,6 +11,7 @@ from .ip_from_file import ip_from_file
 from .ip_plot import ip_plot
 from .ip_clear_data import ip_clear_data
 from .ip_hdr_white import ip_hdr_white
+from .ip_demosaic import ip_demosaic
 
 __all__ = [
     "VCImage",
@@ -23,4 +24,5 @@ __all__ = [
     "ip_plot",
     "ip_clear_data",
     "ip_hdr_white",
+    "ip_demosaic",
 ]

--- a/python/isetcam/ip/ip_demosaic.py
+++ b/python/isetcam/ip/ip_demosaic.py
@@ -1,0 +1,54 @@
+# mypy: ignore-errors
+"""Convenience wrapper for basic demosaicing algorithms."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..imgproc import (
+    ie_nearest_neighbor,
+    ie_bilinear,
+    adaptive_laplacian,
+    pocs,
+)
+
+
+def ip_demosaic(
+    bayer: np.ndarray,
+    pattern: str = "rggb",
+    method: str = "bilinear",
+) -> np.ndarray:
+    """Demosaic a Bayer-pattern image using ``method``.
+
+    Parameters
+    ----------
+    bayer : np.ndarray
+        2-D array containing the raw mosaic image.
+    pattern : str, optional
+        CFA pattern string such as ``"rggb"``. Defaults to ``"rggb"``.
+    method : str, optional
+        Demosaicing method. One of ``'nearest'``, ``'bilinear'``,
+        ``'adaptive'`` (adaptive Laplacian) or ``'pocs'``.
+        Defaults to ``'bilinear'``.
+
+    Returns
+    -------
+    np.ndarray
+        RGB image with shape ``(rows, cols, 3)``.
+    """
+    funcs = {
+        "nearest": ie_nearest_neighbor,
+        "nearest_neighbor": ie_nearest_neighbor,
+        "bilinear": ie_bilinear,
+        "adaptive": adaptive_laplacian,
+        "adaptive_laplacian": adaptive_laplacian,
+        "laplacian": adaptive_laplacian,
+        "pocs": pocs,
+    }
+    key = method.lower()
+    if key not in funcs:
+        raise ValueError("Unknown demosaic method")
+    return funcs[key](bayer, pattern)
+
+
+__all__ = ["ip_demosaic"]

--- a/python/tests/test_ip_demosaic.py
+++ b/python/tests/test_ip_demosaic.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from isetcam.ip import ip_demosaic
+
+
+def test_ip_demosaic_default_bilinear():
+    bayer = np.array([[1, 2], [3, 4]], dtype=float)
+    expected = np.array(
+        [
+            [[1, 2.5, 4], [1, 2, 4]],
+            [[1, 3, 4], [1, 2.5, 4]],
+        ],
+        dtype=float,
+    )
+    out = ip_demosaic(bayer, "rggb")
+    assert np.allclose(out, expected)
+
+
+def test_ip_demosaic_nearest():
+    bayer = np.array([[1, 2], [3, 4]], dtype=float)
+    expected = np.array(
+        [
+            [[1, 2, 4], [1, 2, 4]],
+            [[1, 3, 4], [1, 3, 4]],
+        ],
+        dtype=float,
+    )
+    out = ip_demosaic(bayer, "rggb", method="nearest")
+    assert np.array_equal(out, expected)
+
+
+def test_ip_demosaic_shapes():
+    bayer = np.arange(16, dtype=float).reshape(4, 4)
+    for method in ["bilinear", "nearest", "adaptive", "pocs"]:
+        out = ip_demosaic(bayer, "rggb", method=method)
+        assert out.shape == (4, 4, 3)


### PR DESCRIPTION
## Summary
- wrap demosaicing algorithms in `ip_demosaic`
- export through `ip` and `isetcam` packages
- test ip_demosaic functionality

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_ip_demosaic.py -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_683e2647c2548323aa893083582ad36f