### PR TITLE
Add optical image tutorials

### DIFF
--- a/python/isetcam/camera/camera_clear_data.py
+++ b/python/isetcam/camera/camera_clear_data.py
@@ -18,6 +18,14 @@ def camera_clear_data(camera: Camera) -> Camera:
     """
     camera.optical_image = oi_clear_data(camera.optical_image)
     camera.sensor = sensor_clear_data(camera.sensor)
+    if getattr(camera.optical_image, "name", None) is None:
+        camera.optical_image.name = ""
+    if getattr(camera.sensor, "name", None) is None:
+        camera.sensor.name = ""
+    if getattr(camera.optical_image, "optics_model", None) is None:
+        camera.optical_image.optics_model = ""
+    if getattr(camera, "name", None) is None:
+        camera.name = ""
     if hasattr(camera, "ip"):
         camera.ip = ip_clear_data(camera.ip)
     return camera

--- a/python/isetcam/camera/camera_to_file.py
+++ b/python/isetcam/camera/camera_to_file.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from scipy.io import savemat
 
 from .camera_class import Camera
+from .camera_clear_data import camera_clear_data
 
 
 def camera_to_file(camera: Camera, path: str | Path) -> None:
@@ -17,5 +18,5 @@ def camera_to_file(camera: Camera, path: str | Path) -> None:
     The sensor and optical image dataclasses are stored as nested structures
     under the variable name ``'camera'``.
     """
-    data = asdict(camera)
+    data = asdict(camera_clear_data(camera))
     savemat(str(Path(path)), {"camera": data})

--- a/python/isetcam/opticalimage/__init__.py
+++ b/python/isetcam/opticalimage/__init__.py
@@ -38,6 +38,7 @@ from .oi_illuminant_pattern import oi_illuminant_pattern
 from .oi_illuminant_ss import oi_illuminant_ss
 from .oi_clear_data import oi_clear_data
 from .oi_calculate_otf import oi_calculate_otf
+from .oi_radiance_to_irradiance import oi_radiance_to_irradiance
 from .oi_plot import oi_plot
 from .oi_wb_compute import oi_wb_compute
 from .oi_diffuser import oi_diffuser, oi_birefringent_diffuser
