### PR TITLE
Add Python equivalents for code tutorials

### DIFF
--- a/python/tests/test_code_tutorials.py
+++ b/python/tests/test_code_tutorials.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import importlib.util
+import sys
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial(name: str):
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "code" / name
+    spec = importlib.util.spec_from_file_location(name[:-3], path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_t_code_objects():
+    mod = _load_tutorial("t_code_objects.py")
+    idx, shape = mod.main()
+    assert idx >= 1
+    assert len(shape) == 3
+
+
+def test_t_code_rendering():
+    mod = _load_tutorial("t_code_rendering.py")
+    srgb_shape, spd1_shape, spd2_shape = mod.main()
+    assert srgb_shape == (1, 1, 3)
+    assert spd1_shape[0] == spd1_shape[1] == 120
+    assert spd2_shape[0] == spd2_shape[1] == 120
+
+
+def test_t_code_session():
+    mod = _load_tutorial("t_code_session.py")
+    counts, shape = mod.main()
+    before, after, final = counts
+    assert after == before + 2
+    assert final == after + 1
+    assert len(shape) == 3
+
+
+def test_t_code_startup():
+    mod = _load_tutorial("t_code_startup.py")
+    before, after, root = mod.main()
+    assert after
+    assert root in sys.path

--- a/python/tutorials/code/t_code_objects.py
+++ b/python/tutorials/code/t_code_objects.py
@@ -1,0 +1,21 @@
+from isetcam import ie_init
+from isetcam.scene import scene_create
+from isetcam import vc_add_and_select_object, vc_get_object
+
+
+def main():
+    """Demonstrate adding and retrieving objects from vcSESSION."""
+    ie_init()
+
+    # Create a simple scene and store it
+    scene = scene_create("macbeth d65")
+    idx = vc_add_and_select_object("scene", scene)
+
+    # Retrieve the stored scene
+    stored = vc_get_object("scene", idx)
+
+    return idx, stored.photons.shape
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/code/t_code_rendering.py
+++ b/python/tutorials/code/t_code_rendering.py
@@ -1,0 +1,45 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+from isetcam import ie_init
+from isetcam.illuminant import illuminant_blackbody
+from isetcam.ie_xyz_from_energy import ie_xyz_from_energy
+from isetcam.srgb_xyz import xyz_to_srgb
+
+
+def _enlarge(img: np.ndarray, scale: int) -> np.ndarray:
+    """Upsample an image by nearest-neighbor replication."""
+    return np.kron(img, np.ones((scale, scale, 1)))
+
+
+def main():
+    """Demonstrate simple spectral rendering operations."""
+    ie_init()
+
+    wave = np.arange(400, 701, 10)
+    spd = illuminant_blackbody(3000, wave)
+
+    fig, ax = plt.subplots()
+    ax.plot(wave, spd)
+    ax.set_xlabel("Wavelength (nm)")
+    ax.set_ylabel("Energy (watts/sr/m^2/nm)")
+    ax.grid(True)
+
+    xyz = ie_xyz_from_energy(spd, wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+
+    fig2, ax2 = plt.subplots()
+    ax2.imshow(srgb.reshape(1, 1, 3))
+    ax2.axis("off")
+
+    spd3 = spd.reshape(1, 1, -1)
+    spd_big = _enlarge(spd3, 120)
+
+    spd2 = illuminant_blackbody(8000, wave)
+    spd2_big = _enlarge(spd2.reshape(1, 1, -1), 120)
+
+    return srgb.reshape(1, 1, 3).shape, spd_big.shape, spd2_big.shape
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/code/t_code_session.py
+++ b/python/tutorials/code/t_code_session.py
@@ -1,0 +1,26 @@
+from isetcam import ie_init
+from isetcam.scene import scene_create
+from isetcam.vc_add_and_select_object import vcSESSION
+from isetcam import vc_add_and_select_object, vc_get_object
+
+
+def main():
+    """Demonstrate vcSESSION database management."""
+    ie_init()
+
+    before = len(vcSESSION.get("SCENE", []))
+
+    scene = scene_create("macbeth d65")
+    idx = vc_add_and_select_object("scene", scene)
+    after = len(vcSESSION.get("SCENE", []))
+
+    stored = vc_get_object("scene", idx)
+
+    idx2 = vc_add_and_select_object("scene", scene)
+    final = len(vcSESSION.get("SCENE", []))
+
+    return (before, after, final), stored.photons.shape
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/code/t_code_startup.py
+++ b/python/tutorials/code/t_code_startup.py
@@ -1,0 +1,16 @@
+import sys
+from isetcam.iset_root_path import iset_root_path
+
+
+def main():
+    """Show basic path setup for ISETCam."""
+    root = iset_root_path()
+    before = root in sys.path
+    if not before:
+        sys.path.append(root)
+    after = root in sys.path
+    return before, after, root
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- port MATLAB code tutorials to Python scripts
- show how to add and fetch vcSESSION objects
- demonstrate spectral rendering with matplotlib
- illustrate session management and startup path handling
- test new tutorials

## Testing
- `pytest -k code_tutorials -q`
- `pytest -q` *(fails: web retrieval tests require network)*

------
https://chatgpt.com/codex/tasks/task_e_683fc8c27a4c8323a709eb8df80bc6fb