### PR TITLE
Support PBRT optical images in CP camera

### DIFF
--- a/python/isetcam/cp/cp_camera.py
+++ b/python/isetcam/cp/cp_camera.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Sequence
+from typing import List, Sequence, Optional
 
 from .cp_scene import CPScene
 from .cp_cmodule import CPCModule
@@ -19,13 +19,32 @@ class CPCamera:
         scene: CPScene,
         *,
         exposure_times: Sequence[float] | float = 1.0,
+        focus_dists: Sequence[float] | float | None = None,
+        render_flags: Sequence[bool] | bool | None = None,
     ) -> List:
         """Capture ``scene`` using ``exposure_times`` for each frame."""
         if isinstance(exposure_times, Sequence) and not isinstance(exposure_times, (str, bytes)):
             exp_list = list(exposure_times)
         else:
             exp_list = [float(exposure_times)]
-        scenes = scene.render(exp_list)
+
+        if focus_dists is not None:
+            if isinstance(focus_dists, Sequence) and not isinstance(focus_dists, (str, bytes)):
+                focus_list = list(focus_dists)
+            else:
+                focus_list = [float(focus_dists)]
+        else:
+            focus_list = None
+
+        if render_flags is not None:
+            if isinstance(render_flags, Sequence) and not isinstance(render_flags, (str, bytes)):
+                render_list = list(render_flags)
+            else:
+                render_list = [bool(render_flags)]
+        else:
+            render_list = None
+
+        scenes = scene.render(exp_list, focus_dists=focus_list, render_flags=render_list)
         all_images: List = []
         for module in self.modules:
             all_images.extend(module.compute(scenes, exp_list))

--- a/python/isetcam/cp/cp_cmodule.py
+++ b/python/isetcam/cp/cp_cmodule.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import List
+from typing import List, Sequence
 
 import numpy as np
 
@@ -19,11 +19,17 @@ class CPCModule:
     sensor: Sensor
     optics: Optics
 
-    def compute(self, scenes: List[Scene], exp_times: List[float]) -> List[Sensor]:
-        """Return sensor captures for each scene and exposure time."""
+    def compute(
+        self, scenes: List[Scene | OpticalImage], exp_times: Sequence[float]
+    ) -> List[Sensor]:
+        """Return sensor captures for each scene or optical image."""
+
         outputs: List[Sensor] = []
         for sc, t in zip(scenes, exp_times):
-            oi = oi_compute(sc, self.optics)
+            if isinstance(sc, OpticalImage):
+                oi = sc
+            else:
+                oi = oi_compute(sc, self.optics)
             s = replace(self.sensor)
             s.exposure_time = float(t)
             s = sensor_compute(s, oi)

--- a/python/isetcam/cp/cp_scene.py
+++ b/python/isetcam/cp/cp_scene.py
@@ -38,7 +38,13 @@ class CPScene:
         """Return the first scene in the sequence."""
         return self.scenes[0]
 
-    def render(self, exp_times: Sequence[float]) -> List[Scene | object]:
+    def render(
+        self,
+        exp_times: Sequence[float],
+        *,
+        focus_dists: Sequence[float] | None = None,
+        render_flags: Sequence[bool] | None = None,
+    ) -> List[Scene | object]:
         """Return scenes or optical images for ``exp_times``."""
 
         exp_list = list(exp_times)

--- a/python/tests/test_cp_camera_pbrt.py
+++ b/python/tests/test_cp_camera_pbrt.py
@@ -1,0 +1,32 @@
+import numpy as np
+from isetcam.cp import CPScene, CPCModule, CPCamera
+from isetcam.sensor import sensor_create
+from isetcam.optics import optics_create
+from isetcam.opticalimage import OpticalImage
+
+
+def test_take_picture_pbrt_optical_image(monkeypatch):
+    from isetcam import cp as cp_pkg
+
+    sensor = sensor_create(wave=np.array([550.0]))
+    optics = optics_create()
+    module = cp_pkg.CPCModule(sensor=sensor, optics=optics)
+    camera = cp_pkg.CPCamera([module])
+    scene = cp_pkg.CPScene(scene_type="pbrt", scene_path="dummy")
+
+    def fake_render(self, exp, *, focus_dists=None, render_flags=None):
+        assert focus_dists == [2.0]
+        assert render_flags == [True]
+        oi = OpticalImage(photons=np.ones((1, 1, 1)), wave=np.array([550.0]))
+        return [oi]
+
+    monkeypatch.setattr(cp_pkg.cp_scene.CPScene, "render", fake_render, raising=False)
+
+    def fail_oi_compute(*args, **kwargs):
+        raise RuntimeError("oi_compute should not be called")
+
+    monkeypatch.setattr(cp_pkg.cp_cmodule, "oi_compute", fail_oi_compute)
+
+    sensors = camera.take_picture(scene, exposure_times=0.1, focus_dists=2.0, render_flags=True)
+    assert len(sensors) == 1
+    assert sensors[0].exposure_time == 0.1


### PR DESCRIPTION
## Summary
- extend `CPCModule.compute` to accept `OpticalImage` objects
- update `CPCamera.take_picture` so focus distances and render flags are passed to `CPScene.render`
- allow `CPScene.render` to accept these new arguments
- test PBRT camera workflow

## Testing
- `pytest -q python/tests/test_cp_camera_pbrt.py`
- `pytest -q python/tests/test_cp_camera.py::test_burst_camera_hdr_ev_step -q`
- `pytest -q python/tests/test_cp_scene_pbrt.py::test_cp_scene_render_pbrt -q`


------
https://chatgpt.com/codex/tasks/task_e_684120b221f88323a1bf53d24469d1e9