### PR TITLE
Add wavefront overview tutorial

### DIFF
--- a/python/tests/test_wvf_overview.py
+++ b/python/tests/test_wvf_overview.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import importlib.util
+import sys
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def _load_tutorial():
+    base = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(base))
+    path = base / "tutorials" / "optics" / "t_wvf_overview.py"
+    spec = importlib.util.spec_from_file_location("t_wvf_overview", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_wvf_overview_shapes():
+    mod = _load_tutorial()
+    wvf_shape, psf_shape, mtf_shape = mod.main()
+    assert wvf_shape == psf_shape == mtf_shape
+    assert wvf_shape == (64, 64)

--- a/python/tutorials/optics/t_wvf_overview.py
+++ b/python/tutorials/optics/t_wvf_overview.py
@@ -1,0 +1,43 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from numpy.fft import fft2, fftshift
+from isetcam.optics import wvf_zernike, wvf_mtf
+
+
+def main():
+    """Compute PSF and MTF from a simple Zernike wavefront."""
+    n = 64
+    x = np.linspace(-1, 1, n)
+    X, Y = np.meshgrid(x, x)
+    R = np.sqrt(X ** 2 + Y ** 2)
+    T = np.arctan2(Y, X)
+
+    # Simple combination of Zernike terms (j=2,3,4)
+    coeffs = np.array([0.0, 0.1, -0.1, 0.05])
+    wvf = wvf_zernike(coeffs, R, T)
+    wvf[R > 1] = 0.0
+
+    pupil = (R <= 1) * np.exp(2j * np.pi * wvf)
+    psf = np.abs(fftshift(fft2(pupil))) ** 2
+    psf /= psf.sum()
+    mtf = wvf_mtf(psf)
+
+    fig, axs = plt.subplots(1, 3, figsize=(9, 3))
+    im0 = axs[0].imshow(wvf, extent=[-1, 1, -1, 1], cmap="jet")
+    axs[0].set_title("Wavefront")
+    axs[0].axis("off")
+    fig.colorbar(im0, ax=axs[0])
+    axs[1].imshow(psf, cmap="magma")
+    axs[1].set_title("PSF")
+    axs[1].axis("off")
+    axs[2].imshow(mtf, cmap="magma")
+    axs[2].set_title("MTF")
+    axs[2].axis("off")
+    fig.tight_layout()
+    plt.close(fig)
+
+    return wvf.shape, psf.shape, mtf.shape
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a tutorial demonstrating wavefront computation from Zernike terms
- show PSF and MTF generation with plots
- test the tutorial output

## Testing
- `pytest -q python/tests/test_wvf_overview.py`

------
https://chatgpt.com/codex/tasks/task_e_683ffec4a2a083238146e853177e86e9