### PR TITLE
Fix sensor tutorials

### DIFF
--- a/python/tutorials/camera/t_camera_antialiasing.py
+++ b/python/tutorials/camera/t_camera_antialiasing.py
@@ -32,10 +32,10 @@ def main() -> None:
     sensor.pixel_size = 1.5e-6
     sensor = sensor_set_size_to_fov(sensor, 5, oi)
     sensor = sensor_compute(sensor, oi)
-    sensor_show_image(sensor)
-
     disp = display_create()
     disp.wave = sensor.wave
+    sensor_show_image(sensor, disp)
+
     ip = ip_compute(sensor, disp)
     ip.name = "No anti-aliasing filter"
     ip_plot(ip, kind="image")

--- a/python/tutorials/camera/t_camera_compute.py
+++ b/python/tutorials/camera/t_camera_compute.py
@@ -2,6 +2,7 @@ import numpy as np
 from isetcam import ie_init
 from isetcam.scene import scene_create, scene_show_image
 from isetcam.camera import camera_create, camera_compute, camera_show
+from isetcam.sensor import sensor_show_image
 from isetcam.display import display_create
 from isetcam.ip import ip_compute
 
@@ -27,7 +28,7 @@ def main() -> None:
 
     # Visualize results
     camera_show(cam, "ip")
-    camera_show(cam, "sensor")
+    sensor_show_image(cam.sensor, disp)
 
 
 if __name__ == "__main__":

--- a/python/tutorials/camera/t_camera_introduction.py
+++ b/python/tutorials/camera/t_camera_introduction.py
@@ -24,12 +24,12 @@ def main() -> None:
     camera_compute(cam, scene)
 
     # Visualize the intermediate objects
-    oi_show_image(camera_get(cam, "oi"))
-    sensor_show_image(camera_get(cam, "sensor"))
-
-    # Render to an sRGB image using a default display model
     disp = display_create()
     disp.wave = cam.sensor.wave
+    oi_show_image(camera_get(cam, "oi"), disp)
+    sensor_show_image(camera_get(cam, "sensor"), disp)
+
+    # Render to an sRGB image using the same display model
     ip = ip_compute(cam.sensor, disp)
     ip_plot(ip, kind="image")
 

--- a/python/tutorials/camera/t_camera_noise.py
+++ b/python/tutorials/camera/t_camera_noise.py
@@ -41,7 +41,7 @@ def main() -> None:
     # ----- Photon noise only -----
     sensor_set(cam.sensor, "gain_sd", 0)
     sensor_set(cam.sensor, "offset_sd", 0)
-    scene_low = scene_adjust_luminance(scene, 5)
+    scene_low = scene_adjust_luminance(scene, "mean", 5)
     camera_compute(cam, scene_low)
     sensor_photon_noise(cam.sensor)
     ip_photon = ip_compute(cam.sensor, disp)
@@ -50,7 +50,7 @@ def main() -> None:
     # ----- All noise -----
     sensor_set(cam.sensor, "gain_sd", 5)
     sensor_set(cam.sensor, "offset_sd", 0.01)
-    scene_high = scene_adjust_luminance(scene, 100)
+    scene_high = scene_adjust_luminance(scene, "mean", 100)
     camera_compute(cam, scene_high)
     sensor_photon_noise(cam.sensor)
     ip_all = ip_compute(cam.sensor, disp)

--- a/python/tutorials/camera/t_system_simulate.py
+++ b/python/tutorials/camera/t_system_simulate.py
@@ -56,10 +56,9 @@ def main() -> None:
     sensor = sensor_compute(sensor, oi)
     sensor_add_noise(sensor)
     sensor_gain_offset(sensor, gain=1.0, offset=0.0)
-    sensor_show_image(sensor)
-
     disp = display_create()
     disp.wave = sensor.wave
+    sensor_show_image(sensor, disp)
     oi_show_image(oi, disp)
     ip = ip_compute(sensor, disp)
     ip_plot(ip, kind="image")


### PR DESCRIPTION
## Summary
- allow `sensor_show_image` to demosaic and gamma-correct 2‑D voltage data
- pass displays with matching wavelength to sensor/optical image display helpers
- show demosaiced sensor images in camera tutorials
- fix `scene_adjust_luminance` calls in `t_camera_noise`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'isetcam')*

------
https://chatgpt.com/codex/tasks/task_e_6846648867788323a7133d11ecffbd4f