### PR TITLE
Add basic pipeline notebook with nbval tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,9 +26,11 @@ jobs:
             python/pyproject.toml
             python/requirements.txt
       - name: Install package
-        run: pip install -e "python[tests]" flake8 mypy pytest-cov
+        run: pip install -e "python[tests]" flake8 mypy pytest-cov nbval
       - name: Run tests
         run: pytest --cov=python/isetcam --cov-report=xml -q
+      - name: Run notebook
+        run: pytest --nbval notebooks/basic_pipeline.ipynb -q
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -78,6 +78,12 @@ pytest -q
 Running these tests verifies that the initialization routines and helper
 functions behave as expected.
 
+## Basic Pipeline Notebook
+
+A short Jupyter notebook demonstrates constructing a scene, computing an optical image, simulating a sensor and rendering the result.
+See [notebooks/basic_pipeline.ipynb](../notebooks/basic_pipeline.ipynb) for the full workflow.
+
+
 ## Flake8 Workflow
 
 The GitHub workflow `.github/workflows/python-tests.yml` installs
@@ -615,6 +621,12 @@ xy = chromaticity(xyz)
 
 Remember to run the Python unit tests via `pytest` after installing the
 environment to ensure these functions behave as expected.
+
+## Basic Pipeline Notebook
+
+A short Jupyter notebook demonstrates constructing a scene, computing an optical image, simulating a sensor and rendering the result.
+See [notebooks/basic_pipeline.ipynb](../notebooks/basic_pipeline.ipynb) for the full workflow.
+
 
 After working with these modules you can rerun the unit tests using:
 
@@ -1240,6 +1252,12 @@ print(f"PSNR: {score:.2f} dB")
 ```
 
 As always, run `pytest -q` to confirm these functions behave as expected.
+
+## Basic Pipeline Notebook
+
+A short Jupyter notebook demonstrates constructing a scene, computing an optical image, simulating a sensor and rendering the result.
+See [notebooks/basic_pipeline.ipynb](../notebooks/basic_pipeline.ipynb) for the full workflow.
+
 
 ## Structural Similarity (SSIM)
 

--- a/notebooks/basic_pipeline.ipynb
+++ b/notebooks/basic_pipeline.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Basic pipeline\nThis demo creates a scene, computes an optical image, simulates a sensor and renders the result."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from isetcam.scene import scene_create\n",
+    "from isetcam.optics import optics_create\n",
+    "from isetcam.opticalimage import oi_compute\n",
+    "from isetcam.sensor import sensor_create, sensor_compute\n",
+    "from isetcam.display import display_create\n",
+    "from isetcam.ip import ip_compute, ip_plot\n",
+    "\n",
+    "scene = scene_create('macbeth d65', patch_size=16)\n",
+    "optics = optics_create()\n",
+    "oi = oi_compute(scene, optics)\n",
+    "sensor = sensor_create()\n",
+    "sensor = sensor_compute(sensor, oi)\n",
+    "display = display_create()\n",
+    "ip = ip_compute(sensor, display)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "ax = ip_plot(ip, 'image')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,7 @@ imageio = "*"
 scikit-image = "*"
 
 [project.optional-dependencies]
-tests = ["pytest", "coverage"]
+tests = ["pytest", "coverage", "nbval"]
 rawpy = ["rawpy"]
 OpenEXR = ["OpenEXR"]
 


### PR DESCRIPTION
## Summary
- add `notebooks/basic_pipeline.ipynb`
- reference notebook in documentation
- run notebook with nbval in CI
- include nbval in test extras

## Testing
- `pytest --nbval notebooks/basic_pipeline.ipynb -q` *(fails: unrecognized arguments because plugins are missing)*

------
https://chatgpt.com/codex/tasks/task_e_683e2f15b22483238d9e7b2809bcfce7