### PR TITLE
Add printing halftone utilities and tutorial

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -163,7 +163,7 @@ from .hypercube import (
 
 # Expose subpackages that mirror the MATLAB modules. These are currently
 # placeholders for future development.
-from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip, cp, hypercube, fonts  # noqa: E501
+from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip, cp, hypercube, fonts, printing  # noqa: E501
 from .opticalimage import oi_to_file, oi_plot
 from .sensor import sensor_to_file
 from .display import (
@@ -210,6 +210,7 @@ from .io import (
 )
 from .animated_gif import animated_gif
 from .ie_scp import ie_scp
+from .printing import halftone_dither, halftone_error_diffusion
 from .web import web_flickr, web_pixabay, WebLOC
 
 __all__ = [
@@ -305,6 +306,8 @@ __all__ = [
     'faulty_insert',
     'faulty_list',
     'faulty_pixel_correction',
+    'halftone_dither',
+    'halftone_error_diffusion',
     'ie_psnr',
     'scielab',
     'sc_params',
@@ -347,6 +350,7 @@ __all__ = [
     'human',
     'ip',
     'cp',
+    'printing',
     'fonts',
     'hypercube',
     'oi_to_file',

--- a/python/isetcam/printing/__init__.py
+++ b/python/isetcam/printing/__init__.py
@@ -1,0 +1,10 @@
+# mypy: ignore-errors
+"""Printing and halftoning utilities."""
+
+from .halftone_dither import halftone_dither
+from .halftone_error_diffusion import halftone_error_diffusion
+
+__all__ = [
+    "halftone_dither",
+    "halftone_error_diffusion",
+]

--- a/python/isetcam/printing/halftone_dither.py
+++ b/python/isetcam/printing/halftone_dither.py
@@ -1,0 +1,46 @@
+# mypy: ignore-errors
+"""Simple threshold dithering halftoning."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..ie_scale import ie_scale
+
+
+def halftone_dither(cell: np.ndarray, image: np.ndarray) -> np.ndarray:
+    """Halftone ``image`` using the provided dither ``cell``.
+
+    Parameters
+    ----------
+    cell : np.ndarray
+        Halftone threshold matrix. If the maximum value exceeds ``1`` it is
+        linearly scaled into the range ``[0, 1]``.
+    image : np.ndarray
+        2-D grayscale image with values between ``0`` and ``1``.
+
+    Returns
+    -------
+    np.ndarray
+        Binary halftoned image of the same shape as ``image``.
+    """
+    cell = np.asarray(cell, dtype=float)
+    img = np.asarray(image, dtype=float)
+
+    if cell.max() > 1:
+        low = 0.5 / float(cell.max())
+        high = 1.0 - low
+        cell, _, _ = ie_scale(cell, low, high)
+
+    cell_rows, cell_cols = cell.shape
+    img_rows, img_cols = img.shape
+
+    r = int(np.ceil(img_rows / cell_rows))
+    c = int(np.ceil(img_cols / cell_cols))
+    mask = np.tile(cell, (r, c))
+    mask = mask[:img_rows, :img_cols]
+
+    return (mask < img).astype(int)
+
+
+__all__ = ["halftone_dither"]

--- a/python/isetcam/printing/halftone_error_diffusion.py
+++ b/python/isetcam/printing/halftone_error_diffusion.py
@@ -1,0 +1,61 @@
+# mypy: ignore-errors
+"""Floyd-Steinberg style error diffusion halftoning."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def halftone_error_diffusion(FS: np.ndarray, image: np.ndarray) -> np.ndarray:
+    """Apply error diffusion using diffusion matrix ``FS``.
+
+    Parameters
+    ----------
+    FS : np.ndarray
+        Diffusion matrix defining how the quantization error of each pixel is
+        distributed to its neighbors. The matrix is normalized so that its sum
+        equals ``1``. The current pixel corresponds to the center element of the
+        first row.
+    image : np.ndarray
+        2-D grayscale image with values between ``0`` and ``1``.
+
+    Returns
+    -------
+    np.ndarray
+        Binary halftoned image of the same shape as ``image``.
+    """
+    fs = np.asarray(FS, dtype=float)
+    fs /= fs.sum()
+
+    img = np.asarray(image, dtype=float)
+    img_r, img_c = img.shape
+    fs_r, fs_c_total = fs.shape
+    fs_c = fs_c_total // 2
+
+    temp = np.zeros((img_r + fs_r, img_c + 2 * fs_c), dtype=float)
+    temp[:img_r, fs_c : fs_c + img_c] = img
+
+    for ir in range(img_r):
+        for ic in range(fs_c, img_c):
+            val = temp[ir, ic]
+            temp[ir, ic] = np.round(val)
+            err = val - temp[ir, ic]
+            temp[ir : ir + fs_r, ic - fs_c : ic + fs_c + 1] += err * fs
+
+        temp[ir : ir + fs_r, img_c : img_c + fs_c] += temp[ir + 1 : ir + fs_r + 1, :fs_c]
+
+        for ic in range(img_c, img_c + fs_c):
+            val = temp[ir, ic]
+            temp[ir, ic] = np.round(val)
+            err = val - temp[ir, ic]
+            temp[ir : ir + fs_r, ic - fs_c : ic + fs_c + 1] += err * fs
+
+        temp[ir + 1 : ir + fs_r + 1, fs_c : 2 * fs_c] += temp[ir : ir + fs_r, img_c + fs_c : img_c + 2 * fs_c]
+        temp[:, :fs_c] = 0
+        temp[:, img_c + fs_c :] = 0
+
+    result = temp[:img_r, fs_c : fs_c + img_c]
+    return result.astype(int)
+
+
+__all__ = ["halftone_error_diffusion"]

--- a/python/tests/test_printing_tutorial.py
+++ b/python/tests/test_printing_tutorial.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import importlib.util
+import sys
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial():
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "printing" / "t_printing_halftone.py"
+    spec = importlib.util.spec_from_file_location("t_printing_halftone", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_t_printing_halftone():
+    mod = _load_tutorial()
+    ht_dither, ht_error = mod.main()
+    assert ht_dither.shape == (64, 64)
+    assert ht_error.shape == (64, 64)
+    assert set(np.unique(ht_dither)).issubset({0, 1})
+    assert set(np.unique(ht_error)).issubset({0, 1})

--- a/python/tutorials/printing/t_printing_halftone.py
+++ b/python/tutorials/printing/t_printing_halftone.py
@@ -1,0 +1,50 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.printing import halftone_dither, halftone_error_diffusion
+
+
+def main():
+    """Demonstrate basic halftoning using dithering and error diffusion."""
+    ie_init()
+
+    # Clustered-dot halftone cell (4x4)
+    half_tone_cell_4 = np.array(
+        [
+            [15, 5, 12, 14],
+            [10, 3, 2, 8],
+            [7, 1, 4, 11],
+            [13, 9, 6, 16],
+        ],
+        dtype=float,
+    )
+
+    # Create an 8 strip grayscale sweep
+    sweep_size = 64
+    gray_strips = 8
+    x, y = np.meshgrid(np.arange(sweep_size), np.arange(sweep_size))
+    y = np.floor(y * gray_strips / sweep_size) / gray_strips
+    x = x / (sweep_size * gray_strips)
+    sweep = 1.0 - (x + y)
+
+    monitor_gamma = 2.0
+    sweep_linear = sweep ** monitor_gamma
+
+    ht_dither = halftone_dither(half_tone_cell_4, sweep_linear)
+
+    fs_matrix = np.array(
+        [
+            [0, 0, 0, 7, 5],
+            [3, 5, 7, 5, 3],
+            [1, 3, 5, 3, 1],
+        ],
+        dtype=float,
+    )
+    fs_matrix /= fs_matrix.sum()
+
+    ht_error = halftone_error_diffusion(fs_matrix, sweep_linear)
+
+    return ht_dither, ht_error
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `printing` package with halftone dithering and error diffusion
- expose printing utilities in main module
- add tutorial translating the MATLAB halftone example
- test tutorial output

## Testing
- `pytest -q python/tests/test_printing_tutorial.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7defed888323b423b8c3aa43edd4