### PR TITLE
Enable optics/ip keys in camera_get/set

### DIFF
--- a/python/isetcam/camera/camera_get.py
+++ b/python/isetcam/camera/camera_get.py
@@ -1,5 +1,11 @@
 # mypy: ignore-errors
-"""Retrieve parameters from :class:`Camera` objects."""
+"""Retrieve parameters from :class:`Camera` objects.
+
+Keys beginning with ``"optics"`` or ``"ip"`` are forwarded to
+``optics_get`` and ``ip_get`` respectively when the corresponding
+attribute is present on ``camera``.  For example ``"optics fnumber"``
+returns ``optics_get(camera.optics, "fnumber")``.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +13,8 @@ from typing import Any
 
 from .camera_class import Camera
 from ..ie_param_format import ie_param_format
+from ..optics import optics_get
+from ..ip import ip_get
 
 
 def camera_get(camera: Camera, param: str) -> Any:
@@ -15,7 +23,25 @@ def camera_get(camera: Camera, param: str) -> Any:
     Supported parameters are ``sensor``, ``optical_image``/``oi``, ``name``
     and ``n_wave``/``nwave`` (derived from the sensor's wavelength sampling).
     """
-    key = ie_param_format(param).replace("_", "")
+    # check for sub-object dispatch before normalizing completely
+    raw = str(param).strip()
+    low = raw.lower()
+    if low.startswith("optics"):
+        sub = raw[6:].strip()
+        if not hasattr(camera, "optics"):
+            raise KeyError("Camera has no 'optics' attribute")
+        if not sub:
+            return camera.optics
+        return optics_get(camera.optics, sub)
+    if low.startswith("ip"):
+        sub = raw[2:].strip()
+        if not hasattr(camera, "ip"):
+            raise KeyError("Camera has no 'ip' attribute")
+        if not sub:
+            return camera.ip
+        return ip_get(camera.ip, sub)
+
+    key = ie_param_format(raw).replace("_", "")
     if key == "sensor":
         return camera.sensor
     if key in {"opticalimage", "oi"}:
@@ -25,3 +51,6 @@ def camera_get(camera: Camera, param: str) -> Any:
     if key == "name":
         return getattr(camera, "name", None)
     raise KeyError(f"Unknown camera parameter '{param}'")
+
+
+__all__ = ["camera_get"]

--- a/python/isetcam/camera/camera_set.py
+++ b/python/isetcam/camera/camera_set.py
@@ -1,5 +1,10 @@
 # mypy: ignore-errors
-"""Assign parameters on :class:`Camera` objects."""
+"""Assign parameters on :class:`Camera` objects.
+
+Keys beginning with ``"optics"`` or ``"ip"`` are forwarded to
+``optics_set`` and ``ip_set`` respectively when the corresponding
+attribute is present on ``camera``.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +12,8 @@ from typing import Any
 
 from .camera_class import Camera
 from ..ie_param_format import ie_param_format
+from ..optics import optics_set
+from ..ip import ip_set
 
 
 def camera_set(camera: Camera, param: str, val: Any) -> None:
@@ -15,7 +22,29 @@ def camera_set(camera: Camera, param: str, val: Any) -> None:
     Supported parameters are ``sensor``, ``optical_image``/``oi`` and
     ``name``. ``n_wave`` is derived from the sensor and cannot be set.
     """
-    key = ie_param_format(param).replace("_", "")
+    # check for sub-object dispatch before normalizing completely
+    raw = str(param).strip()
+    low = raw.lower()
+    if low.startswith("optics"):
+        sub = raw[6:].strip()
+        if not hasattr(camera, "optics"):
+            raise KeyError("Camera has no 'optics' attribute")
+        if not sub:
+            camera.optics = val
+        else:
+            optics_set(camera.optics, sub, val)
+        return
+    if low.startswith("ip"):
+        sub = raw[2:].strip()
+        if not hasattr(camera, "ip"):
+            raise KeyError("Camera has no 'ip' attribute")
+        if not sub:
+            camera.ip = val
+        else:
+            ip_set(camera.ip, sub, val)
+        return
+
+    key = ie_param_format(raw).replace("_", "")
     if key == "sensor":
         camera.sensor = val
         return
@@ -28,3 +57,6 @@ def camera_set(camera: Camera, param: str, val: Any) -> None:
     if key in {"nwave", "n_wave"}:
         raise KeyError("'n_wave' is read-only and derived from the sensor")
     raise KeyError(f"Unknown camera parameter '{param}'")
+
+
+__all__ = ["camera_set"]

--- a/python/tests/test_camera_get_set.py
+++ b/python/tests/test_camera_get_set.py
@@ -3,6 +3,8 @@ import numpy as np
 from isetcam.sensor import Sensor
 from isetcam.opticalimage import OpticalImage
 from isetcam.camera import Camera, camera_get, camera_set
+from isetcam.optics import Optics
+from isetcam.ip import VCImage
 
 
 def test_camera_get_set():
@@ -28,3 +30,16 @@ def test_camera_get_set():
 
     camera_set(cam, " NaMe", "new")
     assert camera_get(cam, " NaMe ") == "new"
+
+    # optics and ip forwarding
+    cam.optics = Optics(f_number=4.0, f_length=0.005, wave=wave)
+    cam.ip = VCImage(rgb=np.zeros_like(volts), wave=wave,
+                     illuminant_correction_method="gray world")
+
+    assert camera_get(cam, "optics fnumber") == 4.0
+    camera_set(cam, "optics fnumber", 2.8)
+    assert camera_get(cam, "optics f_number") == 2.8
+
+    assert camera_get(cam, "ip illuminant correction method") == "gray world"
+    camera_set(cam, "ip illuminant correction method", "none")
+    assert camera_get(cam, "ip illuminant correction method") == "none"


### PR DESCRIPTION
## Summary
- allow `camera_get`/`camera_set` to dispatch to optics and IP objects
- document the new behaviour
- add unit tests for the new options

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_camera_get_set.py -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_683e62917d7883238515e66cd61e73f5