### PR TITLE
Add Bayer pattern option to sensor_create

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -2,7 +2,9 @@
 """Sensor-related functions.
 
 The :func:`sensor_vignetting` helper now accepts ``pv_flag='microlens'`` or the
-numeric values ``1``-``3`` to emulate different microlens configurations.
+numeric values ``1``-``3`` to emulate different microlens configurations.  The
+:func:`sensor_create` helper also understands Bayer pattern strings such as
+``"bayer (rggb)"`` or ``"bayer (gbrg)"``.
 """
 
 from __future__ import annotations
@@ -18,7 +20,7 @@ from .sensor_photon_noise import sensor_photon_noise
 from .sensor_add_noise import sensor_add_noise
 from .sensor_to_file import sensor_to_file
 from .sensor_to_exr import sensor_to_exr
-from .sensor_create import sensor_create
+from .sensor_create import sensor_create, parse_bayer_pattern, BAYER_PATTERN_MAP
 from .sensor_snr import sensor_snr
 from .sensor_snr_luxsec import sensor_snr_luxsec
 from .sensor_crop import sensor_crop
@@ -88,6 +90,8 @@ __all__ = [
     "sensor_to_file",
     "sensor_to_exr",
     "sensor_create",
+    "parse_bayer_pattern",
+    "BAYER_PATTERN_MAP",
     "sensor_crop",
     "sensor_roi",
     "sensor_snr",

--- a/python/isetcam/sensor/sensor_create.py
+++ b/python/isetcam/sensor/sensor_create.py
@@ -3,11 +3,41 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Tuple
+
+import re
 
 import numpy as np
 
 from .sensor_class import Sensor
+
+# Mapping from Bayer pattern name to (filter_color_letters, n_colors)
+BAYER_PATTERN_MAP = {
+    "grbg": ("grbg", 3),
+    "rggb": ("rggb", 3),
+    "bggr": ("bggr", 3),
+    "gbrg": ("gbrg", 3),
+}
+
+
+def parse_bayer_pattern(kind: str) -> Tuple[str, int]:
+    """Return CFA letters and number of colors for ``kind``.
+
+    Parameters
+    ----------
+    kind:
+        String describing the sensor type, e.g. ``"bayer"`` or
+        ``"bayer (rggb)"``.
+    """
+
+    flag = kind.lower().replace(" ", "")
+    m = re.match(r"bayer(?:[-(]?([a-z]+)[)]?)?$", flag)
+    if not m:
+        raise ValueError(f"Unknown sensor type '{kind}'")
+    pattern = m.group(1) or "grbg"
+    if pattern not in BAYER_PATTERN_MAP:
+        raise ValueError(f"Unknown Bayer pattern '{pattern}'")
+    return BAYER_PATTERN_MAP[pattern]
 
 _DEF_PIXEL_SIZE = 2.8e-6  # meters
 _DEF_EXPOSURE = 0.01  # seconds
@@ -19,13 +49,12 @@ def sensor_create(kind: str = "bayer", wave: Optional[np.ndarray] = None) -> Sen
     Parameters
     ----------
     kind:
-        Type of sensor to create. Only ``'bayer'`` is currently supported.
+        Type of sensor to create. ``"bayer"`` optionally followed by a
+        CFA pattern (e.g. ``"bayer (rggb)"``) is supported.
     wave:
         Optional wavelength sampling for the sensor's spectral properties.
     """
-    flag = kind.lower().replace(" ", "")
-    if flag != "bayer":
-        raise ValueError(f"Unknown sensor type '{kind}'")
+    letters, n_colors = parse_bayer_pattern(kind)
 
     volts = np.zeros((1, 1), dtype=float)
     s = Sensor(volts=volts, exposure_time=_DEF_EXPOSURE, wave=wave, name=kind)
@@ -33,4 +62,6 @@ def sensor_create(kind: str = "bayer", wave: Optional[np.ndarray] = None) -> Sen
     # Default quantum efficiency and pixel size information
     s.qe = np.ones(s.wave.size, dtype=float)
     s.pixel_size = float(_DEF_PIXEL_SIZE)
+    s.filter_color_letters = letters
+    s.n_colors = n_colors
     return s

--- a/python/tests/test_sensor_create.py
+++ b/python/tests/test_sensor_create.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from isetcam.sensor import sensor_create, Sensor
 
@@ -10,6 +11,8 @@ def test_sensor_create_default():
     assert hasattr(s, "qe")
     assert hasattr(s, "pixel_size")
     assert s.qe.size == s.wave.size
+    assert s.filter_color_letters == "grbg"
+    assert s.n_colors == 3
 
 
 def test_sensor_create_custom_wave():
@@ -17,3 +20,18 @@ def test_sensor_create_custom_wave():
     s = sensor_create(wave=wave)
     assert np.array_equal(s.wave, wave)
     assert s.qe.size == wave.size
+
+
+@pytest.mark.parametrize(
+    "kind,letters",
+    [
+        ("bayer (gbrg)", "gbrg"),
+        ("bayer (rggb)", "rggb"),
+        ("bayer (bggr)", "bggr"),
+        ("bayer (grbg)", "grbg"),
+    ],
+)
+def test_sensor_create_patterns(kind, letters):
+    s = sensor_create(kind)
+    assert s.filter_color_letters == letters
+    assert s.n_colors == 3


### PR DESCRIPTION
## Summary
- extend `sensor_create` with Bayer pattern parsing
- expose `parse_bayer_pattern` and `BAYER_PATTERN_MAP`
- document support for pattern strings in `sensor.__init__`
- test the new patterns

## Testing
- `pytest python/tests/test_sensor_create.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_683e5035fcf083239ceeec8d0881333a