### PR TITLE
Add scene introduction tutorial and test

### DIFF
--- a/python/tests/test_scene_introduction.py
+++ b/python/tests/test_scene_introduction.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import importlib.util
+import sys
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _mpl_available() -> bool:
+    try:
+        import matplotlib.pyplot as _  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _load_tutorial():
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "scene" / "t_scene_introduction.py"
+    spec = importlib.util.spec_from_file_location("t_scene_introduction", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.skipif(not _mpl_available(), reason="matplotlib not installed")
+def test_scene_introduction_exec():
+    mod = _load_tutorial()
+    mod.main()

--- a/python/tutorials/scene/t_scene_introduction.py
+++ b/python/tutorials/scene/t_scene_introduction.py
@@ -1,0 +1,38 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.scene import (
+    scene_create,
+    scene_show_image,
+    scene_plot,
+    scene_adjust_illuminant,
+    scene_description,
+)
+from isetcam.illuminant import illuminant_blackbody
+
+
+def main() -> None:
+    ie_init()
+
+    # Create a simple Macbeth chart scene and display it
+    scene = scene_create("macbeth d65")
+    scene.fov = 8.0
+    scene_show_image(scene)
+
+    # Print a short text description of the scene
+    print(scene_description(scene))
+
+    # Plot the radiance image
+    scene_plot(scene, kind="radiance image")
+
+    # Change some scene parameters
+    scene.distance = 0.6
+    scene.fov /= 2.0
+
+    # Adjust the illuminant to a 5500 K blackbody
+    bb = illuminant_blackbody(5500, scene.wave)
+    scene = scene_adjust_illuminant(scene, bb)
+    scene_show_image(scene)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- translate scene introduction to Python
- exercise the tutorial with a unit test

## Testing
- `pytest -k scene_introduction -vv`

------
https://chatgpt.com/codex/tasks/task_e_683e8bd830a48323a0d7fdfd00bd12be