### PR TITLE
Add display tutorials in Python

### DIFF
--- a/python/tests/test_display_tutorials.py
+++ b/python/tests/test_display_tutorials.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import importlib.util
+import sys
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial(name: str):
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "display" / name
+    spec = importlib.util.spec_from_file_location(name[:-3], path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_t_display_introduction():
+    mod = _load_tutorial("t_display_introduction.py")
+    shape1, shape2, shape3 = mod.main()
+    assert shape1 == shape2 == shape3
+    assert len(shape1) == 3
+
+
+def test_t_display_rendering():
+    mod = _load_tutorial("t_display_rendering.py")
+    patch = mod.main()
+    assert patch.shape == (6, 4, 3)

--- a/python/tutorials/display/t_display_introduction.py
+++ b/python/tutorials/display/t_display_introduction.py
@@ -1,0 +1,39 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from isetcam import ie_init, data_path
+from isetcam.display import display_create, display_plot
+from isetcam.scene import scene_from_file, scene_adjust_illuminant, Scene, scene_show_image
+from isetcam.illuminant import illuminant_create
+
+
+def main():
+    ie_init()
+
+    # Create a display and visualize some of its characteristics
+    disp = display_create("OLED-Samsung")
+    display_plot(disp, kind="spd")
+    display_plot(disp, kind="gamma")
+    display_plot(disp, kind="gamut")
+
+    # Load an image and convert it to a scene using the display model
+    img_path = data_path("images/rgb/eagle.jpg")
+    scene = scene_from_file(img_path)
+    scene_show_image(scene)
+
+    # Change the illuminant while preserving reflectance
+    fl_path = data_path("lights/Fluorescent.mat")
+    scene2 = scene_adjust_illuminant(scene, fl_path)
+    scene2.name = "fluorescent"
+    scene_show_image(scene2)
+
+    # Adjust illuminant using a D50 light
+    ill = illuminant_create("d50", scene.wave)
+    scene3 = scene_adjust_illuminant(scene, ill.spd)
+    scene3.name = "d50"
+    scene_show_image(scene3)
+
+    return scene.photons.shape, scene2.photons.shape, scene3.photons.shape
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/display/t_display_rendering.py
+++ b/python/tutorials/display/t_display_rendering.py
@@ -1,0 +1,46 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from isetcam import ie_init, data_path, ie_read_spectra
+from isetcam.display import display_create, display_apply_gamma
+
+
+def main():
+    ie_init()
+
+    disp = display_create("OLED-Samsung")
+    # Use only RGB primaries
+    disp.spd = disp.spd[:, :3]
+    disp.gamma = disp.gamma[:, :3]
+    wave = disp.wave
+
+    # Load reflectance data and illuminant
+    refl, _, _, _ = ie_read_spectra(data_path("surfaces/reflectances/macbethChart.mat"), wave)
+    d65, _, _, _ = ie_read_spectra(data_path("lights/D65.mat"), wave)
+    xyz_cmfs, _, _, _ = ie_read_spectra(data_path("human/XYZ.mat"), wave)
+
+    d65 = d65.reshape(-1)
+    macbeth_xyz = xyz_cmfs.T @ (d65[:, None] * refl)
+
+    phosphors = disp.spd
+    rgb_lin = np.linalg.inv(xyz_cmfs.T @ phosphors) @ macbeth_xyz
+    rgb_lin /= rgb_lin.max()
+
+    # Scale so that the white patch is [1,1,1]
+    wht = rgb_lin[:, 3]
+    rgb_lin = (1 / wht)[:, None] * rgb_lin
+
+    digital = display_apply_gamma(rgb_lin.T, disp, inverse=True)
+    digital /= digital.max()
+
+    patch = digital.reshape(4, 6, 3).transpose(1, 0, 2)
+    img = np.kron(patch, np.ones((20, 20, 1)))
+
+    fig, ax = plt.subplots()
+    ax.imshow(img)
+    ax.axis("off")
+
+    return patch
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ported `t_displayIntroduction.m` and `t_displayRendering.m` to Python
- added matplotlib visualisations for scenes and display info
- created tests invoking the new tutorials

## Testing
- `PYTHONPATH=python pytest python/tests/test_display_tutorials.py::test_t_display_introduction -q`
- `PYTHONPATH=python pytest python/tests/test_display_tutorials.py::test_t_display_rendering -q`
- `PYTHONPATH=python pytest -q` *(fails: `mocker` fixture missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f0692679c83239e3426cac21805aa