### PR TITLE
Update docs for running tutorials

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -131,6 +131,23 @@ stores the resulting camera structure in a MAT-file:
 isetcam pipeline --scene "grid lines" --output cam.mat
 ```
 
+## Running Tutorials
+
+Tutorial scripts live under ``python/tutorials``.  Each one can be
+executed using the command line interface:
+
+```bash
+isetcam tutorial introduction/t_introduction_to_iset
+```
+
+Automated tests in ``python/tests`` import and run every tutorial
+script.  After editing a tutorial, run the full test suite to confirm it
+still executes correctly:
+
+```bash
+pytest -q
+```
+
 ## Building the Documentation
 
 HTML documentation is generated with Sphinx. After installing the


### PR DESCRIPTION
## Summary
- document how to run tutorial scripts via `isetcam tutorial`
- explain automated testing of tutorials
- remind contributors to run `pytest -q` after tutorial edits

## Testing
- `pytest -q` *(fails: 264 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6840b2de51dc8323a75d513e546a025f