### PR TITLE
Add ISETCam introduction tutorial

### DIFF
--- a/python/tests/test_introduction_tutorial.py
+++ b/python/tests/test_introduction_tutorial.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import importlib.util
+import sys
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial():
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "introduction" / "t_introduction_to_iset.py"
+    spec = importlib.util.spec_from_file_location("t_introduction_to_iset", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_t_introduction_to_iset_exec():
+    mod = _load_tutorial()
+    shapes = mod.main()
+    assert len(shapes) == 4
+    scene_shape, oi_shape, sensor_shape, rgb_shape = shapes
+    assert rgb_shape[-1] == 3
+    assert sensor_shape[0] == rgb_shape[0]
+    assert scene_shape[0] == oi_shape[0]

--- a/python/tutorials/introduction/t_introduction_to_iset.py
+++ b/python/tutorials/introduction/t_introduction_to_iset.py
@@ -1,0 +1,34 @@
+from isetcam import ie_init
+from isetcam.scene import scene_create
+from isetcam.optics import optics_create
+from isetcam.opticalimage import oi_compute
+from isetcam.sensor import sensor_create, sensor_compute
+from isetcam.display import display_create
+from isetcam.ip import ip_compute
+
+
+def main():
+    """Demonstrate a basic ISETCam pipeline."""
+    ie_init()
+
+    # Create a simple scene
+    scene = scene_create("macbeth d65")
+
+    # Form the optical image using default optics
+    optics = optics_create()
+    oi = oi_compute(scene, optics)
+
+    # Generate sensor data
+    sensor = sensor_create()
+    sensor = sensor_compute(sensor, oi)
+
+    # Render to an sRGB image using a default display
+    disp = display_create()
+    disp.wave = sensor.wave
+    ip = ip_compute(sensor, disp)
+
+    return scene.photons.shape, oi.photons.shape, sensor.volts.shape, ip.rgb.shape
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple introductory tutorial demonstrating the ISETCam pipeline
- test the tutorial script executes without error

## Testing
- `flake8 python/tutorials/introduction/t_introduction_to_iset.py python/tests/test_introduction_tutorial.py`
- `pytest python/tests/test_introduction_tutorial.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683f87c496008323a645d8b8ec57fb83