### PR TITLE
Add CLI pipeline command

### DIFF
--- a/python/tests/test_cli_pipeline.py
+++ b/python/tests/test_cli_pipeline.py
@@ -1,0 +1,12 @@
+from isetcam.cli import main
+from isetcam.camera import camera_from_file, Camera
+
+
+def test_cli_pipeline(tmp_path):
+    out = tmp_path / "cam.mat"
+    rc = main(["pipeline", "--scene", "grid lines", "--output", str(out)])
+    assert rc == 0
+    cam = camera_from_file(out)
+    assert isinstance(cam, Camera)
+    assert cam.sensor.volts.size > 0
+    assert cam.optical_image.photons.size > 0


### PR DESCRIPTION
## Summary
- add a `pipeline` subcommand to `isetcam` CLI
- implement processing with scene creation, optical image and sensor computation, and save camera output
- test new command via `test_cli_pipeline`

## Testing
- `PYTHONPATH=$PWD/python pytest -q python/tests/test_cli_pipeline.py --override-ini addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_683e2f07b8588323aa4e5f8eff7d1c0f