### PR TITLE
Enable sphinx-gallery tutorials

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,7 @@ BUILDDIR      = build
 .PHONY: html clean
 
 html:
-$(SPHINXBUILD) -b html $(SOURCEDIR) $(BUILDDIR)
+	$(SPHINXBUILD) -b html $(SOURCEDIR) $(BUILDDIR)
 
 clean:
-rm -rf $(BUILDDIR) $(SOURCEDIR)/api
+	rm -rf $(BUILDDIR) $(SOURCEDIR)/api

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,13 +8,22 @@ sys.path.insert(0, os.path.abspath('../../python'))
 project = 'ISETCam'
 copyright = f'{datetime.now().year}, ISETCam'
 
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx_gallery.gen_gallery',
+]
 
 templates_path = ['_templates']
 exclude_patterns = []
 
 html_theme = 'alabaster'
 html_static_path = ['_static']
+
+sphinx_gallery_conf = {
+    'examples_dirs': os.path.abspath('../../python/tutorials'),
+    'gallery_dirs': 'tutorials',
+}
 
 # Automatically generate API docs
 def run_apidoc(app):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,3 +7,11 @@ Welcome to the experimental Python documentation.
    :maxdepth: 2
 
    api/modules
+
+Tutorials
+---------
+
+.. toctree::
+   :maxdepth: 1
+
+   tutorials/index


### PR DESCRIPTION
## Summary
- add Tutorials index page
- enable `sphinx-gallery` extension and configure galleries
- fix Makefile tab characters

## Testing
- `pytest -q` *(fails: 263 errors during collection)*
- `make -C docs html` *(fails: sphinx-build: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6840a34873808323b6319877a9d90da8