### PR TITLE
Add camera_show utility

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -181,6 +181,7 @@ from .camera import (
     camera_from_file,
     camera_plot,
     camera_moire,
+    camera_show,
 )
 from .optics import optics_to_file, optics_from_file
 from .scene import scene_plot
@@ -367,6 +368,7 @@ __all__ = [
     'camera_from_file',
     'camera_plot',
     'camera_moire',
+    'camera_show',
     'scene_plot',
     'oi_plot',
     'optics_to_file',

--- a/python/isetcam/camera/__init__.py
+++ b/python/isetcam/camera/__init__.py
@@ -19,6 +19,7 @@ from .camera_compute_sequence import camera_compute_sequence
 from .camera_clear_data import camera_clear_data
 from .camera_full_reference import camera_full_reference
 from .camera_computesrgb import camera_computesrgb
+from .camera_show import camera_show
 
 __all__ = [
     "Camera",
@@ -40,4 +41,5 @@ __all__ = [
     "camera_clear_data",
     "camera_full_reference",
     "camera_computesrgb",
+    "camera_show",
 ]

--- a/python/isetcam/camera/camera_show.py
+++ b/python/isetcam/camera/camera_show.py
@@ -1,0 +1,65 @@
+# mypy: ignore-errors
+"""Display parts of a :class:`Camera` using Matplotlib."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - matplotlib might not be installed
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib might not be installed
+    plt = None  # type: ignore
+
+from .camera_class import Camera
+from ..ie_format_figure import ie_format_figure
+from ..opticalimage import oi_show_image
+from ..sensor import sensor_show_image
+
+
+_DEF_KINDS = {"oi", "sensor", "ip"}
+
+
+def camera_show(camera: Camera, which: str = "ip"):
+    """Display ``camera`` data using matplotlib.
+
+    Parameters
+    ----------
+    camera : Camera
+        Camera instance whose data should be visualized.
+    which : str, optional
+        One of ``"oi"``, ``"sensor"`` or ``"ip"`` indicating what to show.
+        Defaults to ``"ip"``.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        Axis with the displayed image.
+    """
+    if plt is None:
+        raise ImportError("matplotlib is required for camera_show")
+
+    key = str(which).lower().replace(" ", "")
+    if key not in _DEF_KINDS:
+        raise ValueError(f"Unknown show option '{which}'")
+
+    if key == "oi":
+        return oi_show_image(camera.optical_image)
+
+    if key == "sensor":
+        return sensor_show_image(camera.sensor)
+
+    # key == "ip"
+    if not hasattr(camera, "ip"):
+        raise ValueError("Camera has no 'ip' attribute")
+    img = np.asarray(camera.ip.rgb, dtype=float)
+    if img.ndim != 3 or img.shape[2] != 3:
+        raise ValueError("camera.ip.rgb must be (rows, cols, 3)")
+
+    fig, ax = plt.subplots()
+    ax.imshow(np.clip(img, 0.0, 1.0))
+    ax.axis("off")
+    ie_format_figure(ax)
+    return ax
+
+
+__all__ = ["camera_show"]

--- a/python/tests/test_camera_show.py
+++ b/python/tests/test_camera_show.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+from isetcam.camera import Camera, camera_show
+from isetcam.sensor import Sensor
+from isetcam.opticalimage import OpticalImage
+from isetcam.ip import VCImage
+from isetcam.display import Display, display_create
+import importlib
+
+
+def _matplotlib_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _simple_camera() -> Camera:
+    wave = np.array([500, 600, 700])
+    sensor = Sensor(volts=np.ones((1, 1, 3)), exposure_time=0.01, wave=wave)
+    oi = OpticalImage(photons=np.ones((1, 1, 3)), wave=wave)
+    cam = Camera(sensor=sensor, optical_image=oi)
+    cam.ip = VCImage(rgb=np.ones((1, 1, 3)), wave=wave)
+    return cam
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_camera_show_oi_sensor_ip(monkeypatch):
+    cam = _simple_camera()
+    disp = Display(spd=np.eye(3), wave=cam.sensor.wave, gamma=None)
+    oi_mod = importlib.import_module("isetcam.opticalimage.oi_show_image")
+    sensor_mod = importlib.import_module("isetcam.sensor.sensor_show_image")
+    monkeypatch.setattr(oi_mod, "display_create", lambda: disp)
+    monkeypatch.setattr(sensor_mod, "display_create", lambda: disp)
+
+    ax1 = camera_show(cam, which="oi")
+    assert ax1 is not None
+    ax2 = camera_show(cam, which="sensor")
+    assert ax2 is not None
+    ax3 = camera_show(cam, which="ip")
+    assert ax3 is not None


### PR DESCRIPTION
## Summary
- visualize different stages of a Camera with `camera_show`
- expose `camera_show` in camera package and project root
- test camera_show

## Testing
- `PYTHONPATH=python pytest -q -c /dev/null python/tests/test_camera_show.py`

------
https://chatgpt.com/codex/tasks/task_e_683e6cdd6f7c83238daa42aee6862c56