### PR TITLE
Add CIE whiteness metric

### DIFF
--- a/python/isetcam/metrics/__init__.py
+++ b/python/isetcam/metrics/__init__.py
@@ -15,6 +15,7 @@ from .iso12233_sfr import iso12233_sfr
 from .iso_speed_saturation import iso_speed_saturation
 from .metrics_compute import metrics_compute
 from .metrics_camera import metrics_camera
+from .cie_whiteness import cie_whiteness
 
 __all__ = [
     "ie_psnr",
@@ -31,6 +32,7 @@ __all__ = [
     "iso_acutance",
     "iso12233_sfr",
     "iso_speed_saturation",
+    "cie_whiteness",
     "metrics_compute",
     "metrics_camera",
 ]

--- a/python/isetcam/metrics/cie_whiteness.py
+++ b/python/isetcam/metrics/cie_whiteness.py
@@ -1,0 +1,107 @@
+# mypy: ignore-errors
+"""CIE 2004 whiteness index."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Sequence
+from scipy.io import loadmat
+
+from ..ie_xyz_from_energy import ie_xyz_from_energy
+from ..chromaticity import chromaticity
+from ..data_path import data_path
+
+
+def _load_illuminant(name: str, wave: np.ndarray) -> np.ndarray:
+    """Load illuminant SPD interpolated to ``wave``."""
+    mat = loadmat(data_path(f"lights/{name}.mat"))
+    src_wave = mat["wavelength"].ravel()
+    spd = np.interp(wave, src_wave, mat["data"].ravel(), left=0.0, right=0.0)
+    return spd
+
+
+def _broadcast_spd(spd: np.ndarray, shape: Sequence[int]) -> np.ndarray:
+    return spd.reshape((1,) * (len(shape) - 1) + (-1,))
+
+
+def cie_whiteness(
+    xyz: np.ndarray | None = None,
+    *,
+    reflectance: np.ndarray | None = None,
+    wavelength: np.ndarray | None = None,
+    illuminant: str | np.ndarray = "D65",
+) -> np.ndarray:
+    """Return the CIE 2004 whiteness index.
+
+    Parameters
+    ----------
+    xyz : np.ndarray, optional
+        CIE XYZ values with the last dimension of length 3.
+    reflectance : np.ndarray, optional
+        Reflectance spectra with wavelength along the final dimension.
+    wavelength : np.ndarray, optional
+        Wavelength sampling corresponding to ``reflectance`` when provided.
+    illuminant : str or np.ndarray, optional
+        Illuminant spectral power distribution. When a string, the SPD is
+        loaded from ``isetcam.data/lights``. Defaults to ``"D65"``.
+
+    Returns
+    -------
+    np.ndarray
+        Whiteness index with the same spatial dimensions as ``xyz`` or
+        ``reflectance``.
+    """
+    squeeze = False
+    if xyz is None:
+        if reflectance is None or wavelength is None:
+            raise ValueError("xyz or reflectance+wavelength required")
+        wave = np.asarray(wavelength).reshape(-1)
+        refl = np.asarray(reflectance, dtype=float)
+        if isinstance(illuminant, str):
+            ill = _load_illuminant(illuminant, wave)
+        else:
+            ill = np.asarray(illuminant, dtype=float)
+            if ill.shape != wave.shape:
+                raise ValueError("illuminant must match wavelength length")
+        energy = refl * _broadcast_spd(ill, refl.shape)
+        xyz = ie_xyz_from_energy(energy, wave)
+        white_xyz = ie_xyz_from_energy(ill.reshape(1, -1), wave)[0]
+        x_n, y_n = chromaticity(white_xyz.reshape(1, 3))[0]
+        Y = 100 * xyz[..., 1] / white_xyz[1]
+    else:
+        xyz = np.asarray(xyz, dtype=float)
+        if xyz.ndim == 1:
+            xyz = xyz.reshape(1, 3)
+            squeeze = True
+        else:
+            squeeze = False
+        if isinstance(illuminant, str):
+            mat = loadmat(data_path(f"lights/{illuminant}.mat"))
+            wave = mat["wavelength"].ravel()
+            ill = mat["data"].ravel()
+            white_xyz = ie_xyz_from_energy(ill.reshape(1, -1), wave)[0]
+            x_n, y_n = chromaticity(white_xyz.reshape(1, 3))[0]
+            Y = xyz[..., 1]
+        elif wavelength is not None and np.iterable(illuminant):
+            ill = np.asarray(illuminant, dtype=float)
+            wave = np.asarray(wavelength).reshape(-1)
+            if ill.shape != wave.shape:
+                raise ValueError("illuminant must match wavelength length")
+            white_xyz = ie_xyz_from_energy(ill.reshape(1, -1), wave)[0]
+            x_n, y_n = chromaticity(white_xyz.reshape(1, 3))[0]
+            Y = xyz[..., 1]
+        else:
+            x_n, y_n = 0.3127, 0.3290
+            Y = xyz[..., 1]
+        if squeeze:
+            xyz = xyz.reshape(1, 3)
+    xy = chromaticity(xyz)
+    x = xy[..., 0]
+    y = xy[..., 1]
+    W = Y + 800 * (x_n - x) + 1700 * (y_n - y)
+    if squeeze:
+        return float(W[0])
+    return W
+
+
+__all__ = ["cie_whiteness"]

--- a/python/tests/test_cie_whiteness.py
+++ b/python/tests/test_cie_whiteness.py
@@ -1,0 +1,40 @@
+import numpy as np
+from isetcam.metrics import cie_whiteness
+
+
+def test_cie_whiteness_xyz_known():
+    Y = 95.0
+    x = 0.31
+    y = 0.33
+    X = Y * x / y
+    Z = Y * (1 - x - y) / y
+    xyz = np.array([X, Y, Z])
+    xn = 0.312740384797229
+    yn = 0.3290629143489663
+    expected = Y + 800 * (xn - x) + 1700 * (yn - y)
+    val = cie_whiteness(xyz)
+    assert np.isclose(float(val), expected, atol=1e-6)
+
+
+def test_cie_whiteness_reflectance_perfect_white():
+    import scipy.io
+    from isetcam.data_path import data_path
+
+    mat = scipy.io.loadmat(data_path("lights/D65.mat"))
+    wave = mat["wavelength"].ravel()
+    ill = mat["data"].ravel()
+    refl = np.ones_like(ill)
+    W = cie_whiteness(reflectance=refl, wavelength=wave, illuminant=ill)
+    assert np.isclose(W.item(), 100.0)
+
+
+def test_cie_whiteness_reflectance_scaled_white():
+    import scipy.io
+    from isetcam.data_path import data_path
+
+    mat = scipy.io.loadmat(data_path("lights/D65.mat"))
+    wave = mat["wavelength"].ravel()
+    ill = mat["data"].ravel()
+    refl = np.full_like(ill, 0.8)
+    W = cie_whiteness(reflectance=refl, wavelength=wave, illuminant=ill)
+    assert np.isclose(W.item(), 80.0)


### PR DESCRIPTION
## Summary
- compute CIE 2004 whiteness index for XYZ or reflectance input
- export new metric in metrics package
- test against known spectra

## Testing
- `mypy python/isetcam/metrics/cie_whiteness.py` *(fails: ModuleNotFoundError: requests)*
- `PYTHONPATH=$PWD/python pytest -q -p no:pytest_cov -c /dev/null python/tests/test_cie_whiteness.py`

------
https://chatgpt.com/codex/tasks/task_e_683e2ef8f0d0832386a38165bc981a19