### PR TITLE
Add display.wave mismatch checks

### DIFF
--- a/python/isetcam/opticalimage/oi_show_image.py
+++ b/python/isetcam/opticalimage/oi_show_image.py
@@ -48,6 +48,11 @@ def oi_show_image(oi: OpticalImage, display: Display | None = None):
     rgb = _photons_to_rgb(oi, display)
     # Render through the display model
     spectral = display_render(rgb, display, apply_gamma=True)
+    if spectral.shape[-1] != len(display.wave):
+        raise ValueError(
+            "display.spd must be resampled to display.wave; expected"
+            f" {len(display.wave)}, got {spectral.shape[-1]}"
+        )
     xyz = ie_xyz_from_photons(spectral, display.wave)
     srgb, _, _ = xyz_to_srgb(xyz)
 

--- a/python/isetcam/sensor/sensor_show_image.py
+++ b/python/isetcam/sensor/sensor_show_image.py
@@ -65,6 +65,11 @@ def sensor_show_image(sensor: Sensor, display: Display | None = None):
 
     lrgb = srgb_to_lrgb(volts)
     spectral = display_render(lrgb, display, apply_gamma=False)
+    if spectral.shape[-1] != len(display.wave):
+        raise ValueError(
+            "display.spd must be resampled to display.wave; expected"
+            f" {len(display.wave)}, got {spectral.shape[-1]}"
+        )
     xyz = ie_xyz_from_photons(spectral, display.wave)
     srgb, _, _ = xyz_to_srgb(xyz)
 

--- a/python/tests/test_oi_show_save.py
+++ b/python/tests/test_oi_show_save.py
@@ -27,6 +27,16 @@ def test_oi_show_image_runs():
 
 
 @pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_oi_show_image_wave_mismatch():
+    wave = np.array([500, 600, 700])
+    photons = np.ones((1, 1, 3))
+    oi = OpticalImage(photons=photons, wave=wave)
+    disp = Display(spd=np.eye(3), wave=np.array([400, 500, 600, 700]), gamma=None)
+    with pytest.raises(ValueError, match="display.spd must be resampled"):
+        oi_show_image(oi, disp)
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
 def test_oi_save_image(tmp_path):
     wave = np.array([500, 600, 700])
     photons = np.ones((1, 1, 3))

--- a/python/tests/test_sensor_show_image.py
+++ b/python/tests/test_sensor_show_image.py
@@ -24,3 +24,13 @@ def test_sensor_show_image_runs():
     disp = Display(spd=np.eye(3), wave=wave, gamma=None)
     ax = sensor_show_image(sensor, disp)
     assert ax is not None
+
+
+@pytest.mark.skipif(not _matplotlib_available(), reason="matplotlib not installed")
+def test_sensor_show_image_wave_mismatch():
+    volts = np.array([[[0.2, 0.4, 0.6]]], dtype=float)
+    wave = np.array([500, 600, 700])
+    sensor = Sensor(volts=volts, wave=wave, exposure_time=0.01)
+    disp = Display(spd=np.eye(3), wave=np.array([400, 500, 600, 700]), gamma=None)
+    with pytest.raises(ValueError, match="display.spd must be resampled"):
+        sensor_show_image(sensor, disp)


### PR DESCRIPTION
## Summary
- check spectral wave dimension against `display.wave` in `sensor_show_image` and `oi_show_image`
- raise clearer error when mismatch is found
- test that the new checks trigger with mismatched display

## Testing
- `PYTHONPATH=python pytest -q python/tests/test_sensor_show_image.py::test_sensor_show_image_runs python/tests/test_sensor_show_image.py::test_sensor_show_image_wave_mismatch python/tests/test_oi_show_save.py::test_oi_show_image_runs python/tests/test_oi_show_save.py::test_oi_show_image_wave_mismatch -q`

------
https://chatgpt.com/codex/tasks/task_e_6846792a47648323b351e8bbf0e307a0