### PR TITLE
Add PBRT scene loader

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -3009,6 +3009,21 @@ print(sc.photons.shape)
 
 Run `pytest -q` after modifying the DDF reader.
 
+## scene_from_pbrt
+
+Render a PBRT file (or recipe) using the optional ISET3D toolbox or a
+local ``pbrt`` executable.
+
+```python
+from isetcam.scene import scene_from_pbrt
+
+sc, oi, extras = scene_from_pbrt('example.pbrt')
+print(extras.get('depth'))
+```
+
+This helper requires additional software and the tests are skipped when
+the backend is not available.
+
 ## scene_make_video
 
 Encode a list of scenes into a movie using ``ffmpeg``.

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -7,6 +7,7 @@ from .scene_utils import get_photons, set_photons, get_n_wave
 from .scene_from_file import scene_from_file
 from .scene_from_ddf_file import scene_from_ddf_file
 from .scene_from_font import scene_from_font
+from .scene_from_pbrt import scene_from_pbrt
 from .scene_get import scene_get
 from .scene_set import scene_set
 from .scene_adjust_luminance import scene_adjust_luminance
@@ -71,6 +72,7 @@ __all__ = [
     "scene_from_file",
     "scene_from_ddf_file",
     "scene_from_font",
+    "scene_from_pbrt",
     "scene_get",
     "scene_set",
     "scene_adjust_luminance",

--- a/python/isetcam/scene/scene_from_pbrt.py
+++ b/python/isetcam/scene/scene_from_pbrt.py
@@ -1,0 +1,89 @@
+# mypy: ignore-errors
+"""Render a PBRT scene using ISET3D or a PBRT executable."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Tuple, Optional
+import shutil
+import subprocess
+
+import numpy as np
+
+from .scene_class import Scene
+from ..opticalimage.oi_class import OpticalImage
+from ..io import openexr_read
+
+try:  # pragma: no cover - optional dependency
+    import iset3d  # type: ignore
+except Exception:  # pragma: no cover - library may not be present
+    iset3d = None  # type: ignore
+
+
+def _iset3d_available() -> bool:
+    return iset3d is not None
+
+
+def _pbrt_available() -> bool:
+    return shutil.which("pbrt") is not None
+
+
+def scene_from_pbrt(path_or_recipe: Any) -> Tuple[Scene, Optional[OpticalImage], dict]:
+    """Render ``path_or_recipe`` and return a :class:`Scene`.
+
+    The function relies on the optional `iset3d` package or a local `pbrt`
+    executable.  When neither backend is available an :class:`ImportError`
+    is raised.
+    """
+    if _iset3d_available():
+        # The path can be a PBRT file or an iset3d recipe object
+        if isinstance(path_or_recipe, (str, Path)):
+            recipe = iset3d.piRead(str(Path(path_or_recipe)))
+        else:
+            recipe = path_or_recipe
+        iset3d.piWrite(recipe)
+        obj, *_ = iset3d.piRender(recipe, "render type", ["radiance", "depth"])
+        photons = np.asarray(getattr(obj, "photons"))
+        wave = np.asarray(getattr(obj, "wave")).reshape(-1)
+        depth = getattr(obj, "depthMap", None)
+        name = getattr(obj, "name", None)
+        if getattr(obj, "type", "scene") == "scene":
+            sc = Scene(photons=photons, wave=wave, name=name)
+            if depth is not None:
+                sc.depth_map = np.asarray(depth)
+            return sc, None, {"depth": getattr(sc, "depth_map", None)}
+        else:
+            oi = OpticalImage(photons=photons, wave=wave, name=name)
+            if depth is not None:
+                oi.depth_map = np.asarray(depth)
+            # Convert optical image to scene
+            sc = Scene(photons=oi.photons, wave=oi.wave, name=oi.name)
+            if depth is not None:
+                sc.depth_map = np.asarray(depth)
+            return sc, oi, {"depth": getattr(sc, "depth_map", None)}
+
+    if _pbrt_available():
+        pbrt = shutil.which("pbrt")
+        assert pbrt is not None
+        path = Path(path_or_recipe)
+        subprocess.run([pbrt, str(path)], check=True)
+        exr_path = path.with_suffix(".exr")
+        channels = openexr_read(exr_path)
+        if set(channels.keys()) >= {"R", "G", "B"}:
+            photons = np.stack([channels["R"], channels["G"], channels["B"]], axis=2)
+        else:
+            key = next(iter(channels))
+            photons = channels[key][:, :, None]
+        sc = Scene(photons=photons)
+        depth_exr = path.with_name(path.stem + "_depth.exr")
+        if depth_exr.exists():
+            depth_channels = openexr_read(depth_exr)
+            if depth_channels:
+                sc.depth_map = next(iter(depth_channels.values()))
+        return sc, None, {"depth": getattr(sc, "depth_map", None)}
+
+    raise ImportError("iset3d or pbrt backend required")
+
+
+__all__ = ["scene_from_pbrt"]
+

--- a/python/tests/test_scene_from_pbrt.py
+++ b/python/tests/test_scene_from_pbrt.py
@@ -1,0 +1,20 @@
+import shutil
+import pytest
+
+from isetcam.scene import scene_from_pbrt
+
+
+def _backend_available() -> bool:
+    try:
+        import iset3d  # noqa: F401
+        return True
+    except Exception:
+        pass
+    return shutil.which("pbrt") is not None
+
+
+@pytest.mark.skipif(_backend_available(), reason="backend available")
+def test_scene_from_pbrt_missing_dep():
+    with pytest.raises(ImportError):
+        scene_from_pbrt("dummy.pbrt")
+


### PR DESCRIPTION
## Summary
- implement `scene_from_pbrt` helper using iset3d or pbrt
- export new helper from `scene` module
- document PBRT scene loader in migration guide
- test ImportError when backend missing

## Testing
- `PYTHONPATH=$PWD/python pytest python/tests/test_scene_from_pbrt.py -q`
- `PYTHONPATH=$PWD/python pytest -q` *(fails: some tutorials and other tests fail; see log)*

------
https://chatgpt.com/codex/tasks/task_e_6840b971d74c83239c07414d5aec2ab9