### PR TITLE
Add Python system simulation tutorial

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -2667,6 +2667,22 @@ iso = iso_speed_saturation(s)
 
 Run `pytest -q` after adding the saturation speed routine.
 
+## iso_acutance
+
+`iso_acutance` integrates an MTF curve using the CPIQ contrast sensitivity
+function to yield an ISO acutance score.
+
+```python
+import numpy as np
+from isetcam.metrics import iso_acutance
+
+freq = np.linspace(0, 50, 5)
+mtf = np.exp(-freq / 25)
+acutance = iso_acutance(freq, mtf)
+```
+
+Run `pytest -q` after implementing the ISO acutance calculation.
+
 ## human_cones, human_cone_mosaic, watson_impulse_response and watson_rgc_spacing
 
 These helpers return cone spectral sensitivities, simulate a simple cone mosaic and model ganglion cell temporal and spatial characteristics.

--- a/python/tutorials/camera/t_system_simulate.py
+++ b/python/tutorials/camera/t_system_simulate.py
@@ -1,29 +1,26 @@
 import numpy as np
-from isetcam import (
-    ie_init,
-    data_path,
+from isetcam import ie_init, data_path
+from isetcam.scene import (
     scene_create,
     scene_adjust_illuminant,
     scene_adjust_luminance,
     scene_show_image,
-    optics_create,
-    optics_set,
-    oi_compute,
-    oi_show_image,
+    scene_slanted_bar,
+)
+from isetcam.optics import optics_create, optics_set
+from isetcam.opticalimage import oi_compute, oi_show_image
+from isetcam.sensor import (
+    Sensor,
     sensor_create,
     sensor_set,
     sensor_compute,
     sensor_add_noise,
     sensor_gain_offset,
     sensor_show_image,
-    display_create,
-    ip_compute,
-    ip_set,
-    ip_plot,
-    scene_slanted_bar,
-    iso12233_sfr,
 )
-from isetcam.sensor import Sensor
+from isetcam.display import display_create
+from isetcam.ip import ip_compute, ip_set, ip_plot
+from isetcam.metrics import iso12233_sfr
 
 
 def build_sensor(rows: int, cols: int) -> Sensor:
@@ -54,7 +51,6 @@ def main() -> None:
     optics_set(optics, "f_length", 3e-3)
 
     oi = oi_compute(scene, optics)
-    oi_show_image(oi)
 
     sensor = build_sensor(466, 642)
     sensor = sensor_compute(sensor, oi)
@@ -63,6 +59,8 @@ def main() -> None:
     sensor_show_image(sensor)
 
     disp = display_create()
+    disp.wave = sensor.wave
+    oi_show_image(oi, disp)
     ip = ip_compute(sensor, disp)
     ip_plot(ip, kind="image")
 
@@ -76,6 +74,7 @@ def main() -> None:
     bar_oi = oi_compute(bar_scene, optics)
     bar_sensor = build_sensor(512, 512)
     bar_sensor = sensor_compute(bar_sensor, bar_oi)
+    disp.wave = bar_sensor.wave
     bar_ip = ip_compute(bar_sensor, disp)
     freq, mtf = iso12233_sfr(bar_ip.rgb)
     print("ISO12233 SFR frequencies:", freq)


### PR DESCRIPTION
## Summary
- add iso_acutance docs to the migration guide
- update `t_system_simulate.py` tutorial to import helpers from submodules
- ensure display wavelength matches sensor when computing pipeline

## Testing
- `PYTHONPATH=python pytest python/tests/test_t_system_simulate.py -q -o addopts=''`
- `PYTHONPATH=python pytest python/tests/test_iso12233_sfr.py -q -o addopts=''`
- `PYTHONPATH=python pytest -q -o addopts=''` *(fails: iso_speed_saturation and web retrieval tests; network unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_683e53284cac83238076fe5dbff3e532