### PR TITLE
Add frequency-orientation scene

### DIFF
--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -49,6 +49,7 @@ from .scene_list import scene_list
 from .scene_make_video import scene_make_video
 from .scene_dead_leaves import scene_dead_leaves
 from .scene_slanted_bar import scene_slanted_bar
+from .scene_freq_orient import scene_freq_orient
 from .scene_wb_create import scene_wb_create
 from .scene_plot import scene_plot
 from .scene_description import scene_description
@@ -108,6 +109,7 @@ __all__ = [
     "scene_list",
     "scene_dead_leaves",
     "scene_slanted_bar",
+    "scene_freq_orient",
     "scene_wb_create",
     "scene_description",
     "scene_clear_data",

--- a/python/isetcam/scene/imgtargets/__init__.py
+++ b/python/isetcam/scene/imgtargets/__init__.py
@@ -1,5 +1,6 @@
 # mypy: ignore-errors
 from .img_dead_leaves import img_dead_leaves
 from .img_slanted_bar import img_slanted_bar
+from .img_fo_target import img_fo_target
 
-__all__ = ["img_dead_leaves", "img_slanted_bar"]
+__all__ = ["img_dead_leaves", "img_slanted_bar", "img_fo_target"]

--- a/python/isetcam/scene/imgtargets/img_fo_target.py
+++ b/python/isetcam/scene/imgtargets/img_fo_target.py
@@ -1,0 +1,73 @@
+# mypy: ignore-errors
+"""Generate a frequency-orientation test target image."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import square
+
+
+def img_fo_target(
+    *,
+    pattern: str = "sine",
+    angles: np.ndarray | list[float] | None = None,
+    freqs: np.ndarray | list[float] | None = None,
+    block_size: int = 32,
+    contrast: float = 1.0,
+) -> np.ndarray:
+    """Return a grayscale frequency/orientation target.
+
+    Parameters
+    ----------
+    pattern : {'sine', 'square'}, optional
+        Type of pattern used for each block. Defaults to ``'sine'``.
+    angles : array-like, optional
+        List of orientations in radians for each row of blocks.
+        Defaults to ``np.linspace(0, np.pi/2, 8)``.
+    freqs : array-like, optional
+        List of spatial frequencies for each column of blocks.
+        Defaults to ``np.arange(1, 9)``.
+    block_size : int, optional
+        Size in pixels of each block. Defaults to ``32``.
+    contrast : float, optional
+        Contrast of the sinusoid or square wave. Defaults to ``1``.
+
+    Returns
+    -------
+    ndarray
+        2-D array containing the target pattern scaled between 0 and 1.
+    """
+    if angles is None:
+        angles = np.linspace(0, np.pi / 2, 8)
+    else:
+        angles = np.asarray(angles, dtype=float).reshape(-1)
+    if freqs is None:
+        freqs = np.arange(1, 9)
+    else:
+        freqs = np.asarray(freqs, dtype=float).reshape(-1)
+    block = int(block_size)
+
+    x = np.arange(block) / block
+    X, Y = np.meshgrid(x, x)
+
+    rows = []
+    patt = pattern.lower()
+    for f in freqs:
+        cols = []
+        for theta in angles:
+            phase = 2 * np.pi * f * (np.cos(theta) * X + np.sin(theta) * Y)
+            if patt == "sine":
+                val = 0.5 * (1 + contrast * np.sin(phase))
+            elif patt == "square":
+                val = 0.5 * (1 + contrast * square(phase))
+            else:
+                raise ValueError(f"Unknown pattern '{pattern}'")
+            cols.append(val)
+        rows.append(np.concatenate(cols, axis=1))
+    img = np.concatenate(rows, axis=0)
+    img = img.T  # frequency increases left->right, orientation top->bottom
+    img = np.clip(img, 1e-6, 1.0)
+    return img
+
+
+__all__ = ["img_fo_target"]

--- a/python/isetcam/scene/scene_create.py
+++ b/python/isetcam/scene/scene_create.py
@@ -12,6 +12,7 @@ from .scene_class import Scene
 from ..luminance_from_photons import luminance_from_photons
 from ..data_path import data_path
 from .scene_adjust_illuminant import scene_adjust_illuminant
+from .scene_freq_orient import scene_freq_orient
 
 
 _DEF_DIR = "data"
@@ -135,6 +136,7 @@ _VALID_TYPES = {
     "whitenoise": _create_whitenoise,
     "frequencysweep": _create_frequency_sweep,
     "gridlines": _create_grid_lines,
+    "freqorient": scene_freq_orient,
 }
 
 

--- a/python/isetcam/scene/scene_freq_orient.py
+++ b/python/isetcam/scene/scene_freq_orient.py
@@ -1,0 +1,58 @@
+# mypy: ignore-errors
+"""Create a frequency/orientation target scene."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .scene_class import Scene
+from ..energy_to_quanta import energy_to_quanta
+from .imgtargets import img_fo_target
+
+_DEF_WAVE = np.arange(400, 701, 10, dtype=float)
+
+
+def _default_params() -> dict:
+    return {
+        "angles": np.linspace(0, np.pi / 2, 8),
+        "freqs": np.arange(1, 9),
+        "block_size": 32,
+        "contrast": 1.0,
+    }
+
+
+def scene_freq_orient(params: dict | None = None) -> Scene:
+    """Return a frequency/orientation target scene.
+
+    Parameters
+    ----------
+    params : dict, optional
+        Dictionary with optional keys ``"angles"``, ``"freqs"``,
+        ``"block_size"`` and ``"contrast"`` controlling the target
+        generation. Any missing key uses a sensible default.
+    """
+    if params is None:
+        params = _default_params()
+    else:
+        d = _default_params()
+        d.update(params)
+        params = d
+
+    img = img_fo_target(
+        pattern="sine",
+        angles=params["angles"],
+        freqs=params["freqs"],
+        block_size=int(params["block_size"]),
+        contrast=float(params["contrast"]),
+    )
+
+    img = img / img.max()
+    ill_photons = energy_to_quanta(_DEF_WAVE, np.ones_like(_DEF_WAVE)).ravel()
+    photons = img[:, :, None] * ill_photons[None, None, :]
+
+    sc = Scene(photons=photons, wave=_DEF_WAVE, name="FOTarget")
+    sc.illuminant = ill_photons
+    return sc
+
+
+__all__ = ["scene_freq_orient"]

--- a/python/tests/test_scene_freq_orient.py
+++ b/python/tests/test_scene_freq_orient.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+from isetcam.scene import scene_freq_orient
+from isetcam.scene.imgtargets import img_fo_target
+from isetcam.energy_to_quanta import energy_to_quanta
+
+_DEF_WAVE = np.arange(400, 701, 10, dtype=float)
+
+
+def test_img_fo_target_size():
+    params = dict(angles=[0, np.pi/2], freqs=[1, 2], block_size=8, contrast=1)
+    img = img_fo_target(
+        pattern="sine",
+        angles=params["angles"],
+        freqs=params["freqs"],
+        block_size=params["block_size"],
+        contrast=params["contrast"],
+    )
+    h = len(params["angles"]) * params["block_size"]
+    w = len(params["freqs"]) * params["block_size"]
+    assert img.shape == (h, w)
+    assert img.max() <= 1.0 and img.min() >= 1e-6
+
+
+def test_scene_freq_orient_blocks():
+    angles = [0, np.pi / 2]
+    freqs = [1]
+    block_size = 8
+    sc = scene_freq_orient(
+        {
+            "angles": angles,
+            "freqs": freqs,
+            "block_size": block_size,
+            "contrast": 1,
+        }
+    )
+    assert sc.photons.shape == (
+        len(angles) * block_size,
+        len(freqs) * block_size,
+        _DEF_WAVE.size,
+    )
+    ill = energy_to_quanta(_DEF_WAVE, np.ones_like(_DEF_WAVE)).ravel()
+    assert np.allclose(sc.illuminant, ill)
+
+    x = np.arange(block_size) / block_size
+    X, Y = np.meshgrid(x, x)
+    top = 0.5 * (1 + np.sin(2 * np.pi * freqs[0] * Y))
+    bottom = 0.5 * (1 + np.sin(2 * np.pi * freqs[0] * X))
+    top = np.clip(top, 1e-6, 1.0) / top.max()
+    bottom = np.clip(bottom, 1e-6, 1.0) / bottom.max()
+    expected_top = top * ill[0]
+    expected_bottom = bottom * ill[0]
+    assert np.allclose(sc.photons[:block_size, :block_size, 0], expected_top)
+    assert np.allclose(sc.photons[block_size:, :block_size, 0], expected_bottom)


### PR DESCRIPTION
## Summary
- add imgtargets/img_fo_target for creating a freq/orient target image
- implement scene_freq_orient and expose it in scene.__init__
- register "freq orient" with scene_create
- test image size and orientation grid

## Testing
- `pytest -q python/tests/test_scene_freq_orient.py --override-ini addopts='' -p no:cov --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_683e683464148323881dfb9aaa23a2b3