### PR TITLE
Fix spectral inversion when converting OI to RGB

### DIFF
--- a/python/isetcam/opticalimage/oi_plot.py
+++ b/python/isetcam/opticalimage/oi_plot.py
@@ -38,7 +38,9 @@ def _photons_to_srgb(oi: OpticalImage, display: Display) -> np.ndarray:
     photons = np.asarray(oi.photons, dtype=float)
     spd = np.asarray(display.spd, dtype=float)
     xw, rows, cols = rgb_to_xw_format(photons)
-    rgb_lin = xw @ np.linalg.pinv(spd)
+    # Convert the spectral data to display RGB values. ``spd`` has shape
+    # ``(n_wave, 3)``, hence we use the pseudoinverse of its transpose.
+    rgb_lin = xw @ np.linalg.pinv(spd.T)
     if display.gamma is not None:
         rgb = display_apply_gamma(rgb_lin, display, inverse=True)
     else:

--- a/python/isetcam/opticalimage/oi_save_image.py
+++ b/python/isetcam/opticalimage/oi_save_image.py
@@ -25,7 +25,9 @@ def _photons_to_rgb(oi: OpticalImage, display: Display) -> np.ndarray:
         raise ValueError("Wavelength dimension mismatch with display")
 
     xw, rows, cols = rgb_to_xw_format(photons)
-    rgb_lin = xw @ np.linalg.pinv(spd)
+    # ``spd`` is ``(n_wave, 3)``. Use the pseudoinverse of the transpose so the
+    # multiplication yields ``(N, 3)`` RGB values.
+    rgb_lin = xw @ np.linalg.pinv(spd.T)
     if display.gamma is not None:
         rgb = display_apply_gamma(rgb_lin, display, inverse=True)
     else:

--- a/python/isetcam/opticalimage/oi_show_image.py
+++ b/python/isetcam/opticalimage/oi_show_image.py
@@ -29,7 +29,10 @@ def _photons_to_rgb(oi: OpticalImage, display: Display) -> np.ndarray:
         raise ValueError("Wavelength dimension mismatch with display")
 
     xw, rows, cols = rgb_to_xw_format(photons)
-    rgb_lin = xw @ np.linalg.pinv(spd)
+    # Solve for the display RGB values that reproduce the spectral data.
+    # ``spd`` has shape ``(n_wave, 3)`` so we need the pseudoinverse of its
+    # transpose to obtain a ``(n_wave, 3)`` -> ``(3,)`` mapping.
+    rgb_lin = xw @ np.linalg.pinv(spd.T)
     if display.gamma is not None:
         rgb = display_apply_gamma(rgb_lin, display, inverse=True)
     else:


### PR DESCRIPTION
## Summary
- correctly invert display SPD to compute linear RGB

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684775d1fb6c83239f2d49bdf10d0b2d