### PR TITLE
Add demosaicing and color pipeline to ip_compute

### DIFF
--- a/python/isetcam/ip/ip_compute.py
+++ b/python/isetcam/ip/ip_compute.py
@@ -6,16 +6,84 @@ from __future__ import annotations
 import numpy as np
 
 from ..sensor import Sensor
-from ..display import Display, display_apply_gamma
+from ..display import Display, display_apply_gamma, display_render
+from ..color_transform_matrix import color_transform_matrix
+from ..rgb_to_xw_format import rgb_to_xw_format
+from ..xw_to_rgb_format import xw_to_rgb_format
+from ..imgproc.image_illuminant_correction import image_illuminant_correction
 from .vcimage_class import VCImage
 from .ip_create import ip_create
+from .ip_demosaic import ip_demosaic
+
+
+def _image_linear_transform(im: np.ndarray, T: np.ndarray) -> np.ndarray:
+    """Return ``im`` transformed by ``T`` in either RGB or XW format."""
+    if im.ndim == 3:
+        xw, r, c = rgb_to_xw_format(im)
+        out = xw @ T
+        return xw_to_rgb_format(out, r, c)
+    if im.ndim == 2:
+        if im.shape[1] != T.shape[0]:
+            raise ValueError("Matrix dimensions do not align")
+        return im @ T
+    raise ValueError("Image must be RGB or XW format")
 
 
 def ip_compute(sensor: Sensor, display: Display) -> VCImage:
     """Return ``VCImage`` rendered from ``sensor`` for ``display``."""
+
     ip = ip_create(sensor, display)
-    rgb = np.repeat(sensor.volts[:, :, None], 3, axis=2)
+
+    # ----- Demosaic -----
+    method = getattr(ip, "demosaic_method", None)
+    if method is None:
+        method = "bilinear"
+        ip.demosaic_method = method
+    vols = np.asarray(sensor.volts, dtype=float)
+    if vols.ndim == 2:
+        pattern = getattr(sensor, "filter_color_letters", "rggb")
+        rgb = ip_demosaic(vols, pattern, method=method)
+    elif vols.ndim == 3 and vols.shape[2] == 3:
+        rgb = vols
+    else:
+        rgb = np.repeat(vols[:, :, None], 3, axis=2)
+
+    # ----- Convert to internal color space -----
+    ics = getattr(ip, "internal_cs", None)
+    if ics is None:
+        ics = "XYZ"
+        ip.internal_cs = ics
+    cs_key = ics.replace(" ", "").lower()
+    if cs_key == "xyz":
+        T = color_transform_matrix("srgb2xyz")
+        img_ics = _image_linear_transform(rgb, T)
+    elif cs_key in {"linearsrgb", "srgb"}:
+        img_ics = rgb
+    else:
+        raise ValueError("Unknown internal color space")
+
+    # ----- Illuminant correction -----
+    illum_method = getattr(ip, "illuminant_correction_method", None)
+    if illum_method is None:
+        illum_method = "none"
+        ip.illuminant_correction_method = illum_method
+    img_ics, _ = image_illuminant_correction(
+        img_ics, method=illum_method, internal_cmf=None, wave=ip.wave
+    )
+
+    # ----- Convert to display space -----
+    if cs_key == "xyz":
+        T = color_transform_matrix("xyz2srgb")
+        lin_rgb = _image_linear_transform(img_ics, T)
+    else:
+        lin_rgb = img_ics
+
+    _ = display_render(lin_rgb, display, apply_gamma=False)
+
     if display.gamma is not None:
-        rgb = display_apply_gamma(rgb, display, inverse=True)
-    ip.rgb = rgb
+        rgb_out = display_apply_gamma(lin_rgb, display, inverse=True)
+    else:
+        rgb_out = lin_rgb
+
+    ip.rgb = rgb_out
     return ip

--- a/python/isetcam/ip/ip_get.py
+++ b/python/isetcam/ip/ip_get.py
@@ -18,6 +18,8 @@ def ip_get(ip: VCImage, param: str) -> Any:
         return len(ip.wave)
     if key == "name":
         return getattr(ip, "name", None)
+    if key == "demosaicmethod":
+        return getattr(ip, "demosaic_method", None)
     if key == "internalcs":
         return getattr(ip, "internal_cs", None)
     if key == "conversionmethodsensor":

--- a/python/isetcam/ip/ip_set.py
+++ b/python/isetcam/ip/ip_set.py
@@ -21,6 +21,9 @@ def ip_set(ip: VCImage, param: str, val: Any) -> None:
     if key == "name":
         ip.name = None if val is None else str(val)
         return
+    if key == "demosaicmethod":
+        ip.demosaic_method = None if val is None else str(val)
+        return
     if key == "internalcs":
         ip.internal_cs = None if val is None else str(val)
         return

--- a/python/isetcam/ip/vcimage_class.py
+++ b/python/isetcam/ip/vcimage_class.py
@@ -15,6 +15,7 @@ class VCImage:
     rgb: np.ndarray
     wave: np.ndarray
     name: str | None = None
+    demosaic_method: str | None = None
     internal_cs: str | None = None
     conversion_method_sensor: str | None = None
     illuminant_correction_method: str | None = None

--- a/python/tests/test_ip_compute.py
+++ b/python/tests/test_ip_compute.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from isetcam.sensor import Sensor
+from isetcam.display import Display, display_apply_gamma
+from isetcam.ip import ip_compute, ip_create, ip_set, ip_get, ip_demosaic
+
+
+def _simple_sensor() -> Sensor:
+    volts = np.array([[0.2, 0.4], [0.6, 0.8]], dtype=float)
+    wave = np.array([500, 510])
+    return Sensor(volts=volts, exposure_time=0.01, wave=wave)
+
+
+def _simple_display(n_levels: int = 4) -> Display:
+    wave = np.array([500, 510])
+    spd = np.ones((2, 3))
+    gamma_vals = np.linspace(0, 1, n_levels) ** 2
+    gamma = gamma_vals.reshape(n_levels, 1).repeat(3, axis=1)
+    return Display(spd=spd, wave=wave, gamma=gamma)
+
+
+def test_ip_compute_pipeline():
+    sensor = _simple_sensor()
+    disp = _simple_display()
+    ip = ip_compute(sensor, disp)
+    expected_lin = ip_demosaic(sensor.volts, "rggb", method="bilinear")
+    expected = display_apply_gamma(expected_lin, disp, inverse=True)
+    assert np.allclose(ip.rgb, expected)
+
+
+def test_ip_set_new_params():
+    sensor = _simple_sensor()
+    disp = _simple_display()
+    ip = ip_create(sensor, disp)
+    ip_set(ip, "demosaic method", "nearest")
+    ip_set(ip, "internal cs", "linear sRGB")
+    ip_set(ip, "conversion method sensor", "current")
+    ip_set(ip, "illuminant correction method", "gray world")
+    assert ip_get(ip, "demosaic method") == "nearest"
+    assert ip_get(ip, "internal cs") == "linear sRGB"
+    assert ip_get(ip, "conversion method sensor") == "current"
+    assert ip_get(ip, "illuminant correction method") == "gray world"


### PR DESCRIPTION
## Summary
- extend `VCImage` with `demosaic_method`
- allow `demosaic method` parameter via `ip_get`/`ip_set`
- implement demosaic and basic color conversion in `ip_compute`
- test new compute pipeline and setters

## Testing
- `flake8` *(fails: numerous existing style violations)*
- `pytest -q` *(fails: pytest-cov missing)*

------
https://chatgpt.com/codex/tasks/task_e_683e503c010883239c1cacf4c0f6e1ec