### PR TITLE
Add display XYZ retrieval

### DIFF
--- a/python/isetcam/display/__init__.py
+++ b/python/isetcam/display/__init__.py
@@ -3,7 +3,9 @@
 
 Use :func:`display_create` to load one of the calibration files that ship
 with ISETCam, or :func:`display_from_file` to load a display definition from a
-MAT-file.
+MAT-file. :func:`display_get` can be used to query various parameters
+including the display white point (``"white xyz"``) and the XYZ values of
+each primary (``"primaries xyz"``).
 """
 
 from .display_class import Display

--- a/python/isetcam/display/display_get.py
+++ b/python/isetcam/display/display_get.py
@@ -9,14 +9,15 @@ import numpy as np
 
 from .display_class import Display
 from ..ie_param_format import ie_param_format
+from ..ie_xyz_from_energy import ie_xyz_from_energy
 
 
 def display_get(display: Display, param: str) -> Any:
     """Return a parameter value from ``display``.
 
     Supported parameters are ``spd``, ``wave``, ``n_wave``/``nwave``, ``gamma``,
-    ``max_luminance`` and ``white_point``/``whitepoint`` in addition to
-    ``name``.
+    ``max_luminance`` and ``white_point``/``whitepoint`` as well as
+    ``white_xyz`` and ``primaries_xyz`` in addition to ``name``.
     """
     key = ie_param_format(param)
     if key == "spd":
@@ -29,6 +30,14 @@ def display_get(display: Display, param: str) -> Any:
         return getattr(display, "max_luminance", None)
     if key in {"whitepoint", "white_point"}:
         return getattr(display, "white_point", None)
+    if key == "whitexyz":
+        spd = np.asarray(display.spd, dtype=float)
+        wave = np.asarray(display.wave, dtype=float)
+        return ie_xyz_from_energy(spd.sum(axis=1), wave).reshape(3)
+    if key == "primariesxyz":
+        spd = np.asarray(display.spd, dtype=float)
+        wave = np.asarray(display.wave, dtype=float)
+        return ie_xyz_from_energy(spd.T, wave)
     if key in {"nwave", "n_wave"}:
         return len(display.wave)
     if key == "name":

--- a/python/tests/test_display_get_set.py
+++ b/python/tests/test_display_get_set.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from isetcam.display import Display, display_get, display_set
+from isetcam import ie_xyz_from_energy
 
 
 def test_display_get_set():
@@ -14,6 +15,13 @@ def test_display_get_set():
     assert display_get(disp, "N WaVe") == 3
     assert np.array_equal(display_get(disp, "  gAmMa"), gamma)
     assert display_get(disp, " NAME ") == "orig"
+
+    # White and primary XYZ from the original data
+    expected_white = ie_xyz_from_energy(spd.sum(axis=1), wave).reshape(3)
+    assert np.allclose(display_get(disp, "white xyz"), expected_white)
+
+    expected_primaries = ie_xyz_from_energy(spd.T, wave)
+    assert np.allclose(display_get(disp, "primaries xyz"), expected_primaries)
 
     new_spd = np.zeros_like(spd)
     display_set(disp, " SpD ", new_spd)


### PR DESCRIPTION
## Summary
- extend `display_get` to return white and primary XYZ values
- document new options in display module
- test `display_get` for `white xyz` and `primaries xyz`

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_display_get_set.py::test_display_get_set -q`

------
https://chatgpt.com/codex/tasks/task_e_683e894c9b508323b417691963c8b741