### PR TITLE
Add xyz support to scene_get

### DIFF
--- a/python/isetcam/scene/scene_get.py
+++ b/python/isetcam/scene/scene_get.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import numpy as np
-
 from .scene_class import Scene
 from ..luminance_from_photons import luminance_from_photons
+from ..ie_xyz_from_photons import ie_xyz_from_photons
 from ..ie_param_format import ie_param_format
 
 
@@ -16,7 +15,7 @@ def scene_get(scene: Scene, param: str) -> Any:
     """Return a parameter value from ``scene``.
 
     Supported parameters are ``photons``, ``wave``, ``n_wave``/``nwave``,
-    ``name``, and ``luminance``.
+    ``name``, ``luminance``, and ``xyz``.
     """
     key = ie_param_format(param)
     if key == "photons":
@@ -29,4 +28,6 @@ def scene_get(scene: Scene, param: str) -> Any:
         return getattr(scene, "name", None)
     if key == "luminance":
         return luminance_from_photons(scene.photons, scene.wave)
+    if key == "xyz":
+        return ie_xyz_from_photons(scene.photons, scene.wave)
     raise KeyError(f"Unknown scene parameter '{param}'")

--- a/python/tests/test_scene_get_set.py
+++ b/python/tests/test_scene_get_set.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from isetcam.scene import Scene, scene_get, scene_set
 from isetcam.luminance_from_photons import luminance_from_photons
+from isetcam.ie_xyz_from_photons import ie_xyz_from_photons
 
 
 def test_scene_get_set():
@@ -28,3 +29,15 @@ def test_scene_get_set():
 
     scene_set(sc, " NaMe", "new")
     assert scene_get(sc, " NAME ") == "new"
+
+
+def test_scene_get_xyz():
+    wave = np.array([500, 510, 520])
+    photons = np.ones((1, 1, 3))
+    sc = Scene(photons=photons, wave=wave)
+
+    xyz = scene_get(sc, "xyz")
+    expected = ie_xyz_from_photons(photons, wave)
+
+    assert xyz.shape == (1, 1, 3)
+    assert np.allclose(xyz, expected)


### PR DESCRIPTION
## Summary
- add xyz retrieval to `scene_get`
- document xyz in the docstring
- test xyz retrieval in scene_get

## Testing
- `flake8 python/isetcam/scene/scene_get.py python/tests/test_scene_get_set.py`
- `PYTHONPATH=python pytest python/tests/test_scene_get_set.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683e8265fbd08323970c9a2db54a0265