### PR TITLE
Add pixel_center_fill_pd utility

### DIFF
--- a/python/isetcam/pixel/__init__.py
+++ b/python/isetcam/pixel/__init__.py
@@ -4,9 +4,11 @@
 from .pixel_class import Pixel
 from .pixel_get import pixel_get
 from .pixel_set import pixel_set
+from .pixel_center_fill_pd import pixel_center_fill_pd
 
 __all__ = [
     "Pixel",
     "pixel_get",
     "pixel_set",
+    "pixel_center_fill_pd",
 ]

--- a/python/isetcam/pixel/pixel_center_fill_pd.py
+++ b/python/isetcam/pixel/pixel_center_fill_pd.py
@@ -1,0 +1,48 @@
+# mypy: ignore-errors
+"""Create a centered photodiode for a :class:`Sensor`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .pixel_class import Pixel
+from ..sensor.sensor_class import Sensor
+
+
+def pixel_center_fill_pd(sensor: Sensor, fill_factor: float) -> Sensor:
+    """Attach a centered photodiode ``Pixel`` to ``sensor``.
+
+    Parameters
+    ----------
+    sensor:
+        Sensor to update.
+    fill_factor:
+        Desired photodiode fill factor ``0`` to ``1`` relative to the pixel
+        pitch stored on ``sensor`` as ``pixel_size``.
+
+    Returns
+    -------
+    Sensor
+        ``sensor`` updated with a ``pixel`` attribute describing the
+        photodiode. The voltage data are scaled by ``fill_factor``.
+    """
+
+    if not 0.0 <= fill_factor <= 1.0:
+        raise ValueError("fill_factor must be between 0 and 1")
+
+    pixel_size = float(getattr(sensor, "pixel_size", 1.0))
+    pd_side = np.sqrt(fill_factor) * pixel_size
+    well_capacity = float(getattr(sensor, "well_capacity", 0.0))
+
+    sensor.pixel = Pixel(
+        width=pd_side,
+        height=pd_side,
+        well_capacity=well_capacity,
+        fill_factor=float(fill_factor),
+    )
+
+    sensor.volts = np.asarray(sensor.volts, dtype=float) * float(fill_factor)
+    return sensor
+
+
+__all__ = ["pixel_center_fill_pd"]

--- a/python/tests/test_pixel_center_fill_pd.py
+++ b/python/tests/test_pixel_center_fill_pd.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from isetcam.sensor import Sensor
+from isetcam.pixel import pixel_center_fill_pd
+
+
+def test_pixel_center_fill_pd_area_and_volts():
+    s = Sensor(volts=np.ones((1, 1)), wave=np.array([550]), exposure_time=1.0)
+    s.pixel_size = 2e-6
+
+    pixel_center_fill_pd(s, 0.25)
+
+    expected_side = np.sqrt(0.25) * s.pixel_size
+    p = s.pixel
+    assert np.isclose(p.width, expected_side)
+    assert np.isclose(p.height, expected_side)
+    assert np.isclose(p.fill_factor, 0.25)
+    assert np.isclose(p.width * p.height, 0.25 * s.pixel_size**2)
+
+    assert np.allclose(s.volts, np.full((1, 1), 0.25))
+
+
+def test_pixel_center_fill_pd_voltage_scaling():
+    s1 = Sensor(volts=np.ones((1, 1)), wave=np.array([550]), exposure_time=1.0)
+    s1.pixel_size = 2e-6
+    pixel_center_fill_pd(s1, 1.0)
+
+    s2 = Sensor(volts=np.ones((1, 1)), wave=np.array([550]), exposure_time=1.0)
+    s2.pixel_size = 2e-6
+    pixel_center_fill_pd(s2, 0.5)
+
+    assert np.allclose(s1.volts, np.full((1, 1), 1.0))
+    assert np.allclose(s2.volts, np.full((1, 1), 0.5))


### PR DESCRIPTION
## Summary
- add a `pixel_center_fill_pd` helper that attaches a centered photodiode description to a `Sensor`
- export this helper from the pixel package
- test that fill factor correctly updates pixel geometry and sensor voltages

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_pixel_center_fill_pd.py -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_683e5037a0dc8323857a921d02e47796