### PR TITLE
Add helpers for data import/export

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -58,6 +58,7 @@ from .vc_rect_to_locs import vc_rect_to_locs
 from .vc_locs_to_rect import vc_locs_to_rect
 from .vc_copy_object import vc_copy_object
 from .vc_rename_object import vc_rename_object
+from .vc_import_object import vc_import_object
 from .rgb_to_xw_format import rgb_to_xw_format
 from .xw_to_rgb_format import xw_to_rgb_format
 from .xyz_to_lab import xyz_to_lab
@@ -165,7 +166,7 @@ from .hypercube import (
 # placeholders for future development.
 from . import scene, opticalimage, sensor, pixel, display, illuminant, camera, imgproc, metrics, optics, human, ip, cp, hypercube, fonts, printing  # noqa: E501
 from .opticalimage import oi_to_file, oi_plot
-from .sensor import sensor_to_file
+from .sensor import sensor_to_file, sensor_save_png
 from .display import (
     display_to_file,
     display_list,
@@ -207,6 +208,7 @@ from .io import (
     ie_save_color_filter,
     ie_save_multispectral_image,
     ie_load_multispectral_image,
+    ie_save_si_data_file,
 )
 from .animated_gif import animated_gif
 from .ie_scp import ie_scp
@@ -355,6 +357,7 @@ __all__ = [
     'hypercube',
     'oi_to_file',
     'sensor_to_file',
+    'sensor_save_png',
     'display_to_file',
     'display_list',
     'display_max_contrast',
@@ -391,6 +394,7 @@ __all__ = [
     'ie_save_color_filter',
     'ie_save_multispectral_image',
     'ie_load_multispectral_image',
+    'ie_save_si_data_file',
     'animated_gif',
     'ie_scp',
     'web_flickr',
@@ -414,6 +418,7 @@ __all__ = [
     'vc_locs_to_rect',
     'vc_copy_object',
     'vc_rename_object',
+    'vc_import_object',
     'font_create',
     'font_get',
     'font_set',

--- a/python/isetcam/io/__init__.py
+++ b/python/isetcam/io/__init__.py
@@ -10,6 +10,7 @@ from .pfm_write import pfm_write
 from .color_filter import ie_read_color_filter, ie_save_color_filter
 from .ie_save_multispectral_image import ie_save_multispectral_image
 from .ie_load_multispectral_image import ie_load_multispectral_image
+from .ie_save_si_data_file import ie_save_si_data_file
 
 __all__ = [
     "openexr_read",
@@ -22,4 +23,5 @@ __all__ = [
     "ie_save_color_filter",
     "ie_save_multispectral_image",
     "ie_load_multispectral_image",
+    "ie_save_si_data_file",
 ]

--- a/python/isetcam/io/ie_save_si_data_file.py
+++ b/python/isetcam/io/ie_save_si_data_file.py
@@ -1,0 +1,30 @@
+# mypy: ignore-errors
+"""Save shift-invariant PSF data to a MAT-file."""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+from scipy.io import savemat
+
+
+def ie_save_si_data_file(
+    path: str | Path,
+    psf: np.ndarray,
+    wave: Iterable[float],
+    um_per_samp: Sequence[float],
+) -> None:
+    """Write ``psf`` and associated metadata to ``path``."""
+    data = {
+        "psf": np.asarray(psf, dtype=float),
+        "wave": np.asarray(list(wave), dtype=float),
+        "umPerSamp": np.asarray(um_per_samp, dtype=float),
+        "notes": {"timeStamp": datetime.datetime.now().isoformat()},
+    }
+    savemat(str(Path(path)), data)
+
+
+__all__ = ["ie_save_si_data_file"]

--- a/python/isetcam/sensor/__init__.py
+++ b/python/isetcam/sensor/__init__.py
@@ -34,6 +34,7 @@ from .sensor_show_cfa import sensor_show_cfa
 from .sensor_show_cfa_weights import sensor_show_cfa_weights
 from .sensor_stats import sensor_stats
 from .sensor_clear_data import sensor_clear_data
+from .sensor_save_png import sensor_save_png
 from .sensor_iso_speed import sensor_iso_speed
 from .sensor_resample_wave import sensor_resample_wave
 from .sensor_rescale import sensor_rescale
@@ -119,4 +120,5 @@ __all__ = [
     "sensor_vignetting",
     "sensor_pixel_coord",
     "sensor_jiggle",
+    "sensor_save_png",
 ]

--- a/python/isetcam/sensor/sensor_save_png.py
+++ b/python/isetcam/sensor/sensor_save_png.py
@@ -1,0 +1,38 @@
+# mypy: ignore-errors
+"""Save a Sensor image as a PNG file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import imageio.v2 as imageio
+
+from .sensor_class import Sensor
+from ..display import Display, display_create, display_render
+from ..srgb_to_lrgb import srgb_to_lrgb
+from ..ie_xyz_from_photons import ie_xyz_from_photons
+from ..srgb_xyz import xyz_to_srgb
+
+
+def sensor_save_png(
+    sensor: Sensor, path: str | Path, display: Display | None = None
+) -> None:
+    """Render ``sensor`` to sRGB and save to ``path``."""
+    if display is None:
+        display = display_create()
+
+    volts = np.asarray(sensor.volts, dtype=float)
+    if volts.ndim != 3 or volts.shape[2] != 3:
+        raise ValueError("sensor.volts must be (rows, cols, 3)")
+
+    lrgb = srgb_to_lrgb(volts)
+    spectral = display_render(lrgb, display, apply_gamma=True)
+    xyz = ie_xyz_from_photons(spectral, display.wave)
+    srgb, _, _ = xyz_to_srgb(xyz)
+
+    arr = (np.clip(srgb, 0.0, 1.0) * 255).round().astype(np.uint8)
+    imageio.imwrite(str(Path(path)), arr)
+
+
+__all__ = ["sensor_save_png"]

--- a/python/isetcam/vc_import_object.py
+++ b/python/isetcam/vc_import_object.py
@@ -1,0 +1,36 @@
+# mypy: ignore-errors
+"""Load an ISET object from a MAT-file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from scipy.io import loadmat
+
+
+_OBJ_MAP = {
+    "scene": "scene",
+    "opticalimage": "opticalimage",
+    "oi": "opticalimage",
+    "isa": "sensor",
+    "sensor": "sensor",
+    "vcimage": "vcimage",
+    "pixel": "pixel",
+    "optics": "optics",
+    "camera": "camera",
+}
+
+
+def vc_import_object(obj_type: str, path: str | Path) -> Any:
+    """Return the object stored in ``path`` of type ``obj_type``."""
+    key = _OBJ_MAP.get(obj_type.lower())
+    if key is None:
+        raise KeyError(f"unknown object type '{obj_type}'")
+    data = loadmat(str(Path(path)), squeeze_me=True, struct_as_record=False)
+    if key not in data:
+        raise KeyError(f"file does not contain '{key}' variable")
+    return data[key]
+
+
+__all__ = ["vc_import_object"]

--- a/python/tests/test_ie_save_si_data_file.py
+++ b/python/tests/test_ie_save_si_data_file.py
@@ -1,0 +1,22 @@
+import numpy as np
+import scipy.io
+
+from isetcam.io import ie_save_si_data_file
+
+
+def test_ie_save_si_data_file_roundtrip(tmp_path):
+    psf = np.random.rand(4, 4, 2)
+    wave = np.array([500, 600])
+    up = [0.1, 0.1]
+    path = tmp_path / "psf.mat"
+    ie_save_si_data_file(path, psf, wave, up)
+
+    data = scipy.io.loadmat(path, squeeze_me=True, struct_as_record=False)
+    assert np.allclose(data["psf"], psf)
+    assert np.allclose(data["wave"], wave)
+    assert np.allclose(data["umPerSamp"], up)
+    notes = data["notes"]
+    if hasattr(notes, "__dict__"):
+        assert "timeStamp" in notes.__dict__
+    else:
+        assert "timeStamp" in notes

--- a/python/tests/test_sensor_save_png.py
+++ b/python/tests/test_sensor_save_png.py
@@ -1,0 +1,13 @@
+import numpy as np
+import imageio.v2 as imageio
+
+from isetcam.sensor import Sensor, sensor_save_png
+
+
+def test_sensor_save_png(tmp_path):
+    volts = np.ones((1, 1, 3), dtype=float) * 0.5
+    sensor = Sensor(volts=volts, exposure_time=0.01, wave=np.array([500, 600, 700]))
+    path = tmp_path / "s.png"
+    sensor_save_png(sensor, path)
+    img = imageio.imread(path)
+    assert img.shape == (1, 1, 3)

--- a/python/tests/test_vc_import_object.py
+++ b/python/tests/test_vc_import_object.py
@@ -1,0 +1,22 @@
+import numpy as np
+import scipy.io
+from dataclasses import asdict
+
+from isetcam import vc_import_object
+from isetcam.sensor import Sensor
+
+
+def test_vc_import_object_sensor(tmp_path):
+    s = Sensor(
+        volts=np.array([[1.0, 2.0]]),
+        exposure_time=0.01,
+        wave=np.array([500, 600]),
+        name="demo",
+    )
+    path = tmp_path / "sensor.mat"
+    scipy.io.savemat(path, {"sensor": asdict(s)})
+
+    loaded = vc_import_object("sensor", path)
+    assert np.allclose(loaded.volts, s.volts)
+    assert loaded.exposure_time == s.exposure_time
+    assert np.array_equal(loaded.wave, s.wave)


### PR DESCRIPTION
## Summary
- port vc_import_object, ie_save_si_data_file and sensor_save_png utilities
- export the new helpers from packages
- test round‑trip MAT read/write and PNG output

## Testing
- `flake8 python/isetcam/vc_import_object.py python/isetcam/io/ie_save_si_data_file.py python/isetcam/sensor/sensor_save_png.py python/tests/test_vc_import_object.py python/tests/test_ie_save_si_data_file.py python/tests/test_sensor_save_png.py`
- `PYTHONPATH=python pytest python/tests/test_vc_import_object.py python/tests/test_ie_save_si_data_file.py python/tests/test_sensor_save_png.py -q`
- `PYTHONPATH=python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd154bb6483238bd5de20dad8c13d