### PR TITLE
Add camera introduction tutorial

### DIFF
--- a/python/tests/test_t_camera_introduction.py
+++ b/python/tests/test_t_camera_introduction.py
@@ -1,0 +1,83 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _mpl_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _load_tutorial():
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "camera" / "t_camera_introduction.py"
+
+    import isetcam
+    from isetcam.scene import scene_create, scene_show_image
+    from isetcam.camera import (
+        camera_create,
+        camera_compute,
+        camera_get,
+        camera_set,
+    )
+    from isetcam.optics import optics_set
+    from isetcam.opticalimage import oi_show_image
+    from isetcam.sensor import sensor_show_image
+    from isetcam.display import display_create
+    from isetcam.ip import ip_compute, ip_set, ip_plot
+
+    # Provide missing symbols expected by the tutorial
+    isetcam.scene_create = scene_create
+    isetcam.scene_show_image = scene_show_image
+    isetcam.camera_create = camera_create
+    isetcam.camera_compute = camera_compute
+    isetcam.camera_get = camera_get
+    isetcam.camera_set = camera_set
+    isetcam.optics_set = optics_set
+    isetcam.oi_show_image = oi_show_image
+    isetcam.sensor_show_image = sensor_show_image
+    isetcam.display_create = display_create
+    isetcam.ip_compute = ip_compute
+    isetcam.ip_set = ip_set
+    isetcam.ip_plot = ip_plot
+
+    spec = importlib.util.spec_from_file_location("t_camera_introduction", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.skipif(not _mpl_available(), reason="matplotlib not installed")
+def test_t_camera_introduction_pipeline():
+    tut = _load_tutorial()
+
+    tut.ie_init()
+    cam = tut.camera_create()
+
+    scene = tut.scene_create("macbeth d65")
+    scene.fov = 8.0
+
+    tut.camera_compute(cam, scene)
+
+    tut.optics_set(cam.optics, "f_number", 16.0)
+    tut.camera_compute(cam, scene)
+
+    disp = tut.display_create()
+    disp.wave = cam.sensor.wave
+
+    ip = tut.ip_compute(cam.sensor, disp)
+    tut.ip_set(ip, "illuminant correction method", "gray world")
+    ip_final = tut.ip_compute(cam.sensor, disp)
+
+    assert ip_final.rgb.shape == (scene.photons.shape[0], scene.photons.shape[1], 3)

--- a/python/tutorials/camera/t_camera_introduction.py
+++ b/python/tutorials/camera/t_camera_introduction.py
@@ -1,0 +1,68 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.scene import scene_create, scene_show_image
+from isetcam.camera import camera_create, camera_compute, camera_get, camera_set
+from isetcam.optics import optics_set
+from isetcam.opticalimage import oi_show_image
+from isetcam.sensor import sensor_show_image
+from isetcam.display import display_create
+from isetcam.ip import ip_compute, ip_set, ip_plot
+
+
+def main() -> None:
+    ie_init()
+
+    # Create a camera with default optics and sensor
+    cam = camera_create()
+
+    # Create a simple Macbeth chart scene and set the field of view
+    scene = scene_create("macbeth d65")
+    scene.fov = 8.0
+    scene_show_image(scene)
+
+    # Compute the camera output from the scene
+    camera_compute(cam, scene)
+
+    # Visualize the intermediate objects
+    oi_show_image(camera_get(cam, "oi"))
+    sensor_show_image(camera_get(cam, "sensor"))
+
+    # Render to an sRGB image using a default display model
+    disp = display_create()
+    disp.wave = cam.sensor.wave
+    ip = ip_compute(cam.sensor, disp)
+    ip_plot(ip, kind="image")
+
+    # Retrieve the processed sRGB data from the VCImage
+    srgb = ip.rgb
+    _ = srgb  # placeholder to mimic the MATLAB tutorial
+
+    # A shorter way using camera_get to obtain the sensor
+    sensor = camera_get(cam, "sensor")
+    ip2 = ip_compute(sensor, disp)
+    srgb2 = ip2.rgb
+    _ = srgb2
+
+    # Modify an optics parameter using camera_set
+    optics_set(cam.optics, "f_number", 16.0)
+    camera_compute(cam, scene)
+    ip3 = ip_compute(cam.sensor, disp)
+    ip_plot(ip3, kind="image")
+
+    # Adjust an IP parameter and recompute
+    ip_set(ip3, "illuminant correction method", "gray world")
+    ip4 = ip_compute(cam.sensor, disp)
+    ip_plot(ip4, kind="image")
+
+    # Re-run the pipeline starting from different stages
+    camera_compute(cam, scene)
+    camera_compute(cam, "oi")
+    camera_compute(cam, "sensor")
+
+    # Final display of the result
+    ip_final = ip_compute(cam.sensor, disp)
+    ip_plot(ip_final, kind="image")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- port MATLAB `t_cameraIntroduction` tutorial to Python
- exercise camera creation, sensor compute, and IP plotting
- provide regression test for tutorial pipeline

## Testing
- `pytest -q` *(fails: unrecognized arguments --cov=python/isetcam)*
- `flake8 python/isetcam` *(fails: numerous style violations)*

------
https://chatgpt.com/codex/tasks/task_e_683e5bf0bc3c8323a5f36da22f64194e