### PR TITLE
Add color tutorial scripts in Python

### DIFF
--- a/python/tests/test_color_tutorials.py
+++ b/python/tests/test_color_tutorials.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import importlib.util
+import sys
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial(name: str):
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "color" / name
+    spec = importlib.util.spec_from_file_location(name[:-3], path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_t_color_energy_quanta():
+    mod = _load_tutorial("t_color_energy_quanta.py")
+    energy, d65_energy, d65_photons, xyz_e, xyz_q = mod.main()
+    assert energy.shape[0] == 61
+    assert d65_energy.shape[0] == 61
+    assert d65_photons.shape[0] == 61
+    assert xyz_e.shape == (61, 3)
+    assert xyz_q.shape == (61, 3)
+
+
+def test_t_color_chromaticity():
+    mod = _load_tutorial("t_color_chromaticity.py")
+    xy_white, xy_primaries, xy_scene = mod.main()
+    assert xy_white.shape[-1] == 2
+    assert xy_primaries.shape == (3, 2)
+    assert xy_scene.shape[1] == 2
+
+
+def test_t_color_spectrum():
+    mod = _load_tutorial("t_color_spectrum.py")
+    rgb_spectrum, srgb = mod.main()
+    assert rgb_spectrum.shape[1] == 3
+    assert srgb.shape == rgb_spectrum.shape
+
+
+def test_t_color_matching():
+    mod = _load_tutorial("t_color_matching.py")
+    rgb2xyz, xyz2rgb, srgb = mod.main()
+    assert rgb2xyz.shape == (3, 3)
+    assert xyz2rgb.shape == (3, 3)
+    assert srgb.shape == (3,)

--- a/python/tutorials/color/t_color_chromaticity.py
+++ b/python/tutorials/color/t_color_chromaticity.py
@@ -1,0 +1,36 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from isetcam import (
+    ie_init,
+    chromaticity,
+    chromaticity_plot,
+    ie_xyz_from_energy,
+    ie_xyz_from_photons,
+)
+from isetcam.display import display_create, display_plot
+from isetcam.scene import scene_create
+
+
+def main():
+    ie_init()
+
+    disp = display_create("lcdExample")
+    display_plot(disp, kind="gamut")
+
+    xy_white = chromaticity(disp.white_point[np.newaxis, :])[0]
+    chromaticity_plot(xy_white[np.newaxis, :])
+
+    xyz_primaries = ie_xyz_from_energy(disp.spd.T, disp.wave)
+    xy_primaries = chromaticity(xyz_primaries)
+    chromaticity_plot(xy_primaries)
+
+    scene = scene_create("macbeth d65")
+    xyz_scene = ie_xyz_from_photons(scene.photons, scene.wave)
+    xy_scene = chromaticity(xyz_scene.reshape(-1, 3))
+    chromaticity_plot(xy_scene)
+
+    return xy_white, xy_primaries, xy_scene
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/color/t_color_energy_quanta.py
+++ b/python/tutorials/color/t_color_energy_quanta.py
@@ -1,0 +1,68 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from isetcam import (
+    ie_init,
+    data_path,
+    ie_read_spectra,
+    quanta_to_energy,
+    energy_to_quanta,
+    ie_xyz_from_energy,
+    ie_xyz_from_photons,
+    chromaticity,
+)
+
+
+def main():
+    ie_init()
+
+    wave = np.arange(400, 705, 5)
+
+    photons = np.ones_like(wave)
+    energy = quanta_to_energy(wave, photons).ravel()
+
+    plt.figure()
+    plt.plot(wave, energy)
+    plt.xlabel("Wavelength (nm)")
+    plt.ylabel("Energy (watts/sr/nm/m2)")
+    plt.grid(True)
+
+    d65_energy, _, _, _ = ie_read_spectra(data_path("lights/D65.mat"), wave)
+    d65_xyz = ie_xyz_from_energy(d65_energy.T, wave).ravel()
+    d65_energy = d65_energy.ravel() * 100 / d65_xyz[1]
+
+    plt.figure()
+    plt.plot(wave, d65_energy)
+    plt.xlabel("Wavelength (nm)")
+    plt.ylabel("Energy (watts/sr/nm/m2)")
+    plt.grid(True)
+
+    d65_photons = energy_to_quanta(wave, d65_energy).ravel()
+    plt.figure()
+    plt.plot(wave, d65_photons)
+    plt.xlabel("Wavelength (nm)")
+    plt.ylabel("Photons (q/sr/nm/m2)")
+    plt.grid(True)
+
+    xyz_energy, _, _, _ = ie_read_spectra(data_path("human/XYZ.mat"), wave)
+    xyz_quanta = energy_to_quanta(wave, xyz_energy)
+
+    plt.figure()
+    plt.plot(wave, xyz_energy)
+    plt.title("XYZ standard (energy)")
+    plt.grid(True)
+
+    plt.figure()
+    plt.plot(wave, xyz_quanta)
+    plt.title("XYZ photons")
+    plt.grid(True)
+
+    d65_xyz_p = ie_xyz_from_photons(d65_photons, wave).ravel()
+    d65_xyz_e = ie_xyz_from_energy(d65_energy, wave).ravel()
+
+    _ = (d65_xyz_p, d65_xyz_e, chromaticity(d65_xyz_e[np.newaxis, :]))
+
+    return energy, d65_energy, d65_photons, xyz_energy, xyz_quanta
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/color/t_color_matching.py
+++ b/python/tutorials/color/t_color_matching.py
@@ -1,0 +1,45 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from isetcam import (
+    ie_init,
+    data_path,
+    ie_read_spectra,
+    ie_xyz_from_energy,
+    lrgb_to_srgb,
+)
+from isetcam.display import display_create, display_set
+
+
+def main():
+    ie_init()
+
+    wave = np.arange(400, 701, 10)
+    XYZ, _, _, _ = ie_read_spectra(data_path("human/XYZ.mat"), wave)
+
+    disp = display_create("LCD-Apple")
+    spd = np.column_stack([
+        np.interp(wave, disp.wave, disp.spd[:, i], left=0.0, right=0.0)
+        for i in range(3)
+    ])
+    display_set(disp, "wave", wave)
+    display_set(disp, "spd", spd)
+
+    rgb2xyz = XYZ.T @ spd
+    xyz2rgb = np.linalg.inv(rgb2xyz)
+
+    d65_energy, _, _, _ = ie_read_spectra(data_path("lights/D65.mat"), wave)
+    d65_energy = d65_energy.ravel()
+    xyz = ie_xyz_from_energy(d65_energy[np.newaxis, :], wave).ravel()
+    rgb = xyz2rgb @ xyz
+    rgb = np.clip(rgb / rgb.max(), 0.0, 1.0)
+    srgb = lrgb_to_srgb(rgb[np.newaxis, :]).ravel()
+
+    plt.figure()
+    plt.imshow(np.ones((10, 10, 3)) * srgb[np.newaxis, np.newaxis, :])
+    plt.axis("off")
+
+    return rgb2xyz, xyz2rgb, srgb
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/color/t_color_spectrum.py
+++ b/python/tutorials/color/t_color_spectrum.py
@@ -1,0 +1,57 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.colors import ListedColormap
+from isetcam import (
+    ie_init,
+    data_path,
+    ie_read_spectra,
+    lrgb_to_srgb,
+)
+from isetcam.display import display_create, display_set
+
+
+def main():
+    ie_init()
+
+    wave = np.arange(390, 731)
+    XYZ, _, _, _ = ie_read_spectra(data_path("human/XYZ.mat"), wave)
+
+    disp = display_create("LCD-Apple")
+    spd = np.column_stack([
+        np.interp(wave, disp.wave, disp.spd[:, i], left=0.0, right=0.0)
+        for i in range(3)
+    ])
+    display_set(disp, "wave", wave)
+    display_set(disp, "spd", spd)
+
+    rgb2xyz = XYZ.T @ spd
+    xyz2rgb = np.linalg.inv(rgb2xyz)
+
+    rgb_spectrum = (xyz2rgb @ XYZ.T).T
+
+    Yvalue = XYZ[:, 1]
+    scale_factor = Yvalue + 0.4
+    rgb_spectrum = rgb_spectrum / scale_factor[:, np.newaxis]
+
+    gray_level = abs(rgb_spectrum.min())
+    rgb_spectrum = rgb_spectrum + gray_level
+    rgb_spectrum = rgb_spectrum / rgb_spectrum.max()
+
+    plt.figure()
+    plt.plot(wave, rgb_spectrum)
+    plt.xlabel("Wavelength (nm)")
+    plt.ylabel("Linear RGB")
+    plt.grid(True)
+
+    srgb = lrgb_to_srgb(rgb_spectrum)
+
+    cmap = ListedColormap(srgb)
+    plt.figure()
+    plt.imshow(np.arange(len(wave))[np.newaxis, :], cmap=cmap, aspect="auto")
+    plt.xlabel("wavelength (nm)")
+
+    return rgb_spectrum, srgb
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement color tutorial scripts in `python/tutorials/color`
- add tests exercising the new tutorials

## Testing
- `pytest -q python/tests/test_color_tutorials.py`

------
https://chatgpt.com/codex/tasks/task_e_683e757d7fac8323b58690f48396536d