### PR TITLE
Add slanted bar scene

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -184,7 +184,8 @@ from .camera import (
 )
 from .optics import optics_to_file, optics_from_file
 from .scene import scene_plot
-from .scene import scene_from_font
+from .scene import scene_from_font, scene_slanted_bar
+from .scene.imgtargets import img_slanted_bar
 from .illuminant import (
     illuminant_to_file,
     illuminant_from_file,
@@ -412,6 +413,8 @@ __all__ = [
     'font_set',
     'font_bitmap_get',
     'scene_from_font',
+    'img_slanted_bar',
+    'scene_slanted_bar',
     'hc_basis',
     'hc_blur',
     'hc_illuminant_scale',

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -48,6 +48,7 @@ from .scene_depth_range import scene_depth_range
 from .scene_list import scene_list
 from .scene_make_video import scene_make_video
 from .scene_dead_leaves import scene_dead_leaves
+from .scene_slanted_bar import scene_slanted_bar
 from .scene_wb_create import scene_wb_create
 from .scene_plot import scene_plot
 from .scene_description import scene_description
@@ -106,6 +107,7 @@ __all__ = [
     "scene_depth_range",
     "scene_list",
     "scene_dead_leaves",
+    "scene_slanted_bar",
     "scene_wb_create",
     "scene_description",
     "scene_clear_data",

--- a/python/isetcam/scene/imgtargets/__init__.py
+++ b/python/isetcam/scene/imgtargets/__init__.py
@@ -1,4 +1,5 @@
 # mypy: ignore-errors
 from .img_dead_leaves import img_dead_leaves
+from .img_slanted_bar import img_slanted_bar
 
-__all__ = ["img_dead_leaves"]
+__all__ = ["img_dead_leaves", "img_slanted_bar"]

--- a/python/isetcam/scene/imgtargets/img_slanted_bar.py
+++ b/python/isetcam/scene/imgtargets/img_slanted_bar.py
@@ -1,0 +1,29 @@
+# mypy: ignore-errors
+"""Generate a binary slanted bar pattern image."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def img_slanted_bar(im_size: int = 384, bar_slope: float = 2.6) -> np.ndarray:
+    """Return a binary slanted bar image.
+
+    Parameters
+    ----------
+    im_size : int, optional
+        Approximate size of the square image in pixels. The actual
+        output dimensions are ``2 * round(im_size / 2) + 1``.
+    bar_slope : float, optional
+        Slope of the separating line ``y = bar_slope * x``. Pixels with
+        ``y`` greater than the line are set to ``1``.
+    """
+    half = int(round(im_size / 2))
+    rng = np.arange(-half, half + 1)
+    X, Y = np.meshgrid(rng, rng)
+    img = (Y > bar_slope * X).astype(float)
+    img = np.clip(img, 1e-6, 1.0)
+    return img
+
+
+__all__ = ["img_slanted_bar"]

--- a/python/isetcam/scene/scene_slanted_bar.py
+++ b/python/isetcam/scene/scene_slanted_bar.py
@@ -1,0 +1,49 @@
+# mypy: ignore-errors
+"""Create a slanted bar test scene."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+from ..energy_to_quanta import energy_to_quanta
+from .imgtargets.img_slanted_bar import img_slanted_bar
+
+_DEF_WAVE = np.arange(400, 701, 10, dtype=float)
+
+
+def scene_slanted_bar(
+    im_size: int = 384,
+    bar_slope: float = 2.6,
+    field_of_view: float = 2.0,
+    wave: np.ndarray | None = None,
+) -> Scene:
+    """Return a slanted bar scene used for resolution testing.
+
+    Parameters
+    ----------
+    im_size : int, optional
+        Approximate size of the square image in pixels. Defaults to ``384``.
+    bar_slope : float, optional
+        Slope of the separating line ``y = bar_slope * x``. Defaults to ``2.6``.
+    field_of_view : float, optional
+        Horizontal field of view of the scene in degrees. Defaults to ``2``.
+    wave : array-like, optional
+        Wavelength samples in nanometers. Defaults to ``400:10:700``.
+    """
+    if wave is None:
+        wave = _DEF_WAVE
+    else:
+        wave = np.asarray(wave, dtype=float)
+
+    pattern = img_slanted_bar(im_size=im_size, bar_slope=bar_slope)
+    ill_photons = energy_to_quanta(wave, np.ones_like(wave)).ravel()
+    photons = pattern[:, :, None] * ill_photons[None, None, :]
+
+    sc = Scene(photons=photons, wave=wave, name="slantedBar")
+    sc.fov = float(field_of_view)
+    sc.illuminant = ill_photons
+    return sc
+
+
+__all__ = ["scene_slanted_bar"]

--- a/python/tests/test_scene_slanted_bar.py
+++ b/python/tests/test_scene_slanted_bar.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from isetcam.scene import scene_slanted_bar
+from isetcam.scene.imgtargets import img_slanted_bar
+from isetcam.energy_to_quanta import energy_to_quanta
+
+
+def _estimate_slope(photons: np.ndarray, ill_val: float) -> float:
+    h = (photons.shape[0] - 1) // 2
+    xs, ys = [], []
+    for j, x in enumerate(range(-h, h + 1)):
+        col = photons[:, j, 0]
+        if np.any(col == ill_val) and np.any(col == ill_val * 1e-6):
+            idx = np.argmax(col == ill_val)
+            xs.append(x)
+            ys.append(idx - h)
+    if len(xs) < 2:
+        return float("nan")
+    return float(np.polyfit(xs, ys, 1)[0])
+
+
+def test_img_slanted_bar_size():
+    img = img_slanted_bar(im_size=32)
+    assert img.shape == (33, 33)
+    assert img.max() == 1.0
+    assert img.min() >= 1e-6
+
+
+def test_scene_slanted_bar_properties():
+    slope = 2.6
+    sc = scene_slanted_bar(im_size=32, bar_slope=slope, field_of_view=3)
+    h = (sc.photons.shape[0] - 1) // 2
+    assert sc.photons.shape[:2] == (2 * h + 1, 2 * h + 1)
+    assert sc.photons.shape[2] == sc.wave.size
+    assert sc.fov == 3
+
+    ill = energy_to_quanta(sc.wave, np.ones_like(sc.wave)).ravel()
+    col = h
+    assert np.allclose(sc.photons[h + 1, col, :], ill)
+    assert np.allclose(sc.photons[h - 1, col, :], ill * 1e-6)
+
+    est = _estimate_slope(sc.photons, ill[0])
+    assert np.isclose(est, slope, rtol=0.02)


### PR DESCRIPTION
## Summary
- port MATLAB `sceneSlantedBar` to Python as `scene_slanted_bar`
- generate slanted bar pattern via `img_slanted_bar`
- expose new utilities in package exports
- test slanted bar creation

## Testing
- `pytest -q python/tests/test_scene_slanted_bar.py -o addopts=''`
- `pytest -q -o addopts=''` *(fails: iso_speed_saturation tests; web access)*

------
https://chatgpt.com/codex/tasks/task_e_683e2ee989b8832381757b445c3f0617