### PR TITLE
Add GUI Python tutorials

### DIFF
--- a/python/isetcam/tutorials/__init__.py
+++ b/python/isetcam/tutorials/__init__.py
@@ -1,0 +1,1 @@
+"""Wrappers for running tutorial scripts as modules."""

--- a/python/isetcam/tutorials/gui/__init__.py
+++ b/python/isetcam/tutorials/gui/__init__.py
@@ -1,0 +1,17 @@
+from importlib import util
+from pathlib import Path
+from typing import Any, Sequence
+
+
+def _run_tutorial(script: str, argv: Sequence[str] | None = None) -> Any:
+    """Execute a tutorial script located under ``python/tutorials/gui``."""
+
+    base = Path(__file__).resolve().parents[3] / "tutorials" / "gui"
+    path = base / f"{script}.py"
+    spec = util.spec_from_file_location(script, path)
+    mod = util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    if hasattr(mod, "main"):
+        return mod.main(argv)
+    return None

--- a/python/isetcam/tutorials/gui/t_gui_isetpref.py
+++ b/python/isetcam/tutorials/gui/t_gui_isetpref.py
@@ -1,0 +1,10 @@
+from . import _run_tutorial
+from typing import Sequence, Any
+
+
+def main(argv: Sequence[str] | None = None) -> Any:
+    return _run_tutorial("t_gui_isetpref", argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/isetcam/tutorials/gui/t_roi_draw.py
+++ b/python/isetcam/tutorials/gui/t_roi_draw.py
@@ -1,0 +1,10 @@
+from . import _run_tutorial
+from typing import Sequence, Any
+
+
+def main(argv: Sequence[str] | None = None) -> Any:
+    return _run_tutorial("t_roi_draw", argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/test_gui_tutorials.py
+++ b/python/tests/test_gui_tutorials.py
@@ -1,0 +1,25 @@
+import os
+import subprocess
+import sys
+
+
+SCRIPTS = [
+    "isetcam.tutorials.gui.t_roi_draw",
+    "isetcam.tutorials.gui.t_gui_isetpref",
+]
+
+
+def _run(module: str) -> None:
+    env = os.environ.copy()
+    env["MPLBACKEND"] = "Agg"
+    subprocess.run(
+        [sys.executable, "-m", module, "--no-interactive"],
+        check=True,
+        env=env,
+        timeout=5,
+    )
+
+
+def test_gui_scripts_launch():
+    for mod in SCRIPTS:
+        _run(mod)

--- a/python/tutorials/gui/t_gui_isetpref.py
+++ b/python/tutorials/gui/t_gui_isetpref.py
@@ -1,0 +1,59 @@
+import argparse
+import matplotlib.pyplot as plt
+from isetcam import ie_init, ie_session_get, ie_session_set
+from isetcam.scene import scene_create, scene_show_image
+
+
+def _prompt(interactive: bool, msg: str):
+    if interactive:
+        input(msg)
+    else:
+        plt.pause(0.5)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Demonstrate ISET preferences"
+    )
+    parser.add_argument(
+        "--no-interactive",
+        action="store_true",
+        help="Run without prompts",
+    )
+    args = parser.parse_args(argv)
+    interactive = not args.no_interactive
+
+    ie_init()
+
+    print("Waitbar:", ie_session_get("waitbar"))
+    print("Font size:", ie_session_get("font size"))
+
+    _prompt(interactive, "Enable waitbar and press Enter...")
+    ie_session_set("waitbar", 1)
+    print("Waitbar:", ie_session_get("waitbar"))
+
+    _prompt(interactive, "Disable waitbar and press Enter...")
+    ie_session_set("waitbar", 0)
+    print("Waitbar:", ie_session_get("waitbar"))
+
+    scene = scene_create("macbeth d65")
+    ax = scene_show_image(scene)
+    plt.show(block=False)
+
+    _prompt(interactive, "Increase font size and press Enter...")
+    size = ie_session_get("font size")
+    ie_session_set("font size", size + 2)
+    ax.set_title("Font size %d" % ie_session_get("font size"))
+    ax.figure.canvas.draw()
+
+    _prompt(interactive, "Restore font size and press Enter...")
+    ie_session_set("font size", size)
+    ax.set_title("Font size %d" % ie_session_get("font size"))
+    ax.figure.canvas.draw()
+
+    plt.close(ax.figure)
+    return True
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/gui/t_roi_draw.py
+++ b/python/tutorials/gui/t_roi_draw.py
@@ -1,0 +1,81 @@
+import argparse
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle, Circle
+import numpy as np
+
+
+def _prompt(interactive: bool):
+    if interactive:
+        input("Press Enter to continue...")
+    else:
+        plt.pause(0.5)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Draw ROI shapes on sample images"
+    )
+    parser.add_argument(
+        "--no-interactive",
+        action="store_true",
+        help="Skip prompts and close immediately",
+    )
+    args = parser.parse_args(argv)
+    interactive = not args.no_interactive
+
+    fig, axs = plt.subplots(2, 2, figsize=(6, 6))
+    titles = ["Scene", "Optical Image", "Sensor", "IP"]
+    for ax, title in zip(axs.ravel(), titles):
+        ax.imshow(np.zeros((100, 100, 3)))
+        ax.set_title(title)
+        ax.axis("off")
+    fig.tight_layout()
+    plt.show(block=False)
+
+    rect = Rectangle(
+        (50, 20),
+        10,
+        5,
+        linewidth=5,
+        edgecolor="r",
+        facecolor="none",
+        linestyle=":",
+    )
+    axs[0, 0].add_patch(rect)
+    _prompt(interactive)
+    rect.remove()
+
+    rect = Rectangle(
+        (50, 50),
+        20,
+        20,
+        linewidth=2,
+        edgecolor="w",
+        facecolor="none",
+        linestyle=":",
+    )
+    axs[0, 1].add_patch(rect)
+    _prompt(interactive)
+    rect.remove()
+
+    circ = Circle((30, 15), 20, edgecolor="w", facecolor="none")
+    axs[0, 1].add_patch(circ)
+    _prompt(interactive)
+    circ.remove()
+
+    circ = Circle((20, 20), 10, edgecolor="w", facecolor="none")
+    axs[1, 0].add_patch(circ)
+    _prompt(interactive)
+    circ.remove()
+
+    rect = Rectangle((50, 50), 20, 20, edgecolor="g", facecolor="none")
+    axs[1, 1].add_patch(rect)
+    _prompt(interactive)
+    rect.remove()
+
+    plt.close(fig)
+    return True
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `t_gui_isetpref.py` and `t_roi_draw.py` tutorials using matplotlib
- provide wrappers so they can be launched as `python -m isetcam.tutorials.gui.*`
- test that each tutorial module launches without error

## Testing
- `flake8 python/isetcam/tutorials python/tutorials/gui`
- `pytest python/tests/test_gui_tutorials.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683fcd7db74c8323990ab5da65f7b1d8