### PR TITLE
Add CLI tutorial subcommand

### DIFF
--- a/python/tests/test_cli_tutorial.py
+++ b/python/tests/test_cli_tutorial.py
@@ -1,0 +1,6 @@
+from isetcam.cli import main
+
+
+def test_cli_tutorial_runs():
+    rc = main(["tutorial", "introduction/t_introduction_to_iset"])
+    assert rc == 0


### PR DESCRIPTION
## Summary
- run tutorials from the CLI via new `tutorial` subcommand
- list available tutorials in CLI help
- test tutorial subcommand

## Testing
- `PYTHONPATH=python pytest python/tests/test_cli.py python/tests/test_cli_pipeline.py python/tests/test_cli_tutorial.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6840a79b416c832392f453c808c317ff