### PR TITLE
Add JPEG utilities and image tutorials

### DIFF
--- a/python/isetcam/ip/__init__.py
+++ b/python/isetcam/ip/__init__.py
@@ -12,6 +12,8 @@ from .ip_plot import ip_plot
 from .ip_clear_data import ip_clear_data
 from .ip_hdr_white import ip_hdr_white
 from .ip_demosaic import ip_demosaic
+from .ip_jpeg_compress import ip_jpeg_compress
+from .ip_jpeg_decompress import ip_jpeg_decompress
 
 __all__ = [
     "VCImage",
@@ -25,4 +27,6 @@ __all__ = [
     "ip_clear_data",
     "ip_hdr_white",
     "ip_demosaic",
+    "ip_jpeg_compress",
+    "ip_jpeg_decompress",
 ]

--- a/python/isetcam/ip/ip_jpeg_compress.py
+++ b/python/isetcam/ip/ip_jpeg_compress.py
@@ -1,0 +1,93 @@
+# mypy: ignore-errors
+"""JPEG-like DCT quantization of a grayscale image."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.fftpack import dct
+
+__all__ = ["ip_jpeg_compress"]
+
+
+def _jpeg_qtable(qfactor: float, table: int = 1) -> np.ndarray:
+    qfactor = float(qfactor)
+    if qfactor < 1:
+        qfactor = 1
+    if qfactor > 100:
+        qfactor = 100
+    if qfactor < 50:
+        scale = 5000 / qfactor
+    else:
+        scale = 200 - 2 * qfactor
+
+    if table == 1:
+        q = np.array([
+            [16, 11, 12, 14, 12, 10, 16, 14],
+            [13, 14, 18, 17, 16, 19, 24, 40],
+            [26, 24, 22, 22, 24, 49, 35, 37],
+            [29, 40, 58, 51, 61, 60, 57, 51],
+            [56, 55, 64, 72, 92, 78, 64, 68],
+            [87, 69, 55, 56, 80, 109, 81, 87],
+            [95, 98, 103, 104, 103, 62, 77, 113],
+            [121, 112, 100, 120, 92, 101, 103, 99],
+        ], dtype=float)
+    elif table == 2:
+        q = np.array([
+            [17, 18, 18, 24, 21, 24, 47, 26],
+            [26, 47, 99, 66, 56, 66, 99, 99],
+            [99, 99, 99, 99, 99, 99, 99, 99],
+            [99, 99, 99, 99, 99, 99, 99, 99],
+            [99, 99, 99, 99, 99, 99, 99, 99],
+            [99, 99, 99, 99, 99, 99, 99, 99],
+            [99, 99, 99, 99, 99, 99, 99, 99],
+            [99, 99, 99, 99, 99, 99, 99, 99],
+        ], dtype=float)
+    else:
+        raise ValueError("table must be 1 or 2")
+
+    q = np.floor((q * scale + 50) / 100)
+    q = np.clip(q, 1, 255)
+    return q
+
+
+def _dct2(block: np.ndarray) -> np.ndarray:
+    return dct(dct(block, axis=0, norm="ortho"), axis=1, norm="ortho")
+
+
+def ip_jpeg_compress(im: np.ndarray, qinfo: float | np.ndarray = 50) -> np.ndarray:
+    """Return quantized DCT coefficients of ``im``.
+
+    Parameters
+    ----------
+    im : np.ndarray
+        Grayscale image with values in range 0-255 or 0-1.
+    qinfo : float or np.ndarray, optional
+        Quality factor (1-100) or custom 8x8 quantization table.
+        Defaults to ``50``.
+    """
+    im = np.asarray(im, dtype=float)
+    if im.ndim != 2:
+        raise ValueError("Image must be 2-D")
+
+    if np.isscalar(qinfo):
+        qtable = _jpeg_qtable(float(qinfo), 1)
+    else:
+        qtable = np.asarray(qinfo, dtype=float)
+        if qtable.shape != (8, 8):
+            raise ValueError("qinfo must be scalar or 8x8 table")
+
+    if im.max() <= 1.0:
+        im = im * 255.0
+
+    r, c = im.shape
+    r = (r // 8) * 8
+    c = (c // 8) * 8
+    im = im[:r, :c]
+
+    coef = np.zeros_like(im)
+    for i in range(0, r, 8):
+        for j in range(0, c, 8):
+            block = im[i : i + 8, j : j + 8]
+            d = _dct2(block)
+            coef[i : i + 8, j : j + 8] = np.round(d / qtable) * qtable
+    return coef

--- a/python/isetcam/ip/ip_jpeg_decompress.py
+++ b/python/isetcam/ip/ip_jpeg_decompress.py
@@ -1,0 +1,30 @@
+# mypy: ignore-errors
+"""Inverse DCT decoding of JPEG coefficients."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.fftpack import idct
+
+__all__ = ["ip_jpeg_decompress"]
+
+
+def _idct2(block: np.ndarray) -> np.ndarray:
+    return idct(idct(block, axis=0, norm="ortho"), axis=1, norm="ortho")
+
+
+def ip_jpeg_decompress(coef: np.ndarray) -> np.ndarray:
+    """Return reconstructed image from quantized DCT coefficients."""
+    coef = np.asarray(coef, dtype=float)
+    if coef.ndim != 2:
+        raise ValueError("Coefficients must be 2-D")
+    r, c = coef.shape
+    if r % 8 != 0 or c % 8 != 0:
+        raise ValueError("Coefficient array size must be multiple of 8")
+
+    img = np.zeros_like(coef)
+    for i in range(0, r, 8):
+        for j in range(0, c, 8):
+            block = coef[i : i + 8, j : j + 8]
+            img[i : i + 8, j : j + 8] = _idct2(block)
+    return img

--- a/python/tests/test_image_tutorials.py
+++ b/python/tests/test_image_tutorials.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import importlib.util
+import sys
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial(name: str):
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "image" / name
+    spec = importlib.util.spec_from_file_location(name[:-3], path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_t_ip():
+    mod = _load_tutorial("t_ip.py")
+    shape = mod.main()
+    assert len(shape) == 3 and shape[2] == 3
+
+
+def test_t_ip_demosaic():
+    mod = _load_tutorial("t_ip_demosaic.py")
+    s1, s2 = mod.main()
+    assert s1 == s2
+    assert s1[2] == 3
+
+
+def test_t_ip_jpeg_monochrome():
+    mod = _load_tutorial("t_ip_jpeg_monochrome.py")
+    im_shape, coef_shape, rec_shape = mod.main()
+    assert coef_shape == im_shape
+    assert rec_shape == im_shape
+
+
+def test_t_ip_jpeg_color():
+    mod = _load_tutorial("t_ip_jpeg_color.py")
+    orig_shape, jpeg_shape = mod.main()
+    assert orig_shape == jpeg_shape
+    assert orig_shape[2] == 3

--- a/python/tutorials/image/t_ip.py
+++ b/python/tutorials/image/t_ip.py
@@ -1,0 +1,24 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.scene import scene_create
+from isetcam.camera import camera_create, camera_compute
+from isetcam.sensor import sensor_create
+from isetcam.display import display_create
+from isetcam.ip import ip_compute
+
+
+def main():
+    ie_init()
+    scene = scene_create("macbeth tungsten")
+    cam = camera_create(sensor_create())
+    cam.sensor.volts = np.zeros((340, 420), dtype=float)
+    camera_compute(cam, scene)
+
+    disp = display_create()
+    disp.wave = cam.sensor.wave
+    ip = ip_compute(cam.sensor, disp)
+    return ip.rgb.shape
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/image/t_ip_demosaic.py
+++ b/python/tutorials/image/t_ip_demosaic.py
@@ -1,0 +1,22 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.scene import scene_create
+from isetcam.camera import camera_create, camera_compute
+from isetcam.sensor import sensor_create
+from isetcam.ip import ip_demosaic
+
+
+def main():
+    ie_init()
+    scene = scene_create("macbeth d65")
+    cam = camera_create(sensor_create())
+    camera_compute(cam, scene)
+    mosaic = cam.sensor.volts
+    pattern = getattr(cam.sensor, "filter_color_letters", "rggb")
+    rgb_bilinear = ip_demosaic(mosaic, pattern, method="bilinear")
+    rgb_nn = ip_demosaic(mosaic, pattern, method="nearest")
+    return rgb_bilinear.shape, rgb_nn.shape
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/image/t_ip_jpeg_color.py
+++ b/python/tutorials/image/t_ip_jpeg_color.py
@@ -1,0 +1,24 @@
+import numpy as np
+import scipy.io
+from isetcam.ip import ip_jpeg_compress, ip_jpeg_decompress
+
+
+def main():
+    mat = scipy.io.loadmat("scripts/image/jpegFiles/clown.mat")
+    X = mat["X"]
+    cmap = mat["map"]
+    rgb = cmap[X.astype(int) - 1]
+
+    r_coef = ip_jpeg_compress(rgb[:, :, 0], 75)
+    g_coef = ip_jpeg_compress(rgb[:, :, 1], 75)
+    b_coef = ip_jpeg_compress(rgb[:, :, 2], 75)
+
+    r_jpeg = ip_jpeg_decompress(r_coef)
+    g_jpeg = ip_jpeg_decompress(g_coef)
+    b_jpeg = ip_jpeg_decompress(b_coef)
+    rgb_jpeg = np.stack([r_jpeg, g_jpeg, b_jpeg], axis=2)
+    return rgb.shape, rgb_jpeg.shape
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/image/t_ip_jpeg_monochrome.py
+++ b/python/tutorials/image/t_ip_jpeg_monochrome.py
@@ -1,0 +1,14 @@
+import scipy.io
+from isetcam.ip import ip_jpeg_compress, ip_jpeg_decompress
+
+
+def main():
+    mat = scipy.io.loadmat("scripts/image/jpegFiles/einstein.mat")
+    im = mat["X"]
+    coef = ip_jpeg_compress(im, 50)
+    recon = ip_jpeg_decompress(coef)
+    return im.shape, coef.shape, recon.shape
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement JPEG block compression/decompression helpers
- expose new helpers from ip package
- port image tutorials to Python
- test new image tutorials

## Testing
- `pytest python/tests/test_image_tutorials.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683f623a4ec08323aa46f451fefaf730