### PR TITLE
Add optics tutorials

### DIFF
--- a/python/tests/test_optics_tutorials.py
+++ b/python/tests/test_optics_tutorials.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import importlib.util
+import sys
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial(name: str):
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "optics" / name
+    spec = importlib.util.spec_from_file_location(name[:-3], path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_t_optics_airy_disk():
+    mod = _load_tutorial("t_optics_airy_disk.py")
+    shape, total, peak = mod.main()
+    assert shape == (64, 64)
+    assert np.isclose(total, 1.0)
+    assert peak <= 1.0
+
+
+def test_t_optics_barrel_distortion():
+    mod = _load_tutorial("t_optics_barrel_distortion.py")
+    rin, rout = mod.main()
+    assert np.all(rout < rin)
+
+
+def test_t_optics_fresnel():
+    mod = _load_tutorial("t_optics_fresnel.py")
+    e_in, e_out, shape = mod.main()
+    assert shape == (32, 32)
+    assert np.isclose(e_in, e_out)
+
+
+def test_t_wvf_mtf():
+    mod = _load_tutorial("t_wvf_mtf.py")
+    shape, center = mod.main()
+    assert shape == (64, 64)
+    assert np.isclose(center, 1.0)
+
+
+def test_t_wvf_zernike():
+    mod = _load_tutorial("t_wvf_zernike.py")
+    shape, mean_val = mod.main()
+    assert shape == (10, 10)
+    assert np.isclose(mean_val, 1.0)

--- a/python/tutorials/optics/t_optics_airy_disk.py
+++ b/python/tutorials/optics/t_optics_airy_disk.py
@@ -1,0 +1,12 @@
+import numpy as np
+from isetcam.optics import optics_airy_psf
+
+
+def main():
+    """Generate an Airy disk PSF and return basic properties."""
+    psf = optics_airy_psf(64, 8.0)
+    return psf.shape, float(psf.sum()), float(psf.max())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/optics/t_optics_barrel_distortion.py
+++ b/python/tutorials/optics/t_optics_barrel_distortion.py
@@ -1,0 +1,16 @@
+import numpy as np
+from isetcam.optics import optics_barrel_distortion
+
+
+def main():
+    """Apply barrel distortion to unit circle points."""
+    x = np.array([1.0, 0.0])
+    y = np.array([0.0, 1.0])
+    xd, yd = optics_barrel_distortion(x, y, k1=-0.3)
+    rin = np.hypot(x, y)
+    rout = np.hypot(xd, yd)
+    return rin, rout
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/optics/t_optics_fresnel.py
+++ b/python/tutorials/optics/t_optics_fresnel.py
@@ -1,0 +1,16 @@
+import numpy as np
+from isetcam.optics import optics_fresnel
+
+
+def main():
+    """Propagate a delta function field using Fresnel approximation."""
+    field = np.zeros((32, 32), dtype=complex)
+    field[16, 16] = 1.0
+    out = optics_fresnel(field, dx=1e-6, wavelength=500e-9, distance=0.01)
+    energy_in = float(np.sum(np.abs(field) ** 2))
+    energy_out = float(np.sum(np.abs(out) ** 2))
+    return energy_in, energy_out, out.shape
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/optics/t_wvf_mtf.py
+++ b/python/tutorials/optics/t_wvf_mtf.py
@@ -1,0 +1,14 @@
+import numpy as np
+from isetcam.optics import optics_airy_psf, wvf_mtf
+
+
+def main():
+    """Compute the MTF of an Airy PSF."""
+    psf = optics_airy_psf(64, 8.0)
+    mtf = wvf_mtf(psf)
+    center = mtf[psf.shape[0] // 2, psf.shape[1] // 2]
+    return mtf.shape, float(center)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/optics/t_wvf_zernike.py
+++ b/python/tutorials/optics/t_wvf_zernike.py
@@ -1,0 +1,16 @@
+import numpy as np
+from isetcam.optics import wvf_zernike
+
+
+def main():
+    """Evaluate a wavefront from a single Zernike coefficient."""
+    rho = np.linspace(0, 1, 10)
+    theta = np.linspace(0, 2 * np.pi, 10, endpoint=False)
+    R, T = np.meshgrid(rho, theta)
+    coeffs = np.array([1.0])
+    wvf = wvf_zernike(coeffs, R, T)
+    return wvf.shape, float(wvf.mean())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add optics tutorial scripts for optics and wavefront functions
- add unit tests that exercise the new tutorials

## Testing
- `pytest -q python/tests/test_optics_tutorials.py`

------
https://chatgpt.com/codex/tasks/task_e_683f17612e708323b3388185759d8c9b