### PR TITLE
Add optic PSF, distortion, Fresnel utilities

### DIFF
--- a/python/isetcam/optics/__init__.py
+++ b/python/isetcam/optics/__init__.py
@@ -14,6 +14,11 @@ from .optics_defocused_mtf import optics_defocused_mtf, optics_defocus_core
 from .optics_coc import optics_coc
 from .optics_clear_data import optics_clear_data
 from .optics_dof import optics_dof
+from .optics_airy_psf import optics_airy_psf
+from .optics_barrel_distortion import optics_barrel_distortion
+from .optics_fresnel import optics_fresnel
+from .wvf_mtf import wvf_mtf
+from .wvf_zernike import wvf_zernike
 
 __all__ = [
     "Optics",
@@ -30,4 +35,9 @@ __all__ = [
     "optics_coc",
     "optics_clear_data",
     "optics_dof",
+    "optics_airy_psf",
+    "optics_barrel_distortion",
+    "optics_fresnel",
+    "wvf_mtf",
+    "wvf_zernike",
 ]

--- a/python/isetcam/optics/optics_airy_psf.py
+++ b/python/isetcam/optics/optics_airy_psf.py
@@ -1,0 +1,38 @@
+# mypy: ignore-errors
+"""Generate an Airy disk point spread function."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.special import j1
+
+
+def optics_airy_psf(size: int, radius: float) -> np.ndarray:
+    """Return an Airy disk PSF.
+
+    Parameters
+    ----------
+    size : int
+        Side length of the square PSF array. Should be odd for symmetry.
+    radius : float
+        Pixel radius of the first zero crossing of the Airy pattern.
+
+    Returns
+    -------
+    np.ndarray
+        Normalized PSF of shape ``(size, size)``.
+    """
+    if size <= 0:
+        raise ValueError("size must be positive")
+    ax = np.linspace(-(size // 2), size // 2, size)
+    xx, yy = np.meshgrid(ax, ax)
+    r = np.hypot(xx, yy)
+    r_norm = np.pi * r / float(radius)
+    psf = np.ones_like(r)
+    mask = r != 0
+    psf[mask] = (2 * j1(r_norm[mask]) / r_norm[mask]) ** 2
+    psf /= psf.sum()
+    return psf
+
+
+__all__ = ["optics_airy_psf"]

--- a/python/isetcam/optics/optics_barrel_distortion.py
+++ b/python/isetcam/optics/optics_barrel_distortion.py
@@ -1,0 +1,31 @@
+# mypy: ignore-errors
+"""Apply simple barrel distortion to coordinates."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def optics_barrel_distortion(x: np.ndarray, y: np.ndarray, k1: float) -> tuple[np.ndarray, np.ndarray]:
+    """Return distorted ``(x, y)`` coordinates.
+
+    Parameters
+    ----------
+    x, y : array-like
+        Undistorted coordinates (typically normalized to the range ``[-1, 1]``).
+    k1 : float
+        Radial distortion coefficient. Negative values yield barrel distortion.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        Distorted ``(x, y)`` coordinates.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    r2 = x ** 2 + y ** 2
+    factor = 1.0 + k1 * r2
+    return x * factor, y * factor
+
+
+__all__ = ["optics_barrel_distortion"]

--- a/python/isetcam/optics/optics_fresnel.py
+++ b/python/isetcam/optics/optics_fresnel.py
@@ -1,0 +1,39 @@
+# mypy: ignore-errors
+"""Simple scalar Fresnel propagation."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.fft import fft2, ifft2, fftshift, ifftshift, fftfreq
+
+
+def optics_fresnel(field: np.ndarray, dx: float, wavelength: float, distance: float) -> np.ndarray:
+    """Propagate ``field`` by ``distance`` using the Fresnel approximation.
+
+    Parameters
+    ----------
+    field : np.ndarray
+        Complex input field sampled on a square grid.
+    dx : float
+        Sample spacing in meters.
+    wavelength : float
+        Wavelength of light in meters.
+    distance : float
+        Propagation distance in meters.
+
+    Returns
+    -------
+    np.ndarray
+        Propagated complex field with the same shape as ``field``.
+    """
+    ny, nx = field.shape
+    fx = fftfreq(nx, dx)
+    fy = fftfreq(ny, dx)
+    FX, FY = np.meshgrid(fx, fy)
+    H = np.exp(-1j * np.pi * wavelength * distance * (FX ** 2 + FY ** 2))
+    F = fft2(ifftshift(field))
+    out = fftshift(ifft2(F * H))
+    return out
+
+
+__all__ = ["optics_fresnel"]

--- a/python/isetcam/optics/wvf_mtf.py
+++ b/python/isetcam/optics/wvf_mtf.py
@@ -1,0 +1,30 @@
+# mypy: ignore-errors
+"""Compute the modulation transfer function from a PSF."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.fft import fft2, fftshift
+
+
+def wvf_mtf(psf: np.ndarray) -> np.ndarray:
+    """Return the MTF corresponding to ``psf``.
+
+    Parameters
+    ----------
+    psf : np.ndarray
+        Point spread function. Must be real valued and centered.
+
+    Returns
+    -------
+    np.ndarray
+        MTF magnitude normalized to one at zero frequency.
+    """
+    otf = fftshift(fft2(psf / np.sum(psf)))
+    mtf = np.abs(otf)
+    center = tuple(s // 2 for s in psf.shape)
+    mtf /= mtf[center]
+    return mtf
+
+
+__all__ = ["wvf_mtf"]

--- a/python/isetcam/optics/wvf_zernike.py
+++ b/python/isetcam/optics/wvf_zernike.py
@@ -1,0 +1,53 @@
+# mypy: ignore-errors
+"""Evaluate a wavefront from Zernike coefficients."""
+
+from __future__ import annotations
+
+import numpy as np
+from math import factorial
+
+# Mapping for the first 10 Noll indices to (n, m)
+_NOLL_TO_NM = {
+    1: (0, 0),
+    2: (1, -1),
+    3: (1, 1),
+    4: (2, 0),
+    5: (2, -2),
+    6: (2, 2),
+    7: (3, -1),
+    8: (3, 1),
+    9: (3, -3),
+    10: (3, 3),
+}
+
+
+def _zernike(n: int, m: int, rho: np.ndarray, theta: np.ndarray) -> np.ndarray:
+    m_abs = abs(m)
+    out = np.zeros_like(rho, dtype=float)
+    for k in range((n - m_abs) // 2 + 1):
+        c = (
+            (-1) ** k
+            * factorial(n - k)
+            / (factorial(k) * factorial((n + m_abs) // 2 - k) * factorial((n - m_abs) // 2 - k))
+        )
+        out += c * rho ** (n - 2 * k)
+    if m >= 0:
+        return out * np.cos(m * theta)
+    else:
+        return out * np.sin(m_abs * theta)
+
+
+def wvf_zernike(coeffs: np.ndarray, rho: np.ndarray, theta: np.ndarray) -> np.ndarray:
+    """Return wavefront from ``coeffs`` evaluated on the ``(rho, theta)`` grid."""
+    if coeffs.ndim != 1:
+        raise ValueError("coeffs must be 1-D")
+    wvf = np.zeros_like(rho, dtype=float)
+    for j, c in enumerate(coeffs, start=1):
+        if j not in _NOLL_TO_NM:
+            raise ValueError("Noll index %d not supported" % j)
+        n, m = _NOLL_TO_NM[j]
+        wvf += c * _zernike(n, m, rho, theta)
+    return wvf
+
+
+__all__ = ["wvf_zernike"]

--- a/python/tests/test_optics_new_modules.py
+++ b/python/tests/test_optics_new_modules.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from isetcam.optics import (
+    optics_airy_psf,
+    optics_barrel_distortion,
+    optics_fresnel,
+)
+
+
+def test_optics_airy_psf_normalized():
+    psf = optics_airy_psf(64, 8.0)
+    assert np.isclose(psf.sum(), 1.0)
+    assert psf.max() <= 1.0
+
+
+def test_optics_barrel_distortion_strength():
+    x = np.array([1.0])
+    y = np.array([0.0])
+    xd, yd = optics_barrel_distortion(x, y, k1=-0.3)
+    r_in = np.hypot(x, y)
+    r_out = np.hypot(xd, yd)
+    assert r_out < r_in
+
+
+def test_optics_fresnel_delta():
+    field = np.zeros((32, 32), dtype=complex)
+    field[16, 16] = 1.0
+    out = optics_fresnel(field, dx=1e-6, wavelength=500e-9, distance=0.01)
+    energy_in = np.sum(np.abs(field) ** 2)
+    energy_out = np.sum(np.abs(out) ** 2)
+    assert np.isclose(energy_in, energy_out)


### PR DESCRIPTION
## Summary
- implement Airy disk PSF, barrel distortion and Fresnel propagation utilities
- add helpers for PSF MTF and Zernike wavefront calculation
- expose new functions in optics package
- add tests for PSF normalization, distortion strength, and Fresnel energy conservation

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_optics_new_modules.py`

------
https://chatgpt.com/codex/tasks/task_e_683f0ad9d3c88323bccaf772a60893f5