### PR TITLE
Enhance CPScene PBRT rendering

### DIFF
--- a/python/isetcam/cp/cp_scene.py
+++ b/python/isetcam/cp/cp_scene.py
@@ -1,32 +1,64 @@
 # mypy: ignore-errors
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import List
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
 
-import numpy as np
+import shutil
+from pathlib import Path
 
-from ..scene import Scene
+
+from ..scene import Scene, scene_from_pbrt
+from ..iset_root_path import iset_root_path
 
 
-@dataclass
+@dataclass(init=False)
 class CPScene:
-    """Container for a sequence of :class:`Scene` objects."""
+    """Container for PBRT or ISETCam scenes."""
 
-    scenes: List[Scene]
+    scenes: List[Scene] = field(default_factory=list)
+    scene_type: str = "pbrt"
+    scene_path: Optional[str] = None
+    lens_file: Optional[str] = None
+
+    def __init__(
+        self,
+        scenes: Optional[Sequence[Scene]] = None,
+        *,
+        scene_type: str = "pbrt",
+        scene_path: Optional[str] = None,
+        lens_file: Optional[str] = None,
+    ) -> None:
+        self.scenes = list(scenes or [])
+        self.scene_type = scene_type
+        self.scene_path = scene_path
+        self.lens_file = lens_file
 
     def preview(self) -> Scene:
         """Return the first scene in the sequence."""
         return self.scenes[0]
 
-    def render(self, exp_times: List[float]) -> List[Scene]:
-        """Return scenes corresponding to ``exp_times``.
+    def render(self, exp_times: Sequence[float]) -> List[Scene | object]:
+        """Return scenes or optical images for ``exp_times``."""
 
-        If only a single scene is stored, it is replicated to match the
-        number of exposure times.
-        """
-        if len(self.scenes) == len(exp_times):
+        exp_list = list(exp_times)
+
+        if self.scene_type == "pbrt" and self.scene_path is not None:
+            path = Path(self.scene_path)
+            computed_dir = iset_root_path() / "data" / "computed"
+            computed_dir.mkdir(parents=True, exist_ok=True)
+            outputs: List[Scene | object] = []
+            for ii, t in enumerate(exp_list, start=1):
+                sc, oi, _ = scene_from_pbrt(path)
+                exr_path = path.with_suffix(".exr")
+                if exr_path.exists():
+                    dest = computed_dir / f"{exr_path.stem}-{ii:03d}-{int(round(t*1000))}{exr_path.suffix}"
+                    shutil.move(exr_path, dest)
+                outputs.append(oi if oi is not None else sc)
+            return outputs
+
+        if len(self.scenes) == len(exp_list):
             return list(self.scenes)
         if len(self.scenes) == 1:
-            return [self.scenes[0] for _ in exp_times]
+            return [self.scenes[0] for _ in exp_list]
         raise ValueError("Number of scenes does not match exposure times")

--- a/python/tests/test_cp_scene_pbrt.py
+++ b/python/tests/test_cp_scene_pbrt.py
@@ -1,0 +1,41 @@
+import shutil
+import numpy as np
+import pytest
+
+from isetcam.cp import CPScene
+from isetcam.scene import Scene
+
+
+def _backend_available() -> bool:
+    try:
+        import iset3d  # noqa: F401
+        return True
+    except Exception:
+        pass
+    return shutil.which("pbrt") is not None
+
+
+@pytest.mark.skipif(not _backend_available(), reason="backend not available")
+def test_cp_scene_render_pbrt(monkeypatch, tmp_path):
+    pbrt_path = tmp_path / "test.pbrt"
+    pbrt_path.write_text("Film \"image\" \"string filename\" [\"test.exr\"]")
+
+    dest_root = tmp_path / "root"
+
+    from isetcam import cp as cp_pkg
+    monkeypatch.setattr(cp_pkg.cp_scene, "iset_root_path", lambda: dest_root)
+
+    def fake_scene_from_pbrt(path):
+        exr = path.with_suffix(".exr")
+        exr.write_text("dummy")
+        return Scene(photons=np.ones((1,1,1)), wave=np.array([550.0])), None, {}
+
+    monkeypatch.setattr(cp_pkg.cp_scene, "scene_from_pbrt", fake_scene_from_pbrt)
+
+    sc = CPScene(scene_type="pbrt", scene_path=str(pbrt_path))
+    out = sc.render([0.1, 0.2])
+    assert len(out) == 2
+
+    comp = dest_root / "data" / "computed"
+    files = sorted(comp.glob("test-*.exr"))
+    assert len(files) == 2


### PR DESCRIPTION
## Summary
- extend CPScene to support PBRT scenes
- cache rendered EXR files
- test PBRT rendering logic

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_cp_camera.py python/tests/test_cp_scene_pbrt.py python/tests/test_scene_from_pbrt.py`
- `pytest -q` *(fails: CalledProcessError and network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6840e3a048808323866bc8fad6d4a604