### PR TITLE
Add global tutorial execution test

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -4,10 +4,12 @@ on:
   push:
     paths:
       - 'python/**'
+      - 'python/tests/test_tutorials.py'
       - '.github/workflows/python-tests.yml'
   pull_request:
     paths:
       - 'python/**'
+      - 'python/tests/test_tutorials.py'
       - '.github/workflows/python-tests.yml'
 
 jobs:

--- a/python/tests/test_tutorials.py
+++ b/python/tests/test_tutorials.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+import pytest
+
+# Skip all tests in this module if matplotlib is unavailable
+pytest.importorskip("matplotlib")
+
+TUTORIALS = sorted(
+    (Path(__file__).resolve().parents[1] / "tutorials").rglob("t_*.py")
+)
+
+@pytest.mark.parametrize("tutorial_path", TUTORIALS)
+def test_run_tutorial(tutorial_path: Path) -> None:
+    env = os.environ.copy()
+    env["MPLBACKEND"] = "Agg"
+    # Ensure the package can be imported when running in subprocess
+    base = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = str(base) + os.pathsep + env.get("PYTHONPATH", "")
+    subprocess.run(
+        [sys.executable, str(tutorial_path)],
+        check=True,
+        env=env,
+        timeout=10,
+    )
+


### PR DESCRIPTION
## Summary
- ensure matplotlib availability for tests
- run each tutorial script using subprocess
- watch tutorial tests in CI workflow

## Testing
- `pytest python/tests/test_tutorials.py -q --maxfail=1` *(fails: CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_e_6840aa195b0083238b2238c6fe560422