@@ -83,6 +84,7 @@ __all__ = [
     "oi_illuminant_ss",
     "oi_clear_data",
     "oi_calculate_otf",
+    "oi_radiance_to_irradiance",
     "oi_wb_compute",
     "oi_diffuser",
     "oi_birefringent_diffuser",

--- a/python/isetcam/opticalimage/oi_class.py
+++ b/python/isetcam/opticalimage/oi_class.py
@@ -17,6 +17,9 @@ class OpticalImage:
     photons: np.ndarray
     wave: np.ndarray | None = None
     name: str | None = None
+    optics_f_number: float = 0.0
+    optics_f_length: float = 0.0
+    optics_model: str = ""
 
     def __post_init__(self) -> None:
         if self.wave is None:

--- a/python/isetcam/opticalimage/oi_clear_data.py
+++ b/python/isetcam/opticalimage/oi_clear_data.py
@@ -37,6 +37,8 @@ def oi_clear_data(oi: OpticalImage) -> OpticalImage:
     for attr in _OPTIONAL_ATTRS:
         if hasattr(oi, attr):
             delattr(oi, attr)
+    if getattr(oi, "name", None) is None:
+        oi.name = ""
     return oi
 
 

--- a/python/isetcam/opticalimage/oi_compute.py
+++ b/python/isetcam/opticalimage/oi_compute.py
@@ -43,4 +43,11 @@ def oi_compute(scene: Scene, optics: Optics) -> OpticalImage:
     scale = (float(optics.f_length) / float(optics.f_number)) ** 2
     oi_photons *= scale
 
-    return OpticalImage(photons=oi_photons, wave=oi_wave, name=getattr(scene, "name", None))  # noqa: E501
+    return OpticalImage(
+        photons=oi_photons,
+        wave=oi_wave,
+        name=getattr(scene, "name", None),
+        optics_f_number=float(optics.f_number),
+        optics_f_length=float(optics.f_length),
+        optics_model=getattr(optics, "model", ""),
+    )

--- a/python/isetcam/opticalimage/oi_radiance_to_irradiance.py
+++ b/python/isetcam/opticalimage/oi_radiance_to_irradiance.py
@@ -1,0 +1,26 @@
+"""Convert scene radiance to optical image irradiance."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def oi_radiance_to_irradiance(radiance: np.ndarray, f_number: float) -> np.ndarray:
+    """Return irradiance from scene radiance for a lens with ``f_number``.
+
+    Parameters
+    ----------
+    radiance : array-like
+        Scene radiance values.
+    f_number : float
+        Lens f-number.
+
+    Returns
+    -------
+    np.ndarray
+        Irradiance corresponding to ``radiance``.
+    """
+    return np.asarray(radiance, dtype=float) * (np.pi / float(f_number) ** 2)
+
+
+__all__ = ["oi_radiance_to_irradiance"]

--- a/python/isetcam/opticalimage/oi_set.py
+++ b/python/isetcam/opticalimage/oi_set.py
@@ -11,11 +11,11 @@ from .oi_class import OpticalImage
 from ..ie_param_format import ie_param_format
 
 
-def oi_set(oi: OpticalImage, param: str, val: Any) -> None:
+def oi_set(oi: OpticalImage, param: str, val: Any, units: str | None = None) -> None:
     """Set a parameter value on ``oi``.
 
-    Supported parameters are ``photons``, ``wave`` and ``name``. ``n_wave`` and
-    ``luminance`` are derived values and therefore cannot be set.
+    Supported parameters include ``photons``, ``wave``, ``name`` and basic optics
+    properties.
     """
     key = ie_param_format(param)
     if key == "photons":
@@ -26,5 +26,17 @@ def oi_set(oi: OpticalImage, param: str, val: Any) -> None:
         return
     if key == "name":
         oi.name = None if val is None else str(val)
+        return
+    if key in {"opticsfnumber", "opticsf_number"}:
+        oi.optics_f_number = float(val)
+        return
+    if key in {"opticsfocallength", "opticsf_length"}:
+        length = float(val)
+        if units == "mm":
+            length /= 1e3
+        oi.optics_f_length = length
+        return
+    if key == "opticsmodel":
+        oi.optics_model = None if val is None else str(val)
         return
     raise KeyError(f"Unknown or read-only optical image parameter '{param}'")

--- a/python/isetcam/quanta2energy.py
+++ b/python/isetcam/quanta2energy.py
@@ -46,7 +46,10 @@ def quanta_to_energy(wavelength: np.ndarray, photons: np.ndarray) -> np.ndarray:
         if photons.ndim == 1:
             photons = photons[np.newaxis, :]
         if photons.shape[1] != len(wavelength):
-            raise ValueError('Photons (Quanta) must be in XW format.')
+            if photons.shape[0] == len(wavelength) and photons.shape[1] == 1:
+                photons = photons.T
+            else:
+                raise ValueError('Photons (Quanta) must be in XW format.')
         return (h * c / 1e-9) * photons / wavelength
 
     raise ValueError('Unknown image format')

--- a/python/isetcam/sensor/sensor_clear_data.py
+++ b/python/isetcam/sensor/sensor_clear_data.py
@@ -32,6 +32,8 @@ def sensor_clear_data(sensor: Sensor) -> Sensor:
     for attr in _OPTIONAL_ATTRS:
         if hasattr(sensor, attr):
             delattr(sensor, attr)
+    if getattr(sensor, "name", None) is None:
+        sensor.name = ""
     return sensor
 
 

--- a/python/isetcam/vc_get_image_format.py
+++ b/python/isetcam/vc_get_image_format.py
@@ -27,8 +27,12 @@ def vc_get_image_format(data: np.ndarray, wave: np.ndarray) -> Optional[str]:
     if data.ndim == 3 and len(wave) == data.shape[2]:
         return 'RGB'
     if data.ndim == 2 and len(wave) == 1:
+        if data.shape[1] == 1:
+            return 'XW'
         return 'RGB'
     if data.ndim == 2 and len(wave) == data.shape[1]:
+        return 'XW'
+    if data.ndim == 2 and len(wave) == data.shape[0] and data.shape[1] == 1:
         return 'XW'
     if data.ndim == 1 and data.size == len(wave):
         return 'XW'

--- a/python/tests/test_oi_tutorials.py
+++ b/python/tests/test_oi_tutorials.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import importlib.util
+import sys
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial(name: str):
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "oi" / name
+    spec = importlib.util.spec_from_file_location(name[:-3], path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_t_oi_introduction():
+    mod = _load_tutorial("t_oi_introduction.py")
+    fn_small, fn_big = mod.main()
+    assert fn_big > fn_small > 0
+
+
+def test_t_oi_principles():
+    mod = _load_tutorial("t_oi_principles.py")
+    p1, p2 = mod.main()
+    assert p1 > 0 and p2 > p1
+
+
+def test_t_oi_radiance_to_irradiance():
+    mod = _load_tutorial("t_oi_radiance_to_irradiance.py")
+    irr = mod.main()
+    assert irr.size == 5
+
+
+def test_t_oi_rt_compute():
+    mod = _load_tutorial("t_oi_rt_compute.py")
+    model = mod.main()
+    assert model == "ray trace"

--- a/python/tutorials/oi/t_oi_introduction.py
+++ b/python/tutorials/oi/t_oi_introduction.py
@@ -1,0 +1,34 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.scene import scene_create, scene_set
+from isetcam.optics import optics_create, optics_set
+from isetcam.opticalimage import (
+    oi_compute,
+    oi_get,
+    oi_set,
+    oi_plot,
+)
+
+
+def main():
+    ie_init()
+
+    scene = scene_create("gridlines", size=256, spacing=64)
+
+    optics = optics_create()
+    oi = oi_compute(scene, optics)
+    oi_set(oi, "name", "Small f number")
+
+    fn_small = oi_get(oi, "optics f number")
+
+    optics_big = optics_create()
+    optics_set(optics_big, "f_number", fn_small * 3)
+    oi_big = oi_compute(scene, optics_big)
+    oi_set(oi_big, "name", "Big f number")
+
+
+    return fn_small, oi_get(oi_big, "optics f number")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/oi/t_oi_principles.py
+++ b/python/tutorials/oi/t_oi_principles.py
@@ -1,0 +1,25 @@
+from isetcam import ie_init, data_path
+from isetcam.scene import scene_from_file, scene_set
+from isetcam.optics import optics_create, optics_set
+from isetcam.opticalimage import oi_compute, oi_get
+
+
+def main():
+    ie_init()
+
+    img_path = data_path("images/rgb/eagle.jpg")
+    scene = scene_from_file(img_path, mean_luminance=100)
+
+    optics = optics_create()
+    oi = oi_compute(scene, optics)
+    power1 = oi_get(oi, "optics diopters")
+
+    optics_set(optics, "f_length", 0.002)
+    oi2 = oi_compute(scene, optics)
+    power2 = oi_get(oi2, "optics diopters")
+
+    return power1, power2
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/oi/t_oi_radiance_to_irradiance.py
+++ b/python/tutorials/oi/t_oi_radiance_to_irradiance.py
@@ -1,0 +1,13 @@
+import numpy as np
+from isetcam.opticalimage import oi_radiance_to_irradiance
+
+
+def main():
+    radiance = np.linspace(0.1, 1.0, 5)
+    f_number = 4.0
+    irradiance = oi_radiance_to_irradiance(radiance, f_number)
+    return irradiance
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/oi/t_oi_rt_compute.py
+++ b/python/tutorials/oi/t_oi_rt_compute.py
@@ -1,0 +1,19 @@
+from isetcam import ie_init
+from isetcam.scene import scene_create
+from isetcam.optics import optics_create
+from isetcam.opticalimage import oi_compute, oi_get
+
+
+def main():
+    ie_init()
+    scene = scene_create("gridlines")
+
+    optics = optics_create()
+    optics.model = "ray trace"
+    oi = oi_compute(scene, optics)
+    model = oi_get(oi, "optics model")
+    return model
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add OpticalImage dataclass parameters for optics metadata
- compute and store lens info in `oi_compute`
- convert radiance to irradiance
- robust camera cleanup before saving
- handle more array shapes in conversion utilities
- add Python optical image tutorials and tests

## Testing
- `PYTHONPATH=python pytest python/tests/test_cli_pipeline.py python/tests/test_oi_tutorials.py -q`
- `PYTHONPATH=python pytest -q` *(fails: test_web_loc, test_web_retrieval due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683e90d95ab083238757b7dc5f166a9d