### PR TITLE
Add PBRT scene listing helper

### DIFF
--- a/docs/matlab_to_python_migration.md
+++ b/docs/matlab_to_python_migration.md
@@ -3024,6 +3024,19 @@ print(extras.get('depth'))
 This helper requires additional software and the tests are skipped when
 the backend is not available.
 
+## pbrt_scene_list
+
+Retrieve the PBRT scene names from the optional ISET3D resources.
+
+```python
+from isetcam.scene import pbrt_scene_list
+
+names = pbrt_scene_list()
+print(len(names))
+```
+
+Run `pytest -q` after adding or modifying the listing helper.
+
 ## scene_make_video
 
 Encode a list of scenes into a movie using ``ffmpeg``.

--- a/python/isetcam/scene/__init__.py
+++ b/python/isetcam/scene/__init__.py
@@ -8,6 +8,7 @@ from .scene_from_file import scene_from_file
 from .scene_from_ddf_file import scene_from_ddf_file
 from .scene_from_font import scene_from_font
 from .scene_from_pbrt import scene_from_pbrt
+from .pbrt_scene_list import pbrt_scene_list
 from .scene_get import scene_get
 from .scene_set import scene_set
 from .scene_adjust_luminance import scene_adjust_luminance
@@ -120,6 +121,7 @@ __all__ = [
     "scene_hdr_lights",
     "scene_create_hdr",
     "scene_make_video",
+    "pbrt_scene_list",
     "scene_init_geometry",
     "scene_init_spatial",
     "scene_photons_from_vector",

--- a/python/isetcam/scene/pbrt_scene_list.py
+++ b/python/isetcam/scene/pbrt_scene_list.py
@@ -1,0 +1,32 @@
+# mypy: ignore-errors
+"""List PBRT scenes from ISET3D resources."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+
+def pbrt_scene_list() -> List[str]:
+    """Return available PBRT scene names.
+
+    The helper relies on the optional :mod:`iset3d` package which provides
+    :func:`piDirGet` for locating PBRT resources. When the package is not
+    installed an :class:`ImportError` is raised.
+    """
+
+    try:  # pragma: no cover - optional dependency
+        import iset3d  # type: ignore
+    except Exception as exc:  # pragma: no cover - library may not be present
+        raise ImportError("iset3d required for PBRT scene listing") from exc
+
+    base = Path(iset3d.piDirGet("scenes"))  # type: ignore[attr-defined]
+    names: list[str] = []
+    if base.exists():
+        for path in base.rglob("*.pbrt"):
+            if path.is_file():
+                names.append(path.stem)
+    return sorted(set(names))
+
+
+__all__ = ["pbrt_scene_list"]

--- a/python/tests/test_pbrt_scene_list.py
+++ b/python/tests/test_pbrt_scene_list.py
@@ -1,0 +1,17 @@
+import pytest
+
+from isetcam.scene import pbrt_scene_list
+
+
+def _iset3d_available() -> bool:
+    try:
+        import iset3d  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(_iset3d_available(), reason="iset3d installed")
+def test_pbrt_scene_list_missing_dep():
+    with pytest.raises(ImportError):
+        pbrt_scene_list()


### PR DESCRIPTION
## Summary
- implement `pbrt_scene_list` helper
- expose helper from the `scene` package
- describe PBRT scene browsing in the migration docs
- test behaviour when ISET3D is not installed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'isetcam')*
- `pip install -e python` *(fails: could not fetch build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68414d23e1408323a05174f62cb21a16