### PR TITLE
Add SQRI metric and Python tutorials

### DIFF
--- a/python/isetcam/metrics/__init__.py
+++ b/python/isetcam/metrics/__init__.py
@@ -16,6 +16,7 @@ from .iso_speed_saturation import iso_speed_saturation
 from .metrics_compute import metrics_compute
 from .metrics_camera import metrics_camera
 from .cie_whiteness import cie_whiteness
+from .sensor_sqr_i import sensor_sqr_i
 
 __all__ = [
     "ie_psnr",
@@ -35,4 +36,5 @@ __all__ = [
     "cie_whiteness",
     "metrics_compute",
     "metrics_camera",
+    "sensor_sqr_i",
 ]

--- a/python/isetcam/metrics/sensor_sqr_i.py
+++ b/python/isetcam/metrics/sensor_sqr_i.py
@@ -1,0 +1,66 @@
+# mypy: ignore-errors
+"""Barten's Square Root Integral metric.
+
+This is a Python reimplementation of the MATLAB ``ieSQRI`` function
+found in ``metrics/sqri/ieSQRI.m``. The metric predicts perceived
+image quality based on the display MTF and luminance.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Sequence, Tuple
+
+
+def sensor_sqr_i(
+    sf: Sequence[float] | np.ndarray,
+    d_mtf: Sequence[float] | np.ndarray,
+    luminance: float,
+    *,
+    width: float = 40.0,
+) -> Tuple[float, np.ndarray]:
+    """Return the SQRI value and human CSF.
+
+    Parameters
+    ----------
+    sf : sequence of float
+        Spatial frequency samples in cycles per degree.
+    d_mtf : sequence of float
+        Display MTF sampled at ``sf``.
+    luminance : float
+        Display luminance in ``cd/m^2``.
+    width : float, optional
+        Angular width of the display in degrees. Default is ``40``.
+
+    Returns
+    -------
+    tuple of float and ndarray
+        ``(sqri, h_csf)`` where ``h_csf`` is the human contrast
+        sensitivity function sampled at ``sf``.
+    """
+
+    sf = np.asarray(sf, dtype=float).reshape(-1)
+    d_mtf = np.asarray(d_mtf, dtype=float).reshape(-1)
+    if sf.shape != d_mtf.shape:
+        raise ValueError("sf and d_mtf must have the same shape")
+
+    a = 540 * (1 + (0.7 / luminance)) ** (-0.2) / (
+        1 + (12 / (width * (1 + (sf / 3) ** 2)))
+    )
+    b = 0.3 * (1 + (100 / luminance)) ** 0.15
+    c = 0.06
+
+    h_csf = (a * sf) * np.exp(-b * sf) * np.sqrt(1 + c * np.exp(b * sf))
+    h_csf = h_csf.reshape(-1)
+
+    du = np.diff(sf)
+    u = sf[1:]
+    dm = 0.5 * (d_mtf[:-1] + d_mtf[1:])
+    dh = 0.5 * (h_csf[:-1] + h_csf[1:])
+
+    sqri = float((1 / np.log(2)) * np.sum((dm * dh) ** 0.5 * (du / u)))
+
+    return sqri, h_csf
+
+
+__all__ = ["sensor_sqr_i"]

--- a/python/tests/test_metrics_tutorials.py
+++ b/python/tests/test_metrics_tutorials.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import importlib.util
+import sys
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial(name: str):
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "metrics" / name
+    spec = importlib.util.spec_from_file_location(name[:-3], path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_t_metrics_cielab():
+    mod = _load_tutorial("t_metrics_cielab.py")
+    de76, de94, de2000 = mod.main()
+    assert de76 > 0
+    assert de94 > 0
+    assert de2000 > 0
+
+
+def test_t_metrics_color():
+    mod = _load_tutorial("t_metrics_color.py")
+    lstar, delta_e = mod.main()
+    assert len(lstar) == 10
+    assert len(delta_e) == 10
+    assert (delta_e > 0).all()
+
+
+def test_t_metrics_sqri():
+    mod = _load_tutorial("t_metrics_sqri.py")
+    sqri, hcsf = mod.main()
+    assert sqri > 0
+    assert hcsf.size == 1000

--- a/python/tutorials/metrics/t_metrics_cielab.py
+++ b/python/tutorials/metrics/t_metrics_cielab.py
@@ -1,0 +1,21 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.metrics import delta_e_ab
+
+
+def main():
+    """Simple demonstration of DeltaE calculations."""
+    ie_init()
+
+    lab1 = np.array([[50.0, 20.0, 30.0]])
+    lab2 = np.array([[55.0, 22.0, 35.0]])
+
+    de76 = float(delta_e_ab(lab1, lab2, version="1976"))
+    de94 = float(delta_e_ab(lab1, lab2, version="94"))
+    de2000 = float(delta_e_ab(lab1, lab2, version="2000"))
+
+    return de76, de94, de2000
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/metrics/t_metrics_color.py
+++ b/python/tutorials/metrics/t_metrics_color.py
@@ -1,0 +1,34 @@
+import numpy as np
+from isetcam import ie_init, data_path, ie_read_spectra
+from isetcam.metrics import delta_e_ab
+from isetcam.xyz_to_lab import xyz_to_lab
+
+
+def main():
+    """Explore CIELAB values for a set of gray surfaces."""
+    ie_init()
+
+    wave = np.arange(400, 701, 10)
+    gray_surfaces = np.outer(np.ones_like(wave, dtype=float), np.linspace(0.1, 1.0, 10))
+
+    d65, _, _, _ = ie_read_spectra(data_path("lights/D65.mat"), wave)
+    xyz_cmfs, _, _, _ = ie_read_spectra(data_path("human/XYZ.mat"), wave)
+
+    gray_spd = d65[:, 0][:, None] * gray_surfaces
+    gray_xyz = xyz_cmfs.T @ gray_spd
+    gray_xyz = gray_xyz * 100.0 / gray_xyz[1, -1]
+    white_xyz = gray_xyz[:, -1]
+
+    lab1 = xyz_to_lab(gray_xyz.T, white_xyz)
+
+    delta_xyz = np.zeros_like(gray_xyz)
+    delta_xyz[1, :] = white_xyz[1] / 20.0
+    lab2 = xyz_to_lab((gray_xyz + delta_xyz).T, white_xyz)
+
+    delta_e = delta_e_ab(lab1, lab2)
+
+    return lab1[:, 0], delta_e
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/metrics/t_metrics_sqri.py
+++ b/python/tutorials/metrics/t_metrics_sqri.py
@@ -1,0 +1,22 @@
+import numpy as np
+from isetcam import ie_init
+from isetcam.metrics import sensor_sqr_i
+
+
+def main():
+    """Compute the SQRI value for a simple display."""
+    ie_init()
+
+    n_sf = 1000
+    sf = np.logspace(-1.5, 1.6, n_sf)
+    d_mtf = np.ones_like(sf)
+    luminance = 100.0
+    width = 14.0
+
+    sqri, hcsf = sensor_sqr_i(sf, d_mtf, luminance, width=width)
+
+    return sqri, hcsf
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `sensor_sqr_i` metric in `isetcam.metrics`
- expose it in the metrics package
- add three Python metric tutorials mirroring MATLAB examples
- test new tutorials

## Testing
- `pytest python/tests/test_metrics_tutorials.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683f840068688323b530d5746f10a4a5