### PR TITLE
Enhance sensor compute pipeline

### DIFF
--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -13,7 +13,7 @@ from .sensor_class import Sensor
 from .sensor_get import sensor_get
 from .sensor_set import sensor_set
 from .sensor_from_file import sensor_from_file
-from .sensor_compute import sensor_compute
+from .sensor_compute import sensor_compute, auto_exposure
 from .sensor_photon_noise import sensor_photon_noise
 from .sensor_add_noise import sensor_add_noise
 from .sensor_to_file import sensor_to_file
@@ -83,6 +83,7 @@ __all__ = [
     "sensor_set",
     "sensor_from_file",
     "sensor_compute",
+    "auto_exposure",
     "sensor_photon_noise",
     "sensor_add_noise",
     "sensor_to_file",

--- a/python/isetcam/sensor/sensor_compute.py
+++ b/python/isetcam/sensor/sensor_compute.py
@@ -7,6 +7,73 @@ import numpy as np
 
 from ..opticalimage import OpticalImage
 from .sensor_class import Sensor
+from .sensor_get import sensor_get
+from .sensor_add_noise import sensor_add_noise
+from .sensor_gain_offset import sensor_gain_offset
+
+
+def _parse_pattern(letters: np.ndarray | str) -> np.ndarray | None:
+    """Return CFA pattern array if ``letters`` encodes a square pattern."""
+    if isinstance(letters, str):
+        size = int(np.sqrt(len(letters)))
+        if size * size == len(letters):
+            return np.array(list(letters)).reshape(size, size)
+        return None
+    letters = np.asarray(letters)
+    if letters.ndim == 2:
+        return letters
+    if letters.ndim == 1:
+        size = int(np.sqrt(letters.size))
+        if size * size == letters.size:
+            return letters.reshape(size, size)
+    return None
+
+
+def auto_exposure(sensor: Sensor, oi: OpticalImage, level: float = 0.95) -> float:
+    """Return exposure time that keeps peak signal below ``level`` of swing."""
+
+    if oi.photons.shape[-1] != sensor.wave.size:
+        raise ValueError("OpticalImage and Sensor must have matching wavelengths")
+
+    qe = getattr(sensor, "qe", np.ones(sensor.wave.size, dtype=float))
+    qe = np.asarray(qe, dtype=float)
+    if qe.size != sensor.wave.size:
+        raise ValueError("sensor.qe length must match sensor.wave")
+
+    photons = np.asarray(oi.photons, dtype=float) * qe
+
+    if hasattr(sensor, "filter_spectra") and hasattr(sensor, "filter_color_letters"):
+        fs = np.asarray(sensor.filter_spectra, dtype=float)
+        if fs.shape[0] != sensor.wave.size:
+            raise ValueError("filter_spectra first dimension must match sensor.wave")
+        pattern = _parse_pattern(getattr(sensor, "filter_color_letters"))
+        if pattern is None:
+            raise ValueError("filter_color_letters must form a square CFA pattern")
+        fnames = getattr(sensor, "filter_names", None)
+        if fnames is None:
+            raise AttributeError("sensor missing 'filter_names'")
+        letter_map = {str(n)[0].lower(): i for i, n in enumerate(fnames)}
+        pr, pc = pattern.shape
+        rows, cols = sensor.volts.shape[:2]
+        mosaic = np.tile(pattern, (rows // pr + 1, cols // pc + 1))[:rows, :cols]
+        max_signal = 0.0
+        for letter in np.unique(mosaic):
+            idx = letter_map.get(str(letter).lower())
+            if idx is None:
+                raise ValueError(f"Unknown CFA letter '{letter}'")
+            spectral = fs[:, idx]
+            integ = (photons * spectral).sum(axis=2)
+            val = float(np.max(integ[mosaic == letter]))
+            if val > max_signal:
+                max_signal = val
+    else:
+        max_signal = float((photons.sum(axis=2)).max())
+
+    if max_signal <= 0:
+        return 0.0
+
+    v_swing = sensor_get(sensor, "voltage_swing")
+    return float(level * v_swing / max_signal)
 
 
 def sensor_compute(sensor: Sensor, oi: OpticalImage) -> Sensor:
@@ -29,15 +96,47 @@ def sensor_compute(sensor: Sensor, oi: OpticalImage) -> Sensor:
     if oi.photons.shape[-1] != sensor.wave.size:
         raise ValueError("OpticalImage and Sensor must have matching wavelengths")
 
-    qe = getattr(sensor, "qe", None)
-    if qe is None:
-        qe = np.ones(sensor.wave.size, dtype=float)
-    else:
-        qe = np.asarray(qe, dtype=float)
-        if qe.size != sensor.wave.size:
-            raise ValueError("sensor.qe length must match sensor.wave")
+    if getattr(sensor, "auto_exposure", False):
+        sensor.exposure_time = auto_exposure(sensor, oi)
 
-    electrons = (oi.photons * qe).sum(axis=2) * float(sensor.exposure_time)
-    sensor.volts = electrons
+    qe = getattr(sensor, "qe", np.ones(sensor.wave.size, dtype=float))
+    qe = np.asarray(qe, dtype=float)
+    if qe.size != sensor.wave.size:
+        raise ValueError("sensor.qe length must match sensor.wave")
+
+    photons = np.asarray(oi.photons, dtype=float) * qe
+
+    if hasattr(sensor, "filter_spectra") and hasattr(sensor, "filter_color_letters"):
+        fs = np.asarray(sensor.filter_spectra, dtype=float)
+        if fs.shape[0] != sensor.wave.size:
+            raise ValueError("filter_spectra first dimension must match sensor.wave")
+        pattern = _parse_pattern(getattr(sensor, "filter_color_letters"))
+        if pattern is None:
+            raise ValueError("filter_color_letters must form a square CFA pattern")
+        fnames = getattr(sensor, "filter_names", None)
+        if fnames is None:
+            raise AttributeError("sensor missing 'filter_names'")
+        letter_map = {str(n)[0].lower(): i for i, n in enumerate(fnames)}
+        pr, pc = pattern.shape
+        rows, cols = sensor.volts.shape[:2]
+        mosaic = np.tile(pattern, (rows // pr + 1, cols // pc + 1))[:rows, :cols]
+        volts = np.zeros((rows, cols), dtype=float)
+        for letter in np.unique(mosaic):
+            idx = letter_map.get(str(letter).lower())
+            if idx is None:
+                raise ValueError(f"Unknown CFA letter '{letter}'")
+            spectral = fs[:, idx]
+            integ = (photons * spectral).sum(axis=2) * float(sensor.exposure_time)
+            volts[mosaic == letter] = integ[mosaic == letter]
+    else:
+        volts = photons.sum(axis=2) * float(sensor.exposure_time)
+
+    sensor.volts = volts
+
+    sensor_add_noise(sensor)
+    gain = getattr(sensor, "analog_gain", 1.0)
+    offset = getattr(sensor, "analog_offset", 0.0)
+    sensor_gain_offset(sensor, gain=gain, offset=offset)
+
     return sensor
 

--- a/python/tests/test_sensor_compute.py
+++ b/python/tests/test_sensor_compute.py
@@ -1,5 +1,9 @@
 import numpy as np
-from isetcam.sensor import Sensor, sensor_compute
+from isetcam.sensor import (
+    Sensor,
+    sensor_compute,
+    auto_exposure,
+)
 from isetcam.opticalimage import OpticalImage
 
 
@@ -25,3 +29,51 @@ def test_sensor_compute_with_qe():
     sensor_compute(s, oi)
     expected = (oi.photons * qe).sum(axis=2) * 2.0
     assert np.allclose(s.volts, expected)
+
+
+def test_sensor_compute_auto_exposure():
+    oi = OpticalImage(photons=10.0 * np.ones((2, 2, 1)), wave=np.array([500]))
+    s = Sensor(volts=np.zeros((2, 2)), wave=oi.wave, exposure_time=1.0)
+    s.voltage_swing = 5.0
+    s.auto_exposure = True
+    sensor_compute(s, oi)
+    expected_time = 0.95 * 5.0 / 10.0
+    assert np.isclose(s.exposure_time, expected_time)
+    expected = np.full((2, 2), 10.0 * expected_time)
+    assert np.allclose(s.volts, expected)
+
+
+def test_sensor_compute_color_filters():
+    oi = OpticalImage(photons=np.ones((2, 2, 1)), wave=np.array([500]))
+    s = Sensor(volts=np.zeros((2, 2)), wave=oi.wave, exposure_time=1.0)
+    s.filter_spectra = np.array([[1.0, 0.5]])
+    s.filter_names = ["r", "g"]
+    s.filter_color_letters = "rggr"
+    sensor_compute(s, oi)
+    expected = np.array([[1.0, 0.5], [0.5, 1.0]])
+    assert np.allclose(s.volts, expected)
+
+
+def test_sensor_compute_noise_gain_offset():
+    np.random.seed(0)
+    oi = OpticalImage(photons=np.ones((1, 1, 1)) * 4.0, wave=np.array([500]))
+    s = Sensor(volts=np.zeros((1, 1)), wave=oi.wave, exposure_time=1.0)
+    s.gain_sd = 10.0
+    s.offset_sd = 0.1
+    s.analog_gain = 2.0
+    s.analog_offset = 1.0
+    sensor_compute(s, oi)
+    np.random.seed(0)
+    g = 1.0 + 0.1 * np.random.randn(1, 1)
+    o = 0.1 * np.random.randn(1, 1)
+    expected = (4.0 * g + o) * 2.0 + 1.0
+    assert np.allclose(s.volts, expected)
+
+
+def test_auto_exposure_function():
+    oi = OpticalImage(photons=5.0 * np.ones((1, 1, 1)), wave=np.array([500]))
+    s = Sensor(volts=np.zeros((1, 1)), wave=oi.wave, exposure_time=1.0)
+    s.voltage_swing = 4.0
+    t = auto_exposure(s, oi)
+    expected_t = 0.95 * 4.0 / 5.0
+    assert np.isclose(t, expected_t)


### PR DESCRIPTION
## Summary
- implement auto exposure helper and integrate into sensor compute
- apply color filter mosaics, DSNU/PRNU noise and analog gain/offset
- export `auto_exposure` in sensor package
- expand tests for auto exposure, noise and color filters

## Testing
- `PYTHONPATH=$PWD pytest -q -o addopts= tests/test_sensor_compute.py`
- `PYTHONPATH=python pytest -q -o addopts=` *(fails: iso_speed_saturation and web tests; network unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_683e503a16a083238cebd753951de08e