### PR TITLE
Add sensor tutorial translations

### DIFF
--- a/python/tests/test_sensor_tutorials.py
+++ b/python/tests/test_sensor_tutorials.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import importlib.util
+import sys
+import pytest
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial(name: str):
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "sensor" / name
+    spec = importlib.util.spec_from_file_location(name[:-3], path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _rawpy_available() -> bool:
+    try:
+        import rawpy  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def test_t_sensor_exposure_color():
+    mod = _load_tutorial("t_sensor_exposure_color.py")
+    exp_time, rgb1, rgb2 = mod.main()
+    assert exp_time > 0
+    assert rgb1.shape == (3,)
+    assert rgb2.shape == (3,)
+
+
+def test_t_sensor_color_filters():
+    mod = _load_tutorial("t_sensor_color_filters.py")
+    shape, names, mean_v = mod.main()
+    assert len(names) == shape[1]
+    assert mean_v >= 0
+
+
+def test_t_sensor_fpn():
+    mod = _load_tutorial("t_sensor_fpn.py")
+    base_mean, var_p, var_fpn = mod.main()
+    assert base_mean >= 0
+    assert var_fpn > var_p >= 0
+
+
+def test_t_sensor_input_refer():
+    mod = _load_tutorial("t_sensor_input_refer.py")
+    e1, lum, e2, ill, q = mod.main()
+    assert e1 > 0
+    assert e2 > 0
+    assert lum > 0
+    assert ill > 0
+    assert q > 0
+
+
+def test_t_sensor_spatial_resolution():
+    mod = _load_tutorial("t_sensor_spatial_resolution.py")
+    coarse_shape, fine_shape = mod.main()
+    assert coarse_shape[0] > 0 and fine_shape[0] > 0
+    assert fine_shape[0] >= coarse_shape[0]
+
+
+@pytest.mark.skipif(not _rawpy_available(), reason="rawpy not available")
+def test_t_sensor_read_raw():
+    mod = _load_tutorial("t_sensor_read_raw.py")
+    cropped_shape, rgb_shape = mod.main()
+    assert len(cropped_shape) == 2
+    assert rgb_shape[-1] == 3

--- a/python/tutorials/sensor/t_sensor_color_filters.py
+++ b/python/tutorials/sensor/t_sensor_color_filters.py
@@ -1,0 +1,31 @@
+import numpy as np
+from isetcam import ie_init, data_path, ie_read_color_filter
+from isetcam.scene import scene_create
+from isetcam.optics import optics_create
+from isetcam.opticalimage import oi_compute
+from isetcam.sensor import sensor_create, sensor_compute
+
+
+def main():
+    """Demonstrate loading color filters and computing sensor response."""
+    ie_init()
+
+    sensor = sensor_create()
+    wave = sensor.wave
+    filt_path = data_path("sensor/colorfilters/RGB.mat")
+    spectra, names, _ = ie_read_color_filter(filt_path, wave)
+    sensor.filter_spectra = spectra
+    sensor.filter_names = names
+
+    scene = scene_create("uniform monochromatic", wavelength=550, size=64)
+    scene.fov = 2.0
+    optics = optics_create()
+    oi = oi_compute(scene, optics)
+    sensor.volts = np.zeros(oi.photons.shape[:2], dtype=float)
+    sensor = sensor_compute(sensor, oi)
+
+    return sensor.filter_spectra.shape, sensor.filter_names, sensor.volts.mean()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/sensor/t_sensor_exposure_color.py
+++ b/python/tutorials/sensor/t_sensor_exposure_color.py
@@ -1,0 +1,55 @@
+import numpy as np
+from isetcam import ie_init, data_path, ie_read_color_filter
+from isetcam.scene import scene_create
+from isetcam.optics import optics_create
+from isetcam.opticalimage import oi_compute
+from isetcam.sensor import (
+    sensor_create,
+    sensor_compute,
+)
+from isetcam.display import display_create
+from isetcam.ip import ip_compute, ip_set
+
+
+def main():
+    """Illustrate exposure changes causing color errors when saturated."""
+    ie_init()
+
+    scene = scene_create("macbeth d65")
+    scene.fov = 8.0
+    optics = optics_create()
+    oi = oi_compute(scene, optics)
+
+    sensor = sensor_create()
+    sensor.volts = np.zeros(oi.photons.shape[:2], dtype=float)
+
+    # Attach RGB color filters and exaggerate green sensitivity
+    spec, names, _ = ie_read_color_filter(
+        data_path("sensor/colorfilters/RGB.mat"), sensor.wave
+    )
+    spec[:, 1] *= 1.5
+    sensor.filter_spectra = spec
+    sensor.filter_names = names
+    sensor.auto_exposure = True
+
+    sensor = sensor_compute(sensor, oi)
+    exp_time = sensor.exposure_time
+
+    disp = display_create()
+    disp.wave = sensor.wave
+    ip = ip_compute(sensor, disp)
+    ip_set(ip, "illuminant correction method", "gray world")
+    rgb1 = ip.rgb.mean(axis=(0, 1))
+
+    sensor.auto_exposure = False
+    sensor.exposure_time = 3 * exp_time
+    sensor = sensor_compute(sensor, oi)
+    ip2 = ip_compute(sensor, disp)
+    ip_set(ip2, "illuminant correction method", "gray world")
+    rgb2 = ip2.rgb.mean(axis=(0, 1))
+
+    return exp_time, rgb1, rgb2
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/sensor/t_sensor_fpn.py
+++ b/python/tutorials/sensor/t_sensor_fpn.py
@@ -1,0 +1,46 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.scene import scene_create
+from isetcam.optics import optics_create
+from isetcam.opticalimage import oi_compute
+from isetcam.sensor import (
+    sensor_create,
+    sensor_compute,
+    sensor_photon_noise,
+    sensor_add_noise,
+    sensor_set,
+)
+
+
+def main():
+    """Illustrate sensor noise components."""
+    ie_init()
+
+    scene = scene_create("uniform monochromatic", wavelength=550, size=128)
+    scene.fov = 8.0
+    optics = optics_create()
+    oi = oi_compute(scene, optics)
+
+    sensor = sensor_create()
+    sensor.volts = np.zeros(oi.photons.shape[:2], dtype=float)
+    sensor = sensor_compute(sensor, oi)
+    base = sensor.volts.copy()
+
+    # Photon noise only
+    sensor.volts = base.copy()
+    sensor_photon_noise(sensor)
+    photon_only = sensor.volts.copy()
+
+    # Photon noise + fixed pattern noise
+    sensor.volts = base.copy()
+    sensor_set(sensor, "gain_sd", 5.0)
+    sensor_set(sensor, "offset_sd", 0.05)
+    sensor_photon_noise(sensor)
+    sensor_add_noise(sensor)
+    fpn = sensor.volts.copy()
+
+    return base.mean(), photon_only.var(), fpn.var()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/sensor/t_sensor_input_refer.py
+++ b/python/tutorials/sensor/t_sensor_input_refer.py
@@ -1,0 +1,39 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.vc_constants import vc_constants
+from isetcam.scene import scene_create, scene_adjust_luminance
+from isetcam.optics import optics_create
+from isetcam.opticalimage import oi_compute, oi_get
+from isetcam.sensor import sensor_create, sensor_compute, sensor_set
+
+
+def main():
+    """Relate scene luminance to photon absorptions."""
+    ie_init()
+
+    target = 3.0
+    scene = scene_create("uniform monochromatic", wavelength=550, size=64)
+    scene = scene_adjust_luminance(scene, "mean", 1.0)
+    optics = optics_create()
+    oi = oi_compute(scene, optics)
+
+    sensor = sensor_create()
+    sensor.volts = np.zeros(oi.photons.shape[:2], dtype=float)
+    sensor_set(sensor, "exposure_time", 1.0)
+    sensor = sensor_compute(sensor, oi)
+    electrons = sensor.volts.mean()
+
+    new_lum = 1.0 * (target / electrons)
+    scene = scene_adjust_luminance(scene, "mean", new_lum)
+    oi = oi_compute(scene, optics)
+    lum_img = oi_get(oi, "luminance")
+    ill = float(lum_img.mean())
+    sensor = sensor_compute(sensor, oi)
+    electrons_new = sensor.volts.mean()
+
+    q = vc_constants("q")
+    return electrons, new_lum, electrons_new, ill, q
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/sensor/t_sensor_read_raw.py
+++ b/python/tutorials/sensor/t_sensor_read_raw.py
@@ -1,0 +1,20 @@
+from isetcam import data_path
+from isetcam.sensor import sensor_dng_read, sensor_crop
+from isetcam.display import display_create
+from isetcam.ip import ip_compute
+
+
+def main():
+    """Load a DNG file into a sensor and crop the data."""
+    path = data_path("images/rawcamera/MCC-centered.dng")
+    sensor = sensor_dng_read(path)
+    cropped = sensor_crop(sensor, (500, 1000, 2500, 2500))
+
+    disp = display_create()
+    disp.wave = cropped.wave
+    ip = ip_compute(cropped, disp)
+    return cropped.volts.shape, ip.rgb.shape
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/sensor/t_sensor_spatial_resolution.py
+++ b/python/tutorials/sensor/t_sensor_spatial_resolution.py
@@ -1,0 +1,32 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.scene import scene_create
+from isetcam.optics import optics_create
+from isetcam.opticalimage import oi_compute
+from isetcam.sensor import sensor_create, sensor_compute
+
+
+def main():
+    """Show effect of pixel size on spatial aliasing."""
+    ie_init()
+
+    scene = scene_create("frequency sweep", size=256)
+    scene.fov = 1.0
+    optics = optics_create()
+    oi = oi_compute(scene, optics)
+
+    coarse = sensor_create()
+    coarse.pixel_size = 6e-6
+    coarse.volts = np.zeros(oi.photons.shape[:2], dtype=float)
+    coarse = sensor_compute(coarse, oi)
+
+    fine = sensor_create()
+    fine.pixel_size = 2e-6
+    fine.volts = np.zeros(oi.photons.shape[:2], dtype=float)
+    fine = sensor_compute(fine, oi)
+
+    return coarse.volts.shape, fine.volts.shape
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python versions of several MATLAB sensor tutorials
- demonstrate sensor color filters, noise, exposure, raw DNG loading and more
- include tests exercising these new tutorials

## Testing
- `pytest python/tests/test_sensor_tutorials.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683e9bc300848323865e64f58cde2b54